### PR TITLE
Fix artifacts link

### DIFF
--- a/pages/agent/cli_artifact.md.erb
+++ b/pages/agent/cli_artifact.md.erb
@@ -2,7 +2,7 @@
 
 The Buildkite Agent’s `artifact` command provides support for uploading and downloading of build artifacts, allowing you to share binary data between build steps no matter the machine or network.
 
-See the [Using Build Artifacts]((/docs/builds/artifacts)) guide for a step-by-step example.
+See the [Using Build Artifacts](/docs/builds/artifacts) guide for a step-by-step example.
 
 <%= toc %>
 


### PR DESCRIPTION
This PR fixes the artifacts link on the buildkite-agent artifacts page.