### PR TITLE
Document pipeline.yml environment interpolation and caveats

### DIFF
--- a/pages/agent/cli_pipeline.md.erb
+++ b/pages/agent/cli_pipeline.md.erb
@@ -44,7 +44,7 @@ Options:
 
 ## Pipeline format
 
-The pipeline can be written as YAML or JSON, but YAML is more commonly for its readability. There are two top level properties you can specify:
+The pipeline can be written as YAML or JSON, but YAML is more common for its readability. There are two top level properties you can specify:
 
 * `env` - A map of <a href="/docs/builds/environment-variables">environment variables</a> to apply to all steps
 * `steps` - A list of [build pipeline steps](/docs/pipelines/defining-steps)

--- a/pages/agent/cli_pipeline.md.erb
+++ b/pages/agent/cli_pipeline.md.erb
@@ -49,6 +49,31 @@ The pipeline can be written as YAML or JSON, but YAML is more commonly for its r
 * `env` - a hash of build-wide environment variables
 * `steps` - an array of build steps to be run (a mix of script, [`wait`](/docs/pipelines/wait-step) and [`block`](/docs/pipelines/block-step) steps)
 
+## Environment variable interpolation
 
+As of the Buildkite Agent 3.0 beta, the `pipeline upload` command interpolates all $ environment variables in your pipeline.yml files.
 
+For example:
 
+```yml
+- trigger: "$BUILDKITE_PIPELINE_SLUG-deploy"
+  label: "\:rocket\: Deploy"
+  branches: "master"
+  async: true
+  build:
+    message: "$BUILDKITE_MESSAGE"
+    commit: "$BUILDKITE_COMMIT"
+    branch: "$BUILDKITE_BRANCH"
+```
+
+You can also set defaults, for example:
+
+```
+"${SOME_ENV_VAR:default-value}"
+```
+
+Although we do not recommend it, if you need to emulate this behavior in older 2.0 agents you can use the following workaround:
+
+```shell
+echo $(eval echo $(cat pipeline.yml)) | buildkite-agent pipeline upload
+```

--- a/pages/agent/cli_pipeline.md.erb
+++ b/pages/agent/cli_pipeline.md.erb
@@ -6,7 +6,7 @@ See the [Uploading Build Pipelines](/docs/pipelines/uploading-pipelines) guide f
 
 <%= toc %>
 
-## Uploading Pipelines
+## Uploading pipelines
 
 ```
 Usage:
@@ -42,22 +42,22 @@ Options:
    --debug-http                                 Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
 ```
 
-## Pipeline Format
+## Pipeline format
 
 The pipeline can be written as YAML or JSON, but YAML is more commonly for its readability. There are two top level properties you can specify:
 
-* `env` - a hash of build-wide environment variables
-* `steps` - an array of build steps to be run (a mix of script, [`wait`](/docs/pipelines/wait-step) and [`block`](/docs/pipelines/block-step) steps)
+* `env` - A map of <a href="/docs/builds/environment-variables">environment variables</a> to apply to all steps
+* `steps` - An list of [build pipeline steps](/docs/pipelines/defining-steps)
 
-## Environment variable interpolation
+## Environment variable substitution
 
-As of the Buildkite Agent 3.0 beta, the `pipeline upload` command interpolates all $ environment variables in your pipeline.yml files.
+The `pipeline upload` command in Buildkite Agent versions 3.0 and above supports environment variable substitution using the syntax `$VAR` and `${VAR}`.
 
-For example:
+For example, the following pipeline substitutes a number of [Buildkite’s default environment variables](/docs/builds/environment-variables) into a [trigger step](/docs/pipelines/trigger-step):
 
 ```yml
-- trigger: "$BUILDKITE_PIPELINE_SLUG-deploy"
-  label: "\:rocket\: Deploy"
+- command: "$BUILDKITE_PIPELINE_SLUG-deploy"
+  label: "\:rocket\:"
   branches: "master"
   async: true
   build:
@@ -66,13 +66,39 @@ For example:
     branch: "$BUILDKITE_BRANCH"
 ```
 
-You can also set defaults, for example:
+### Default values
 
