### PR TITLE
Add environment variable doco

### DIFF
--- a/pages/agent/build_pipelines.md.erb
+++ b/pages/agent/build_pipelines.md.erb
@@ -74,7 +74,42 @@ A command step that uses all the possible configuration keys:
   concurrency_group: 'serial_tests'
   timeout_in_minutes: 60
 ```
+ 
+## Environment variables
 
+Environment variables are automatically interpolated when you upload your build, for example:
+      
+```yml
+- command: echo 'building ${BUILDKITE_PIPELINE_SLUG}...'      
+```
+      
+Will be uploaded as:
+      
+```yml
+# Assuming your pipeline is called 'my-first-buildkite-pipeline'
+- command: echo 'building my-first-buildkite-pipeline...'      
+```
+      
+For a full list of available Buildkite environment variables, see [Environment Variable](/docs/guides/envionrment-variables) that can be used inside your templates.
+      
+You can escape environment variables for use at build time using an extra `$`:
+      
+```yml
+- command: echo 'building in this directory: $$PWD'      
+```    
+
+Will be uploaded as:
+      
+```yml
+- command: echo 'building in this directory: $PWD'      
+```
+
+Environment variables can also be escaped with backslashes:
+      
+```yml
+- command: echo 'building in this directory: \$PWD'      
+```
+      
 ## Waiter steps
 
 A *waiter* step waits for all previous steps to complete before continuing, for example:


### PR DESCRIPTION
Suggest adding some documentation like so around the buildkite pipeline upload process regarding environment variables in pipelines. I had to dig into the [agent source code](https://github.com/buildkite/agent/blob/master/agent/pipeline_parser_test.go#L107) to figure out what was going on, and there's a great deal of useful things you can do with the plain pipeline yaml (instead of dynamically generating the pipeline). 

For example, we're using pipelines that do things like:

``` yaml
- command: docker run -w /tmp -v $PWD:/tmp some-container
```

Which would use the working directory on the agent that originally uploaded the pipeline. If the step is not run on the same agent, this would cause docker not to volume the current directory. The solution was to escape the variables:

``` yaml
- command: docker run -w /tmp -v $$PWD:/tmp some-container
```

But this doesn't seem to be documented anywhere?
