### PR TITLE
Parameter clarification

### DIFF
--- a/pages/api.md.erb
+++ b/pages/api.md.erb
@@ -18,9 +18,9 @@ curl https://api.buildkite.com
 <%= present_json response: "Hello World" %>
 ```
 
-## Parameters
+## Parameters and Properties
 
-Some API methods take parameters. Some have parameters within the path of the URI, such as 'my-org' and 'my-pipeline' in the following request:
+Some API methods take parameters and/or properties. Many have parameters within the path of the URI, such as 'my-org' and 'my-pipeline' in the following request:
 
 ```bash
 curl "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds"
@@ -32,7 +32,7 @@ For GET requests, additional parameters can be supplied as HTTP query string par
 curl "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?state=passed"
 ```
 
-For POST, PATCH, PUT, and DELETE requests, additional parameters should be encoded as JSON with the Content-Type 'application/json':
+For POST, PATCH, PUT, and DELETE requests, there are path parameters but query parameters are not accepted. Additional properties should be encoded as JSON with the Content-Type 'application/json':
 
 ```bash
 curl -X POST "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds" \

--- a/pages/api.md.erb
+++ b/pages/api.md.erb
@@ -117,7 +117,7 @@ The following changes were made in v2 of our API:
 
 - <code>POST /v1/organizations/{org.slug}/agents</code> has been removed
 - <code>DELETE /v1/organizations/{org.slug}/agents/{id}</code> has been removed
-- All project-related properties in JSON responses and requests have been renamed to pipeline
+- All project-related parameters in JSON responses and requests have been renamed to pipeline
 - The <code>featured_build</code> pipeline property has been removed
 - The deprecated <code>/accounts</code> URL has been removed
 - URLS containing <code>/projects</code> have been renamed to <code>/pipelines</code>

--- a/pages/api.md.erb
+++ b/pages/api.md.erb
@@ -18,6 +18,31 @@ curl https://api.buildkite.com
 <%= present_json response: "Hello World" %>
 ```
 
+## Parameters
+
+Some API methods take parameters. Some have parameters within the path of the URI, such as 'my-org' and 'my-pipeline' in the following request:
+
+```bash
+curl "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds"
+```
+
+For GET requests, additional parameters can be supplied as HTTP query string parameters:
+
+```bash
+curl "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?state=passed"
+```
+
+For POST, PATCH, PUT, and DELETE requests, additional parameters should be encoded as JSON with the Content-Type 'application/json':
+
+```bash
+curl -X POST "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds" \
+  -d '{
+    "commit": "abcd0b72a1e580e90712cdd9eb26d3fb41cd09c8",
+    "branch": "master",
+    "message": "Testing all the things :rocket:"
+  }'
+```
+
 ## Authentication
 
 There are two ways to authenticate with the Buildkite API: access tokens and basic authentication.

--- a/pages/api.md.erb
+++ b/pages/api.md.erb
@@ -32,7 +32,7 @@ For GET requests, additional parameters can be supplied as HTTP query string par
 curl "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?state=passed"
 ```
 
-For POST, PATCH, PUT, and DELETE requests, there are path parameters but query parameters are not accepted. Additional properties should be encoded as JSON with the Content-Type 'application/json':
+For POST, PATCH, PUT, and DELETE requests, there are path parameters but query parameters are not accepted. Additional properties should be encoded as JSON:
 
 ```bash
 curl -X POST "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds" \

--- a/pages/api.md.erb
+++ b/pages/api.md.erb
@@ -31,9 +31,10 @@ curl "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/bu
 Some API requests accept JSON request bodies for specifying data. For example, the [build create API](/docs/api/builds#create-a-build) can be passed the required properties using the following `curl` command:
 
 ```