-```
-"${SOME_ENV_VAR:default-value}"
+If an environment variable has not been set its default value will be a blank string. You can set your own default value using the syntax `${VAR:-default}`.
+
+For example, the following step will run the command `deploy.sh staging` if the `DEPLOY_ENV` environment variable has not been set or is blank (i.e. `""`):
+
+```yaml
+- command: "deploy.sh \"${DEPLOY_ENV:-staging}\""
 ```
 
-Although we do not recommend it, if you need to emulate this behavior in older 2.0 agents you can use the following workaround:
+If you need to substitute blank values (i.e. `""`) you can use the syntax `${VAR-default}`.
+
+For example, if the `DEPLOY_ENV` environment variable is set to `""` the following step will run the command `deploy.sh ""`, and if it has not been set it will run the command `deploy.sh "staging"`:
+
+```yaml
+- command: "deploy.sh \"${DEPLOY_ENV-staging}\""
+```
+
+### Character ranges
+
+You can substitute a range of characters from an environment variable by specifying a start and end position using the syntax `${VAR:start:end}`.
+
+For example, the following step will echo the first 7 characters of the `BUILDKITE_COMMIT` environment variable:
+
+```yaml
+- command: "echo ${BUILDKITE_COMMIT:0:7}"
+```
+
+If the environment variable has not been set, the range will return a blank string.
+
+### Buildkite Agent 2.x support
+
+If you want to use environment variable substitution, but are unable to update your Buildkite Agent to version 3.0 or above, it is possible (but not recommended) to emulate the behavior using your shell’s built-in environment variable substitution:
 
 ```shell
 echo $(eval echo $(cat pipeline.yml)) | buildkite-agent pipeline upload

--- a/pages/agent/cli_pipeline.md.erb
+++ b/pages/agent/cli_pipeline.md.erb
@@ -51,7 +51,7 @@ The pipeline can be written as YAML or JSON, but YAML is more common for its rea
 
 ## Environment variable substitution
 
-The `pipeline upload` command in Buildkite Agent versions 3.0 and above supports environment variable substitution using the syntax `$VAR` and `${VAR}`.
+In Buildkite Agent versions 3.0 and above, the `pipeline upload` command supports environment variable substitution using the syntax `$VAR` and `${VAR}`.
 
 For example, the following pipeline substitutes a number of [Buildkite’s default environment variables](/docs/builds/environment-variables) into a [trigger step](/docs/pipelines/trigger-step):
 

--- a/pages/agent/cli_pipeline.md.erb
+++ b/pages/agent/cli_pipeline.md.erb
@@ -47,7 +47,7 @@ Options:
 The pipeline can be written as YAML or JSON, but YAML is more commonly for its readability. There are two top level properties you can specify:
 
 * `env` - A map of <a href="/docs/builds/environment-variables">environment variables</a> to apply to all steps
-* `steps` - An list of [build pipeline steps](/docs/pipelines/defining-steps)
+* `steps` - A list of [build pipeline steps](/docs/pipelines/defining-steps)
 
 ## Environment variable substitution
 
@@ -56,33 +56,57 @@ The `pipeline upload` command in Buildkite Agent versions 3.0 and above supports
 For example, the following pipeline substitutes a number of [Buildkite’s default environment variables](/docs/builds/environment-variables) into a [trigger step](/docs/pipelines/trigger-step):
 
 ```yml
-- command: "$BUILDKITE_PIPELINE_SLUG-deploy"
-  label: "\:rocket\:"
+- trigger: "app-deploy"
+  label: "\:rocket\: Deploy"
   branches: "master"
   async: true
   build:
-    message: "$BUILDKITE_MESSAGE"
-    commit: "$BUILDKITE_COMMIT"
-    branch: "$BUILDKITE_BRANCH"
+    message: "${BUILDKITE_MESSAGE}"
+    commit: "${BUILDKITE_COMMIT}"
+    branch: "${BUILDKITE_BRANCH}"
 ```
 
-### Default values
+### Buildkite Agent 2.x support
 
-If an environment variable has not been set its default value will be a blank string. You can set your own default value using the syntax `${VAR:-default}`.
+If you are unable to upgrade your agent to version 3.0 or above, it is possible (but not recommended) to emulate the agent’s environment variable substitution using bash:
 
-For example, the following step will run the command `deploy.sh staging` if the `DEPLOY_ENV` environment variable has not been set or is blank (i.e. `""`):
+```shell
+echo $(eval echo $(cat pipeline.yml)) | buildkite-agent pipeline upload
+```
+
+### Handling blank and missing values
+
+If an environment variable has not been set it will evaluate to a blank string. You can set a fallback value using the syntax `${VAR:-default-value}`.
+
+For example, the following step will run the command `deploy.sh staging`:
 
 ```yaml
-- command: "deploy.sh \"${DEPLOY_ENV:-staging}\""
+- command: "deploy.sh \"${SERVER:-staging}\""
 ```
 
