### PR TITLE
Correct field name for job name in uploaded steps

### DIFF
--- a/pages/guides/uploading_pipelines.md.erb
+++ b/pages/guides/uploading_pipelines.md.erb
@@ -18,7 +18,7 @@ For example, here is a pipeline that simply prints “Hello!”:
 
 ```yml
 steps:
-  - label: Example Test
+  - name: Example Test
     command: echo "Hello!"
 ```
 
@@ -45,7 +45,7 @@ A more complicated example of a script step, showing all the possible configurat
 ```yml
 steps:
   - command: deploy.sh
-    label: Deploy
+    name: Deploy
     branches: master
     env:
       FOO: bar
@@ -74,7 +74,7 @@ A *blocker* step will pause the pipeline and wait for a team member to unblock i
 steps:
   - command: command.sh
   - block:
-      label: ":rocket: Deploy"
+      name: ":rocket: Deploy"
   - command: deploy.sh
 ```
 


### PR DESCRIPTION
Previously the docs indicated that an uploaded pipeline step could have a field "label" to set the step's name, but in fact the expected field name is "name".