### PR TITLE
Update Build Location for buildkite-agent

### DIFF
--- a/pages/agent/_apt_locations.md.erb
+++ b/pages/agent/_apt_locations.md.erb
@@ -1,6 +1,6 @@
 * Configuration: `/etc/buildkite-agent/buildkite-agent.cfg`
 * Hooks: `/etc/buildkite-agent/hooks/`
-* Builds: `/var/buildkite-agent/builds/`
+* Builds: `/var/lib/buildkite-agent/builds/`
 * Logs, depending on your system:
   - `journalctl -f -u buildkite-agent` (systemd)
   - `/var/log/upstart/buildkite-agent.log` (upstart)


### PR DESCRIPTION
I'm not positive if this is the default file location for builds across all Linux distributions, but it was certainly the case for Ubuntu:
```
ubuntu@ciders:/var/lib/buildkite-agent$ buildkite-agent -v
buildkite-agent version 2.3, build 1382
ubuntu@ciders:/var/lib/buildkite-agent$ ls
builds
```

Any feedback is appreciated.