### PR TITLE
Properly escape emoji in code block

### DIFF
--- a/pages/builds/managing_log_output.md.erb
+++ b/pages/builds/managing_log_output.md.erb
@@ -32,7 +32,7 @@ fi
 You can even include colors and emojis!
 
 ```bash
-echo -e "--- Running \033[33mspecs\033[0m \:cow:\:bell:"
+echo -e "--- Running \033[33mspecs\033[0m \:cow\:\:bell\:"
 ```
 
 <%= image("collapsing_example.png", size: '261x127', alt: 'Screenshot of colored, emoji build output') %>


### PR DESCRIPTION
From this issue https://github.com/buildkite/frontend/issues/132 - fixing up the emoji escaping in the docs so that it looks correct inside a rendered code block. 