-If you need to substitute blank values (i.e. `""`) you can use the syntax `${VAR-default}`.
+<table>
+  <thead>
+    <tr><th>Environment Variables</th><th>Syntax</th><th>Result</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code></code></td><td><code>"${SERVER:-staging}"</code></td><td><code>"staging"</code></td></tr>
+    <tr><td><code>SERVER=""</code></td><td><code>"${SERVER:-staging}"</code></td><td><code>"staging"</code></td></tr>
+    <tr><td><code>SERVER="staging-5"</code></td><td><code>"${SERVER:-staging}"</code></td><td><code>"staging-5"</code></td></tr>
+  </tbody>
+</table>
 
-For example, if the `DEPLOY_ENV` environment variable is set to `""` the following step will run the command `deploy.sh ""`, and if it has not been set it will run the command `deploy.sh "staging"`:
+If you need to substitute environment variables containing empty strings, you can use the syntax `${VAR-default-value}` (notice the missing `:`).
 
-```yaml
-- command: "deploy.sh \"${DEPLOY_ENV-staging}\""
-```
+<table>
+  <thead>
+    <tr><th>Environment Variables</th><th>Syntax</th><th>Result</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code></code></td><td><code>"${SERVER-staging}"</code></td><td><code>"staging"</code></td></tr>
+    <tr><td><code>SERVER=""</code></td><td><code>"${SERVER-staging}"</code></td><td><code>""</code></td></tr>
+    <tr><td><code>SERVER="staging-5"</code></td><td><code>"${SERVER-staging}"</code></td><td><code>"staging-5"</code></td></tr>
+  </tbody>
+</table>
 
 ### Character ranges
 
@@ -91,15 +115,7 @@ You can substitute a range of characters from an environment variable by specify
 For example, the following step will echo the first 7 characters of the `BUILDKITE_COMMIT` environment variable:
 
 ```yaml
-- command: "echo ${BUILDKITE_COMMIT:0:7}"
+- command: "echo \"Short commit is: ${BUILDKITE_COMMIT:0:7}\""
 ```
 
 If the environment variable has not been set, the range will return a blank string.
-
-### Buildkite Agent 2.x support
-
-If you want to use environment variable substitution, but are unable to update your Buildkite Agent to version 3.0 or above, it is possible (but not recommended) to emulate the behavior using your shell’s built-in environment variable substitution:
-
-```shell
-echo $(eval echo $(cat pipeline.yml)) | buildkite-agent pipeline upload
-```

--- a/pages/agent/cli_pipeline.md.erb
+++ b/pages/agent/cli_pipeline.md.erb
@@ -80,7 +80,23 @@ If you need to prevent substitution, you can escape the `$` character by using `
 
 For example, using `$$USD` and `\$USD` will both result in the same value: `$USD`.
 
-### Handling blank and missing values
+### Requiring environment variables
+
+You can set required environment variables using the syntax `${VAR?}`. If `VAR` is not set, the `pipeline upload` command will print and error and exit with a status of 1.
+
+For example, the following step will cause the pipeline upload to error if the `SERVER` environment variable has not been set:
+
+```yaml
+- command: "deploy.sh \"${SERVER?}\""
+```
+
+You can set a custom error message after the `?` character. For example, the following prints the error message `SERVER: is not set. Please specify a server` if the environment variable has not been set:
+
+```yaml
+- command: "deploy.sh \"${SERVER?is not set. Please specify a server}\""
+```
+
+### Default, blank and missing values
 
 If an environment variable has not been set it will evaluate to a blank string. You can set a fallback value using the syntax `${VAR:-default-value}`.
 
@@ -114,25 +130,9 @@ If you need to substitute environment variables containing empty strings, you ca
   </tbody>
 </table>
 
-### Requiring environment variables
+### Extracting character ranges
 
-You can set required environment variables using the syntax `${VAR?}`. If `VAR` is not set, the `pipeline upload` command will print and error and exit with a status of 1.
-
-For example, the following step will cause the pipeline upload to error if the `SERVER` environment variable has not been set:
-
-```yaml
-- command: "deploy.sh \"${SERVER?}\""
-```
-
-You can set a custom error message after the `?` character. For example, the following prints the error message `SERVER: is not set. Please specify a server` if the environment variable has not been set:
-
-```yaml
-- command: "deploy.sh \"${SERVER?is not set. Please specify a server}\""
-```
-
-### Character ranges
-
-You can substitute a range of characters from an environment variable by specifying a start and end position using the syntax `${VAR:start:end}`.
+You can substitute a subset of characters from an environment variable by specifying a start and end range using the syntax `${VAR:start:end}`.
 
 For example, the following step will echo the first 7 characters of the `BUILDKITE_COMMIT` environment variable:
 

--- a/pages/agent/cli_pipeline.md.erb
+++ b/pages/agent/cli_pipeline.md.erb
@@ -74,6 +74,12 @@ If you are unable to upgrade your agent to version 3.0 or above, it is possible 
 echo $(eval echo $(cat pipeline.yml)) | buildkite-agent pipeline upload
 ```
 