-curl -X POST "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds" -d '{
-  "key: "value"
-}'
+curl -X POST "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds" \
+  -d '{
+    "key": "value"
+  }'
 ```
 
 The data encoding is assumed to be `application/json`. Unless explicitly stated by an API endpoint, you can not post data as `www-form-urlencoded` or `multipart/form-data`.

--- a/pages/api.md.erb
+++ b/pages/api.md.erb
@@ -117,7 +117,7 @@ The following changes were made in v2 of our API:
 
 - <code>POST /v1/organizations/{org.slug}/agents</code> has been removed
 - <code>DELETE /v1/organizations/{org.slug}/agents/{id}</code> has been removed
-- All project-related parameters in JSON responses and requests have been renamed to pipeline
+- All project-related properties in JSON responses and requests have been renamed to pipeline
 - The <code>featured_build</code> pipeline property has been removed
 - The deprecated <code>/accounts</code> URL has been removed
 - URLS containing <code>/projects</code> have been renamed to <code>/pipelines</code>

--- a/pages/api.md.erb
+++ b/pages/api.md.erb
@@ -37,7 +37,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pip
   }'
 ```
 
-The data encoding is assumed to be `application/json`. Unless explicitly stated by an API endpoint, you can not post data as `www-form-urlencoded` or `multipart/form-data`.
+The data encoding is assumed to be `application/json`. Unless explicitly stated you can not encode properties as `www-form-urlencoded` or `multipart/form-data`.
 
 ## Authentication
 

--- a/pages/api.md.erb
+++ b/pages/api.md.erb
@@ -18,30 +18,25 @@ curl https://api.buildkite.com
 <%= present_json response: "Hello World" %>
 ```
 
-## Parameters and Properties
+## Query String Parameters
 
-Some API methods take parameters and/or properties. Many have parameters within the path of the URI, such as 'my-org' and 'my-pipeline' in the following request:
+Some API endpoints accept query string parameters which are added to the end of the URL. For example, the [builds listing APIs](/docs/api/builds#list-all-builds) can be filtered by `state` using the following `curl` command:
 
-```bash
-curl "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds"
 ```
-
-For GET requests, additional parameters can be supplied as HTTP query string parameters:
-
-```bash
 curl "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds?state=passed"
 ```
 
-For POST, PATCH, PUT, and DELETE requests, there are path parameters but query parameters are not accepted. Additional properties should be encoded as JSON:
+## Request Body Properties
 
-```bash
-curl -X POST "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds" \
-  -d '{
-    "commit": "abcd0b72a1e580e90712cdd9eb26d3fb41cd09c8",
-    "branch": "master",
-    "message": "Testing all the things :rocket:"
-  }'
+Some API requests accept JSON request bodies for specifying data. For example, the [build create API](/docs/api/builds#create-a-build) can be passed the required properties using the following `curl` command:
+
 ```
+curl -X POST "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds" -d '{
+  "key: "value"
+}'
+```
+
+The data encoding is assumed to be `application/json`. Unless explicitly stated by an API endpoint, you can not post data as `www-form-urlencoded` or `multipart/form-data`.
 
 ## Authentication
 

--- a/pages/api/access_tokens.md.erb
+++ b/pages/api/access_tokens.md.erb
@@ -25,7 +25,7 @@ curl -u "user@email.com" -X POST "https://api.buildkite.com/v2/access_tokens" \
 }
 ```
 
-Required [properties](/docs/api#request-body-properties):
+Required [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>
@@ -33,7 +33,7 @@ Required [properties](/docs/api#request-body-properties):
 </tbody>
 </table>
 
-Optional [properties](/docs/api#request-body-properties):
+Optional [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>

--- a/pages/api/access_tokens.md.erb
+++ b/pages/api/access_tokens.md.erb
@@ -25,7 +25,7 @@ curl -u "user@email.com" -X POST "https://api.buildkite.com/v2/access_tokens" \
 }
 ```
 
-Required properties:
+Required parameters:
 
 <table>
 <tbody>
