### PR TITLE
Parallelising builds: Update info about knapsack gem

### DIFF
--- a/pages/builds/parallelizing_builds.md.erb
+++ b/pages/builds/parallelizing_builds.md.erb
@@ -62,7 +62,7 @@ You can use these two environment variables to divide your application’s tests
 The following libraries have built-in support for the `BUILDKITE_PARALLEL_*` environment variables:
 
 * [Knapsack](https://github.com/ArturT/knapsack)
-<br>A ruby gem for that will automatically divide your tests between parallel jobs, as well as making sure each job runs in comparable time. Supports RSpec, Cucumber and Minitest.
+<br>A ruby gem for that will automatically divide your tests between parallel jobs, as well as making sure each job runs in comparable time. Supports RSpec, Cucumber, Minitest, Spinach and Turnip.
 
 * [Knapsack Pro](https://github.com/KnapsackPro/knapsack_pro-ruby)
 <br>Is more advanced version of knapsack gem. Knapsack Pro has automated recording of tests time execution and can distribute tests across parallel jobs with predetermine split (regular mode) or in a dynamic way (queue mode) to get most optimal test suite split. You can learn more [how to configure project with Knapsack Pro and Buildkite](http://docs.knapsackpro.com/2017/auto-balancing-7-hours-tests-between-100-parallel-jobs-on-ci-buildkite-example) in the article.

--- a/pages/builds/parallelizing_builds.md.erb
+++ b/pages/builds/parallelizing_builds.md.erb
@@ -65,8 +65,7 @@ The following libraries have built-in support for the `BUILDKITE_PARALLEL_*` env
 <br>A ruby gem for that will automatically divide your tests between parallel jobs, as well as making sure each job runs in comparable time. Supports RSpec, Cucumber, Minitest, Spinach and Turnip.
 
 * [Knapsack Pro](https://github.com/KnapsackPro/knapsack_pro-ruby)
-<br>Is more advanced version of knapsack gem. Knapsack Pro has automated recording of tests time execution and can distribute tests across parallel jobs with predetermine split (regular mode) or in a dynamic way (queue mode) to get most optimal test suite split. You can learn more [how to configure project with Knapsack Pro and Buildkite](http://docs.knapsackpro.com/2017/auto-balancing-7-hours-tests-between-100-parallel-jobs-on-ci-buildkite-example) in the article.
-<br>See an example repository of how to run Rails CI with [Knapsack Pro and test steps in parallel with Buildkite](https://github.com/KnapsackPro/buildkite-rails-parallel-example-with-knapsack_pro). Here is an example for [Docker, Knapsack Pro and Buildkite](https://github.com/KnapsackPro/buildkite-rails-docker-parallel-example-with-knapsack_pro).
+<br>A commercially supported version of Knapsack that provides a hosted service for test timing data and additional job distribution modes. See the [documentation](https://github.com/KnapsackPro/knapsack_pro-ruby#info-for-buildkitecom-users) and [step-by-step tutorial](http://docs.knapsackpro.com/2017/auto-balancing-7-hours-tests-between-100-parallel-jobs-on-ci-buildkite-example) for setup instructions and example pipelines.
 
 ## Isolated jobs
 

--- a/pages/builds/parallelizing_builds.md.erb
+++ b/pages/builds/parallelizing_builds.md.erb
@@ -64,6 +64,10 @@ The following libraries have built-in support for the `BUILDKITE_PARALLEL_*` env
 * [Knapsack](https://github.com/ArturT/knapsack)
 <br>A ruby gem for that will automatically divide your tests between parallel jobs, as well as making sure each job runs in comparable time. Supports RSpec, Cucumber and Minitest.
 
+* [Knapsack Pro](https://github.com/KnapsackPro/knapsack_pro-ruby)
+<br>Is more advanced version of knapsack gem. Knapsack Pro has automated recording of tests time execution and can distribute tests across CI nodes with predetermine split (regular mode) or in a dynamic way (queue mode) to get most optimal test suite split. You can learn more [how to configure project with Knapsack Pro and Buildkite](http://docs.knapsackpro.com/2017/auto-balancing-7-hours-tests-between-100-parallel-jobs-on-ci-buildkite-example) in the article.
+<br>See an example repository of how to run Rails CI with [Knapsack Pro and test steps in parallel with Buildkite](https://github.com/KnapsackPro/buildkite-rails-parallel-example-with-knapsack_pro). Here is an example for [Docker, Knapsack Pro and Buildkite](https://github.com/KnapsackPro/buildkite-rails-docker-parallel-example-with-knapsack_pro).
+
 ## Isolated jobs
 
 You can safely run multiple agents on a single machine, though you’ll still need to ensure your application’s code is able to be run in parallel. One convenient way of doing this is by using the agent’s [built in Docker and Docker Compose support](docker-containerized-builds) which will run each job in one or more completely isolated containers.

--- a/pages/builds/parallelizing_builds.md.erb
+++ b/pages/builds/parallelizing_builds.md.erb
@@ -65,7 +65,7 @@ The following libraries have built-in support for the `BUILDKITE_PARALLEL_*` env
 <br>A ruby gem for that will automatically divide your tests between parallel jobs, as well as making sure each job runs in comparable time. Supports RSpec, Cucumber and Minitest.
 
 * [Knapsack Pro](https://github.com/KnapsackPro/knapsack_pro-ruby)
-<br>Is more advanced version of knapsack gem. Knapsack Pro has automated recording of tests time execution and can distribute tests across CI nodes with predetermine split (regular mode) or in a dynamic way (queue mode) to get most optimal test suite split. You can learn more [how to configure project with Knapsack Pro and Buildkite](http://docs.knapsackpro.com/2017/auto-balancing-7-hours-tests-between-100-parallel-jobs-on-ci-buildkite-example) in the article.
+<br>Is more advanced version of knapsack gem. Knapsack Pro has automated recording of tests time execution and can distribute tests across parallel jobs with predetermine split (regular mode) or in a dynamic way (queue mode) to get most optimal test suite split. You can learn more [how to configure project with Knapsack Pro and Buildkite](http://docs.knapsackpro.com/2017/auto-balancing-7-hours-tests-between-100-parallel-jobs-on-ci-buildkite-example) in the article.
 <br>See an example repository of how to run Rails CI with [Knapsack Pro and test steps in parallel with Buildkite](https://github.com/KnapsackPro/buildkite-rails-parallel-example-with-knapsack_pro). Here is an example for [Docker, Knapsack Pro and Buildkite](https://github.com/KnapsackPro/buildkite-rails-docker-parallel-example-with-knapsack_pro).
 
 ## Isolated jobs


### PR DESCRIPTION
I added a few more tests runners in knapsack gem.

I also worked with a few companies with large projects. They use Buildkite and knapsack_pro gem. Often people ask me how to run a project with knapsack_pro and what CI provider I recommend and my first choice is Buildkite because it can be really fast comparing to other solutions.

I prepared article with a simple introduction to Buildkite:
http://docs.knapsackpro.com/2017/auto-balancing-7-hours-tests-between-100-parallel-jobs-on-ci-buildkite-example
and examples of configured Ruby/Rails project + knapack_pro with and without Docker:
* https://github.com/KnapsackPro/buildkite-rails-docker-parallel-example-with-knapsack_pro
* https://github.com/KnapsackPro/buildkite-rails-parallel-example-with-knapsack_pro

Here is related PR for list of pipelines:
https://github.com/buildkite/example-pipelines/pull/4