### PR TITLE
Add docs for field parameter on unblock api endpoint

### DIFF
--- a/pages/rest_api/jobs.md.erb
+++ b/pages/rest_api/jobs.md.erb
@@ -48,7 +48,13 @@ Error responses:
 Unblocks a build’s "Block pipeline" job. The job’s `unblockable` property indicates whether it is able to be unlocked, and the `unblock_url` property points to this endpoint.
 
 ```bash
-curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.slug}/builds/{build.number}/jobs/{job.id}/unblock"
+curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.slug}/builds/{build.number}/jobs/{job.id}/unblock"  \
+  -d '{
+    "fields": {
+      "name": "Liam Neeson",
+      "email": "liam@evilbatmanvillans.com",
+    }
+  }'
 ```
 
 ```json
@@ -75,6 +81,7 @@ Optional [request body properties](/docs/api#request-body-properties):
 <table>
 <tbody>
   <tr><th><code>unblocker</code></th><td>The user id of the person activating the job.<br><em>Default value: the user making the API request</em>.</td></tr>
+  <tr><th><code>fields</code></th><td>The fields provided to the unblocker as a key/value map.<br><em>Default value: </em><code>{}</code>.</td></tr>
 </tbody>
 </table>
 %>


### PR DESCRIPTION
Docs for:

```bash
curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.slug}/builds/{build.number}/jobs/{job.id}/unblock"  \
  -d '{
    "fields": {
      "name": "Liam Neeson",
      "email": "liam@evilbatmanvillans.com",
    }
  }'
```