### PR TITLE
Links on how to download artifacts outside of a running build

### DIFF
--- a/pages/agent/build_artifacts.md.erb
+++ b/pages/agent/build_artifacts.md.erb
@@ -85,6 +85,12 @@ Options:
    --no-color              Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
 ```
 
+## Downloading Artifacts Outside a Running Build
+
+The `buildkite-agent artifact download` command only works within the context of a running build.
+
+If you want to download an artifact outside of a build, you can use our [Artifact Download API](/docs/api/artifacts#download-an-artifact).
+
 ## Fetching the SHA of an artifact
 
 Use this command in your build scripts to verify downloaded artifacts against the original SHA-1 of the file.

--- a/pages/agent/build_artifacts.md.erb
+++ b/pages/agent/build_artifacts.md.erb
@@ -89,7 +89,7 @@ Options:
 
 The `buildkite-agent artifact download` command only works within the context of a running build.
 
-If you want to download an artifact outside of a build, you can use our [Artifact Download API](/docs/api/artifacts#download-an-artifact).
+If you want to download an artifact from outside a build use our [Artifact Download API](/docs/api/artifacts#download-an-artifact).
 
 ## Fetching the SHA of an artifact
 

--- a/pages/guides/artifacts.md.erb
+++ b/pages/guides/artifacts.md.erb
@@ -48,7 +48,7 @@ buildkite-agent artifact download "*.tar.gz" pkg/
 
 The `buildkite-agent artifact download` command only works within the context of a running build.
 
-If you want to download an artifact outside of a build, you can use our [Artifact Download API](/docs/api/artifacts#download-an-artifact).
+If you want to download an artifact from outside a build use our [Artifact Download API](/docs/api/artifacts#download-an-artifact).
 
 ## Further documentation
 

--- a/pages/guides/artifacts.md.erb
+++ b/pages/guides/artifacts.md.erb
@@ -44,6 +44,12 @@ You can also use wildcard arguments to download multiple assets at once (just ma
 buildkite-agent artifact download "*.tar.gz" pkg/
 ```
 
+## Downloading Artifacts Outside a Running Build
+
+The `buildkite-agent artifact download` command only works within the context of a running build.
+
+If you want to download an artifact outside of a build, you can use our [Artifact Download API](/docs/api/artifacts#download-an-artifact).
+
 ## Further documentation
 
 See the [Buildkite Agent artifact documentation](/docs/agent/build-artifacts) for a full list of options and details of Buildkite’s artifact support.


### PR DESCRIPTION
It can be a little confusing because you think you might be able to use the `buildkite-agent artifact download` command outside of a running build. This is just to have a presence on the other pages to point peeps in the right direction.