### PR TITLE
fixed 404

### DIFF
--- a/pages/guides/parallelizing_builds.md.erb
+++ b/pages/guides/parallelizing_builds.md.erb
@@ -74,6 +74,6 @@ We've provided a number of APIs to allow you to automatically scale your build a
 
 * Using the [Pipelines API](/docs/api/pipelines) you’re able to fetch the `scheduled_jobs_count`, `waiting_jobs_count` and `running_jobs_count` to get an overview of the number of jobs waiting to be run. Based on this you can spin up new agent machines to process the jobs waiting to be run.
 * Using [agent prioritization](/docs/agent/prioritization) you’ll able to define a core set up agents that are assigned work first, and then lower priority agents which you may spin up and spin down on demand.
-* Using the [Agents API](docs/api/agents) you’re able to fetch your agent’s `job` and `last_job_finished_at`, which allow you to see if they have been idle. You can then remotely shut down an agent process using the [agent stop API](/docs/api/agents#stop-an-agent) (passing `"force": false` to ensure it won’t cancel any running job).
+* Using the [Agents API](/docs/api/agents) you’re able to fetch your agent’s `job` and `last_job_finished_at`, which allow you to see if they have been idle. You can then remotely shut down an agent process using the [agent stop API](/docs/api/agents#stop-an-agent) (passing `"force": false` to ensure it won’t cancel any running job).
 
 Using these three APIs you can automate your build infrastructure, scale your agents based on demand, and ensure no-one has to wait for their build to start.


### PR DESCRIPTION
https://buildkite.com/docs/guides/parallelizing-builds
the link for 'Agents API' points to
https://buildkite.com/docs/guides/docs/api/agents
but should point to:
https://buildkite.com/docs/api/agents