### PR TITLE
Fix typo in the AWS agent docs page

### DIFF
--- a/pages/agent/aws.md.erb
+++ b/pages/agent/aws.md.erb
@@ -14,7 +14,7 @@ instance type. For Amazon Linux use the RH/CentOS installer.
 The [Elastic CI Stack for AWS][github] is a pre-built CloudFormtion template
 that gives you an autoscaling Buildkite Agent cluster in your own AWS. The
 stack includes Docker, S3 and CloudWatch integration, and is suitable for
-parallizing large legacy test suites, testing any Linux-based project that can
+parallelizing large legacy test suites, testing any Linux-based project that can
 run within Docker, and performing AWS ops related tasks.
 
 [Read the documentation][github] on GitHub, and launch it easily using the


### PR DESCRIPTION
✨

Fix for https://github.com/buildkite/docs/issues/104