### PR TITLE
Remove section about linking your git email

### DIFF
--- a/pages/quickstart/getting_started.md.erb
+++ b/pages/quickstart/getting_started.md.erb
@@ -16,16 +16,6 @@ We’ve created a simple [bash-example test repository](https://github.com/build
 
 <a class="inline-block" href="/new?template=https://github.com/buildkite/bash-example" target="__blank"><img src="https://buildkite.com/button.svg" alt="Add Bash Example to Buildkite" class="no-decoration" width="160" height="30"></a>
 
-## Link your git email address to Buildkite
-
-Before creating a build, link the email address you have associated with your git user account to Buildkite. Until you've linked your git email address, any builds created on commits you've authored won't be linked to your Buildkite account. 
-
-Check your git user's associated email address by running `git config --get user.email` in your terminal. If this email address is different to the one you used to sign up to Buildkite, add it to your account under Personal Settings > Email Addresses:
-
-<%= image "email-address.png", size: "251x52", alt: "Screenshot of email address section of Buildkite settings" %>
-
-After you have verified the new email address, builds that you run in Buildkite will show up in your My Builds menu. 
-
 ## Create your first build
 
 Now that you’ve started an agent and created a pipeline you’re ready to run your first build. Click the *New Build* button in the top right corner:


### PR DESCRIPTION
Since the my builds email popup is now live, we don't really need this section anymore. Also the image was broken 😅