@@ -33,7 +33,7 @@ Required properties:
 </tbody>
 </table>
 
-Optional properties:
+Optional parameters:
 
 <table>
 <tbody>

--- a/pages/api/access_tokens.md.erb
+++ b/pages/api/access_tokens.md.erb
@@ -25,7 +25,7 @@ curl -u "user@email.com" -X POST "https://api.buildkite.com/v2/access_tokens" \
 }
 ```
 
-Required parameters:
+Required properties:
 
 <table>
 <tbody>
@@ -33,7 +33,7 @@ Required parameters:
 </tbody>
 </table>
 
-Optional parameters:
+Optional properties:
 
 <table>
 <tbody>

--- a/pages/api/access_tokens.md.erb
+++ b/pages/api/access_tokens.md.erb
@@ -25,7 +25,7 @@ curl -u "user@email.com" -X POST "https://api.buildkite.com/v2/access_tokens" \
 }
 ```
 
-Required properties:
+Required [properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>
@@ -33,7 +33,7 @@ Required properties:
 </tbody>
 </table>
 
-Optional properties:
+Optional [properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>

--- a/pages/api/agents.md.erb
+++ b/pages/api/agents.md.erb
@@ -59,7 +59,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/agents"
 ]
 ```
 
-Optional query string parameters:
+Optional [query string parameters](/docs/api#query-string-parameters):
 
 <table>
 <tbody>
@@ -138,7 +138,7 @@ Instruct an agent to stop accepting new build jobs and shut itself down.
 curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}/stop"
 ```
 
-Optional properties:
+Optional [properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>

--- a/pages/api/agents.md.erb
+++ b/pages/api/agents.md.erb
@@ -138,7 +138,7 @@ Instruct an agent to stop accepting new build jobs and shut itself down.
 curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}/stop"
 ```
 
-Optional parameters:
+Optional properties:
 
 <table>
 <tbody>

--- a/pages/api/agents.md.erb
+++ b/pages/api/agents.md.erb
@@ -141,7 +141,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}/s
   }'
 ```
 
-Optional [properties](/docs/api#request-body-properties):
+Optional [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>

--- a/pages/api/agents.md.erb
+++ b/pages/api/agents.md.erb
@@ -138,7 +138,7 @@ Instruct an agent to stop accepting new build jobs and shut itself down.
 curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}/stop"
 ```
 
-Optional properties:
+Optional parameters:
 
 <table>
 <tbody>

--- a/pages/api/agents.md.erb
+++ b/pages/api/agents.md.erb
@@ -135,7 +135,10 @@ Success response: `200 OK`
 Instruct an agent to stop accepting new build jobs and shut itself down.
 
 ```bash
-curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}/stop"
+curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}/stop" \
+  -d '{
+    "force": true
+  }'
 ```
 
 Optional [properties](/docs/api#request-body-properties):

--- a/pages/api/builds.md.erb
+++ b/pages/api/builds.md.erb
@@ -10,7 +10,7 @@ Returns a [paginated list](<%= paginated_resource_docs_url %>) of all builds acr
 curl "https://api.buildkite.com/v2/builds"
 ```
 
