### PR TITLE
Queue is now "default" for Elastic Stack

### DIFF
--- a/pages/guides/elastic_ci_stack_aws.md.erb
+++ b/pages/guides/elastic_ci_stack_aws.md.erb
@@ -48,7 +48,7 @@ After clicking _“Next”_ you’ll configure the stack using the details from 
 
 <%= image "aws-parameters.png", size: '561x311', alt: 'AWS Parameters' %>
 
-By default the stack uses a job queue of `elastic` but you can specify any other queue (including `default`). See the [Buildkite Agent Job Queue docs](/docs/agent/queues) for more info.
+By default the stack uses a job queue of `default` but you can specify any other queue name you’d like. See the [Buildkite Agent Job Queue docs](/docs/agent/queues) for more info.
 
 Once you're ready, click the _“I acknowledge that this template might cause AWS CloudFormation to create IAM resources.”_ checkbox then click _“Create”_:
 
@@ -70,10 +70,6 @@ You've now got a working Elastic CI Stack ready to run builds! :tada:
 We’ve created a sample [bash-parallel-example sample pipeline](https://github.com/buildkite/bash-parallel-example) for you to test with your new autoscaling stack. Click the _“Add to Buildkite”_ button below (or on the [GitHub Readme](https://github.com/buildkite/bash-parallel-example)):
 
 <a class="inline-block" href="/new?template=https://github.com/buildkite/bash-parallel-example" target="__blank"><img src="https://buildkite.com/button.svg" alt="Add Bash Example to Buildkite" class="no-decoration" width="160" height="30"></a>
-
-To ensure builds target your new stack open the _“Agent Targeting Rules”_ for the first step and set the queue (e.g. `queue=elastic`) then click _“Create Pipeline”_ at the bottom of the page.
-
-<%= image "buildkite-queue.gif", alt: 'Buildkite Elastic Queue' %>
 
 Your pipeline is now ready for it’s first build. Click "New Build" in the top right and choose a build message (perhaps a little party `\:parrot\:`?):
 


### PR DESCRIPTION
The queue is now "default" on the stack to help reduce confusion when getting up and running. This updates the guide to match.

Also I've updated the [Elastic CI Stack 1.1 release](https://github.com/buildkite/elastic-ci-stack-for-aws/releases/tag/v1.1) with a note to say the default queue name has changed.