### PR TITLE
Add "blocked" webhook event documentation

### DIFF
--- a/pages/webhooks/build_events.md.erb
+++ b/pages/webhooks/build_events.md.erb
@@ -8,6 +8,7 @@
 <tbody>
   <tr><th><code>build.scheduled</code></th><td><%= webhook_description "build.scheduled" %></td></tr>
   <tr><th><code>build.running</code></th><td><%= webhook_description "build.running" %></td></tr>
+  <tr><th><code>build.blocked</code></th><td><%= webhook_description "build.blocked" %></td></tr>
   <tr><th><code>build.finished</code></th><td><%= webhook_description "build.finished" %></td></tr>
 </tbody>
 </table>


### PR DESCRIPTION
Not sure where to edit the `webhook_description` but I believe this is now part of the officially supported webhooks