+### Escaping the `$` character
+
+If you need to prevent substitution, you can escape the `$` character by using `$$` or `\$`.
+
+For example, using `$$USD` and `\$USD` will both result in the same value: `$USD`.
+
 ### Handling blank and missing values
 
 If an environment variable has not been set it will evaluate to a blank string. You can set a fallback value using the syntax `${VAR:-default-value}`.
@@ -107,6 +113,22 @@ If you need to substitute environment variables containing empty strings, you ca
     <tr><td><code>SERVER="staging-5"</code></td><td><code>"${SERVER-staging}"</code></td><td><code>"staging-5"</code></td></tr>
   </tbody>
 </table>
+
+### Requiring environment variables
+
+You can set required environment variables using the syntax `${VAR?}`. If `VAR` is not set, the `pipeline upload` command will print and error and exit with a status of 1.
+
+For example, the following step will cause the pipeline upload to error if the `SERVER` environment variable has not been set:
+
+```yaml
+- command: "deploy.sh \"${SERVER?}\""
+```
+
+You can set a custom error message after the `?` character. For example, the following prints the error message `SERVER: is not set. Please specify a server` if the environment variable has not been set:
+
+```yaml
+- command: "deploy.sh \"${SERVER?is not set. Please specify a server}\""
+```
 
 ### Character ranges
 

--- a/pages/pipelines/trigger_step.md.erb
+++ b/pages/pipelines/trigger_step.md.erb
@@ -117,5 +117,5 @@ _Optional_ `build` _attributes:_
 
 <div class="Docs__note">
 <p class="Docs__note__heading">Environment variable support</p>
-<p>Use of environment variables in pipeline.yml files is only supported in Buildkite Agent 3.0 and above. See the <a href="/docs/agent/cli-pipeline#environment-variable-interpolation">pipeline command documentation</a> for more information.</p>
+<p>Buildkite Agent 3.0 or above is required to use pipeline.yml environment variable substitution. See the <a href="/docs/agent/cli-pipeline#environment-variable-substitution">pipeline command documentation</a> for more information.</p>
 </div>

--- a/pages/pipelines/trigger_step.md.erb
+++ b/pages/pipelines/trigger_step.md.erb
@@ -105,14 +105,14 @@ _Optional_ `build` _attributes:_
 ```
 
 ```yml
-- trigger: "$BUILDKITE_PIPELINE_SLUG-deploy"
+- trigger: "app-deploy"
   label: "\:rocket\: Deploy"
   branches: "master"
   async: true
   build:
-    message: "$BUILDKITE_MESSAGE"
-    commit: "$BUILDKITE_COMMIT"
-    branch: "$BUILDKITE_BRANCH"
+    message: "${BUILDKITE_MESSAGE}"
+    commit: "${BUILDKITE_COMMIT}"
+    branch: "${BUILDKITE_BRANCH}"
 ```
 
 <div class="Docs__note">

--- a/pages/pipelines/trigger_step.md.erb
+++ b/pages/pipelines/trigger_step.md.erb
@@ -100,7 +100,6 @@ _Optional_ `build` _attributes:_
 - trigger: "data-generator"
   label: "\:package\: Generate data"
   build:
-    message: "Data for $BUILDKITE_BUILD_NUMBER"
     meta_data:
       release-version: "1.1"
 ```
@@ -115,3 +114,8 @@ _Optional_ `build` _attributes:_
     commit: "$BUILDKITE_COMMIT"
     branch: "$BUILDKITE_BRANCH"
 ```
+
+<div class="Docs__note">
+<p class="Docs__note__heading">Environment variable support</p>
+<p>Use of environment variables in pipeline.yml files is only supported in Buildkite Agent 3.0 and above. See the <a href="/docs/agent/cli-pipeline#environment-variable-interpolation">pipeline command documentation</a> for more information.</p>
+</div>


### PR DESCRIPTION
Our current [trigger documentation](https://buildkite.com/docs/pipelines/trigger-step) uses environment variable interpolation in the examples, but that's not supported in Buildkite Agent 2.0, only in the new Buildkite Agent 3.0 betas. Which can cause confusion (buildkite/feedback#260).

It is very common to want to use trigger steps in this way, so instead of just modifying those examples not to use interpolation, this adds documentation to the `pipeline upload` command, and a note below the trigger examples. The idea is that people will upgrade to 3.0 if necessary, or use the workaround if they can't upgrade their agent.

- [x] First cut
- [x] Update `pipeline upload` docs for `$VAR`, `${VAR}` and `${VAR:-default}` support etc