-Optional query string parameters:
+Optional [query string parameters](/docs/api#query-string-parameters):
 
 <%= render_markdown 'api/builds_list_query_strings' %>
 
@@ -26,7 +26,7 @@ Returns a [paginated list](<%= paginated_resource_docs_url %>) of an organizatio
 curl "https://api.buildkite.com/v2/organizations/{org.slug}/builds"
 ```
 
-Optional query string parameters:
+Optional [query string parameters](/docs/api#query-string-parameters):
 
 <%= render_markdown 'api/builds_list_query_strings' %>
 
@@ -115,7 +115,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
 ]
 ```
 
-Optional query string parameters:
+Optional [query string parameters](/docs/api#query-string-parameters):
 
 <%= render_markdown 'api/builds_list_query_strings' %>
 
@@ -323,7 +323,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
 }
 ```
 
-Required properties:
+Required [properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>
@@ -333,7 +333,7 @@ Required properties:
 </tbody>
 </table>
 
-Optional properties:
+Optional [properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>

--- a/pages/api/builds.md.erb
+++ b/pages/api/builds.md.erb
@@ -323,7 +323,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
 }
 ```
 
-Required properties:
+Required parameters:
 
 <table>
 <tbody>
@@ -333,7 +333,7 @@ Required properties:
 </tbody>
 </table>
 
-Optional properties:
+Optional parameters:
 
 <table>
 <tbody>

--- a/pages/api/builds.md.erb
+++ b/pages/api/builds.md.erb
@@ -323,7 +323,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
 }
 ```
 
-Required [properties](/docs/api#request-body-properties):
+Required [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>
@@ -333,7 +333,7 @@ Required [properties](/docs/api#request-body-properties):
 </tbody>
 </table>
 
-Optional [properties](/docs/api#request-body-properties):
+Optional [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>

--- a/pages/api/builds.md.erb
+++ b/pages/api/builds.md.erb
@@ -323,7 +323,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
 }
 ```
 
-Required parameters:
+Required properties:
 
 <table>
 <tbody>
@@ -333,7 +333,7 @@ Required parameters:
 </tbody>
 </table>
 
-Optional parameters:
+Optional properties:
 
 <table>
 <tbody>

--- a/pages/api/jobs.md.erb
+++ b/pages/api/jobs.md.erb
@@ -29,7 +29,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 ```
 
 <%#
-Optional [properties](/docs/api#request-body-properties):
+Optional [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>

--- a/pages/api/jobs.md.erb
+++ b/pages/api/jobs.md.erb
@@ -29,7 +29,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 ```
 
 <%#
-Optional properties:
+Optional parameters:
 
 <table>
 <tbody>

--- a/pages/api/jobs.md.erb
+++ b/pages/api/jobs.md.erb
@@ -29,7 +29,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 ```
 
 <%#
-Optional properties:
+Optional [properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>

--- a/pages/api/jobs.md.erb
+++ b/pages/api/jobs.md.erb
@@ -29,7 +29,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 ```
 
 <%#
-Optional parameters:
+Optional properties:
 
 <table>
 <tbody>

--- a/pages/api/pipelines.md.erb
+++ b/pages/api/pipelines.md.erb
@@ -215,7 +215,7 @@ The resulting pipeline pipeline:
   <%= responsive_image_tag 'docs/api/projects_api_pipeline_example.png', 730, 174, alt: 'Picture of the build pipeline that is created' %>
 </div>
 
