### PR TITLE
Path to id_rsa and id_rsa.pub file were incorrect.

### DIFF
--- a/pages/agent/gcloud.md.erb
+++ b/pages/agent/gcloud.md.erb
@@ -177,11 +177,11 @@ spec:
     volumeMounts:
     - name: ssh-key
       subPath: id_rsa
-      mountPath: /root/id_rsa
+      mountPath: /root/.ssh/id_rsa
       readOnly: true
     - name: ssh-key
       subPath: id_rsa.pub
-      mountPath: /root/id_rsa.pub
+      mountPath: /root/.ssh/id_rsa.pub
       readOnly: true
     ...
   volumes:


### PR DESCRIPTION
Hi, I am using Buildkite on a Kubernetes cluster and it's been awesome. I followed your documentation. Everything went well except for the placement of the `id_rsa` and `id_rsa.pub` files which are supposed to be in the `/root/.ssh/` folder. When I deployed using the new folder it works. Thanks!