### PR TITLE
Agent actually supports EC2 config as env vars

### DIFF
--- a/pages/agent/configuration.md.erb
+++ b/pages/agent/configuration.md.erb
@@ -29,12 +29,12 @@ _Environment variable:_ `BUILDKITE_AGENT_META_DATA`
 `meta-data-ec2`<br>
 Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data<br>
 _Default:_ `false`<br>
-_Environment variable:_ None
+_Environment variable:_ `BUILDKITE_AGENT_META_DATA_EC2`
 
 `meta-data-ec2-tags`<br>
 Include the host's EC2 tags as meta-data<br>
 _Default:_ `false`<br>
-_Environment variable:_ None
+_Environment variable:_ `BUILDKITE_AGENT_META_DATA_EC2_TAGS`
 
 `git-clean-flags`<br>
 Flags to pass to the `git clean` command<br>


### PR DESCRIPTION
See https://github.com/buildkite/agent/blob/master/clicommand/agent_start.go#L116-L124