-Required [properties](/docs/api#request-body-properties):
+Required [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>
@@ -225,7 +225,7 @@ Required [properties](/docs/api#request-body-properties):
   </tbody>
 </table>
 
-Optional [properties](/docs/api#request-body-properties):
+Optional [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>
@@ -303,7 +303,7 @@ curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{
 }
 ```
 
-Optional [properties](/docs/api#request-body-properties):
+Optional [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>

--- a/pages/api/pipelines.md.erb
+++ b/pages/api/pipelines.md.erb
@@ -215,7 +215,7 @@ The resulting pipeline pipeline:
   <%= responsive_image_tag 'docs/api/projects_api_pipeline_example.png', 730, 174, alt: 'Picture of the build pipeline that is created' %>
 </div>
 
-Required properties:
+Required [properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>
@@ -225,7 +225,7 @@ Required properties:
   </tbody>
 </table>
 
-Optional properties:
+Optional [properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>
@@ -303,7 +303,7 @@ curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{
 }
 ```
 
-Optional properties:
+Optional [properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>

--- a/pages/api/pipelines.md.erb
+++ b/pages/api/pipelines.md.erb
@@ -215,7 +215,7 @@ The resulting pipeline pipeline:
   <%= responsive_image_tag 'docs/api/projects_api_pipeline_example.png', 730, 174, alt: 'Picture of the build pipeline that is created' %>
 </div>
 
-Required parameters:
+Required properties:
 
 <table>
 <tbody>
@@ -225,7 +225,7 @@ Required parameters:
   </tbody>
 </table>
 
-Optional parameters:
+Optional properties:
 
 <table>
 <tbody>
@@ -248,7 +248,7 @@ Error responses:
 
 ## Update a pipeline
 
-Updates one or more parameters of an existing pipeline:
+Updates one or more properties of an existing pipeline:
 
 ```bash
 curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{slug}" \
@@ -303,7 +303,7 @@ curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{
 }
 ```
 
-Optional parameters:
+Optional properties:
 
 <table>
 <tbody>

--- a/pages/api/pipelines.md.erb
+++ b/pages/api/pipelines.md.erb
@@ -215,7 +215,7 @@ The resulting pipeline pipeline:
   <%= responsive_image_tag 'docs/api/projects_api_pipeline_example.png', 730, 174, alt: 'Picture of the build pipeline that is created' %>
 </div>
 
-Required properties:
+Required parameters:
 
 <table>
 <tbody>
@@ -225,7 +225,7 @@ Required properties:
   </tbody>
 </table>
 
-Optional properties:
+Optional parameters:
 
 <table>
 <tbody>
@@ -248,7 +248,7 @@ Error responses:
 
 ## Update a pipeline
 
-Updates one or more properties of an existing pipeline:
+Updates one or more parameters of an existing pipeline:
 
 ```bash
 curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{slug}" \
@@ -303,7 +303,7 @@ curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{
 }
 ```
 
-Optional properties:
+Optional parameters:
 
 <table>
 <tbody>

--- a/pages/guides/uploading_pipelines.md.erb
+++ b/pages/guides/uploading_pipelines.md.erb
@@ -28,7 +28,7 @@ To test your new `.buildkite/pipeline.yml` simply commit the file, push the comm
 
 ## Pipeline format
 
-The pipeline can be uploaded as YML and JSON, and they both have the same structure. There are two top level properties:
+The pipeline can be uploaded as YML and JSON, and they both have the same structure. There are two top level parameters:
 
 * `env` - a hash of build-wide environment variables
 * `steps` - an array of build steps to be run (a mix of script, waiter and blocker steps)

--- a/pages/guides/uploading_pipelines.md.erb
+++ b/pages/guides/uploading_pipelines.md.erb
@@ -28,7 +28,7 @@ To test your new `.buildkite/pipeline.yml` simply commit the file, push the comm
 
 ## Pipeline format
 
-The pipeline can be uploaded as YML and JSON, and they both have the same structure. There are two top level parameters:
+The pipeline can be uploaded as YML and JSON, and they both have the same structure. There are two top level properties:
 
 * `env` - a hash of build-wide environment variables
 * `steps` - an array of build steps to be run (a mix of script, waiter and blocker steps)

--- a/pages/guides/uploading_pipelines.md.erb
+++ b/pages/guides/uploading_pipelines.md.erb
@@ -28,7 +28,7 @@ To test your new `.buildkite/pipeline.yml` simply commit the file, push the comm
 
 ## Pipeline format
 
-The pipeline can be uploaded as YML and JSON, and they both have the same structure. There are two top level properties:
+The pipeline can be uploaded as YAML and JSON, and they both have the same structure. There are two top level properties:
 
 * `env` - a hash of build-wide environment variables
 * `steps` - an array of build steps to be run (a mix of script, waiter and blocker steps)


### PR DESCRIPTION
There has been a little confusion around how to supply parameters to requests, so let's clarify!

I've also renamed "properties" to "parameters". `http://.../builds?state=passed` has a parameter to me, not a property. Parameters seem like a superset of properties. Thoughts?

/cc @keithpitt