### PR TITLE
Add example for using an environment variable from steps

### DIFF
--- a/pages/agent/cli_pipeline.md.erb
+++ b/pages/agent/cli_pipeline.md.erb
@@ -66,6 +66,14 @@ For example, the following pipeline substitutes a number of [Buildkite’s defau
     branch: "${BUILDKITE_BRANCH}"
 ```
 
+If you want an environment variable to be evaluated at run-time (for example, using the step’s environment variables) make sure to escape the `$` character using `$$` or `\$`. For example:
+
+```yml
+- command: "deploy.sh $$SERVER"
+  env:
+    SERVER: "server-a"
+```
+
 ### Buildkite Agent 2.x support
 
 If you are unable to upgrade your agent to version 3.0 or above, it is possible (but not recommended) to emulate the agent’s environment variable substitution using bash:


### PR DESCRIPTION
If you've been using a pre-3.0 Buildkite Agent, with a pipeline that uses `$SOME_ENV` in it's commands, it can be a bit of trial and error to figure out exactly how you need to update your pipeline.yml files to make them work with the new environment variable interpolation.

Because this is probably quite common, this PR updates the environment variable section with an example of doing exactly this. Which should, fingers crossed, help people who are snagged by this.

We should also look at updating our "Pipeline Steps" documentation with this type of example too.

Before:

<img width="887" alt="before" src="https://user-images.githubusercontent.com/153/27112927-2716d132-50fd-11e7-843d-f3da232804bb.png">

After:

<img width="890" alt="after" src="https://user-images.githubusercontent.com/153/27112929-29752d34-50fd-11e7-8ea8-8da73868535f.png">