### PR TITLE
Update examples to use systemd service@ files.

### DIFF
--- a/pages/agent/debian.md.erb
+++ b/pages/agent/debian.md.erb
@@ -28,9 +28,10 @@ You can run as many parallel agents on the one machine as you wish by duplicatin
 
 ```shell
 # For Debian 8.x (systemd)
-sudo cp /lib/systemd/system/buildkite-agent.service /lib/systemd/system/buildkite-agent-2.service
-sudo systemctl start buildkite-agent-2
-sudo tail -f /var/log/syslog | grep buildkite-agent-2
+sudo cp /lib/systemd/system/buildkite-agent.service /lib/systemd/system/buildkite-agent@.service
+sudo systemctl start buildkite-agent@2
+sudo systemctl start buildkite-agent@3
+sudo tail -f /var/log/syslog | grep buildkite-agent@
 
 # For Debian 7.x (using upstart)
 sudo cp /etc/init/buildkite-agent.conf /etc/init/buildkite-agent-2.conf

--- a/pages/agent/redhat.md.erb
+++ b/pages/agent/redhat.md.erb
@@ -32,8 +32,10 @@ The configuration file is located at `/etc/buildkite-agent/buildkite-agent.cfg`.
 You can run as many parallel agents on the one machine as you wish by simply copying the init.d and starting it:
 
 ```shell
-sudo cp /usr/lib/systemd/system/buildkite-agent.service /usr/lib/systemd/system/buildkite-agent-2.service
-sudo systemctl enable buildkite-agent-2 && systemctl start buildkite-agent-2
+sudo cp /usr/lib/systemd/system/buildkite-agent.service /usr/lib/systemd/system/buildkite-agent@.service
+sudo systemctl enable buildkite-agent@2 && systemctl start buildkite-agent@2
+sudo systemctl enable buildkite-agent@3 && systemctl start buildkite-agent@3
+...
 ```
 
 For older systems without `systemctl` (such as Amazon Linux) you instead use:


### PR DESCRIPTION
Only after pushing this did I notice #40, but this essentially updates the docs with a more systemd-esque way of launching multiple agents that allows running any number of agents without having to copy init files over and over.

This is a subjective change, as it might be 'best' for buildkite-agent itself to simply install a `buildkite-agent@.service` file out of the box, so that people can do this without a manual copy and the service file can be kept up to date.