### PR TITLE
Fix link for Mac OS X installation documentation

### DIFF
--- a/pages/agent/installation.md.erb
+++ b/pages/agent/installation.md.erb
@@ -6,7 +6,7 @@ The Buildkite Agent runs on your own machine, whether it's a VPS, server, deskto
 * [Debian](debian)
 * [CentOS/Redhat](redhat)
 * [FreeBSD](freebsd)
-* [Mac](debian)
+* [Mac OS X](osx)
 * [Windows](windows)
 * [Linux](linux)
 * [Docker](docker)


### PR DESCRIPTION
Previous link incorrectly pointed to debian, renamed Mac to Mac OS X for consistency with name in side panel.