### PR TITLE
Fix errors and clarify artifact upload docs

### DIFF
--- a/pages/agent/cli_artifact.md.erb
+++ b/pages/agent/cli_artifact.md.erb
@@ -162,16 +162,24 @@ Downloading a specific file into a specific directory (note the trailing slash):
 buildkite-agent artifact download build.zip tmp/
 ```
 
-Downloading all the files uploaded to `log` into a local `log` directory (note that local directories will be created to match the uploaded file paths):
+Downloading all the files uploaded to `log` (including all subdirectories) into a local `log` directory (note that local directories will be created to match the uploaded file paths):
 
 ```bash
 buildkite-agent artifact download "log/*" .
 ```
 
-Downloading all the files uploaded to `coverage` into a local `tmp/coverage` directory (note that local directories are created to match the uploaded file path):
+Downloading all the files uploaded to `coverage` (including all subdirectories) into a local `tmp/coverage` directory (note that local directories are created to match the uploaded file path):
 
 ```bash
 buildkite-agent artifact download "coverage/*" tmp/
+```
+
+Downloading all images (from any directory) into a local `images/` directory (note that local directories are created to match the uploaded file path, and that you can run multiple download commands into the same directory):
+
+```bash
+buildkite-agent artifact download "*.jpg" images/
+buildkite-agent artifact download "*.jpeg" images/
+buildkite-agent artifact download "*.png" images/
 ```
 
 ### Artifact download pattern syntax

--- a/pages/agent/cli_artifact.md.erb
+++ b/pages/agent/cli_artifact.md.erb
@@ -6,9 +6,9 @@ See the [Using Build Artifacts](/docs/builds/artifacts) guide for a step-by-step
 
 <%= toc %>
 
-## Uploading Artifacts
+## Uploading artifacts
 
-Use this command in your build scripts to store artifacts for accessing via the web interface or downloading in future build steps. Alternatively you can configure the agent to automatically upload artifacts based on a file pattern (see the [Using Build Artifacts guide](/docs/builds/artifacts) for details).
+Use this command in your build scripts to store artifacts for accessing via the web interface or downloading in future build steps. Alternatively, you can configure the agent to automatically upload artifacts based on a file pattern (see the [Using Build Artifacts guide](/docs/builds/artifacts) for details).
 
 ```
 Usage:
@@ -33,51 +33,24 @@ Example:
    $ export BUILDKITE_S3_SECRET_ACCESS_KEY=yyy
    $ export BUILDKITE_S3_DEFAULT_REGION=eu-central-1 # default is us-east-1
    $ export BUILDKITE_S3_ACL=private # default is public-read
-   $ buildkite-agent artifact upload "log/**/*.log" s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID`
+   $ buildkite-agent artifact upload "log/**/*.log" s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID
 
 Options:
 
-   --job                Which job should the artifacts be uploaded to [$BUILDKITE_JOB_ID]
-   --agent-access-token          The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
-   --endpoint 'https://agent.buildkite.com/v3'  The agent API endpoint [$BUILDKITE_AGENT_ENDPOINT]
-   --debug              Enable debug mode [$BUILDKITE_AGENT_DEBUG]
-   --no-color              Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --job value                 Which job should the artifacts be uploaded to [$BUILDKITE_JOB_ID]
+   --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
+   --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
+   --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
+   --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
 ```
 
-## Glob path pattern
-
-Glob path patterns are used throughout Buildkite for artifact file paths. We use a [custom globbing function](https://github.com/buildkite/agent/blob/16a9807a91c4dd1388649557108d4092ae4860a4/glob/glob.go) on the backend that expands the patterns available. The path patterns differ slightly when uploading and downloading artifacts. 
-
-The pattern that you define should be designed to match whole strings rather than substrings. 
-Keep in mind while you're writing your path pattern:
-
-- there are two wildcards available that match non-separator characters:
-  + `*` to match a sequence of characters
-  + `?` to match a single character
-- character ranges surrounded by `[]` support the `^` as a negator
-- special characters can be escaped with `\\`
-- multiple paths are separated with `;`
-- surround the pattern with quotes
-
-The source path you supply to the upload command will be replicated exactly at the destination. If you run:
-
-```bash
-buildkite-agent artifact upload "log/test.log"
-```
-
-Buildkite will store the file at `log/test.log`. If you want it to be stored as `test.log` without the full path, then you'll need to change into the file's directory before running your upload command:
-
-```bash
-cd log
-buildkite-agent artifact upload "test.log"
-```
-
-### Examples
+### Artifact upload examples
 
 Uploading a specific file:
 
 ```bash
-buildkite-agent artifact upload "log/test.log"
+buildkite-agent artifact upload log/test.log
 ```
 
 Uploading all the jpegs and pngs, in all folders and subfolders:
@@ -104,19 +77,38 @@ Uploading a file name with special characters e.g. `hello??.html`:
 buildkite-agent artifact upload "hello\?\?.html"
 ```
 
-## Downloading Artifacts
+### Artifact upload glob syntax
+
+Glob path patterns are used throughout Buildkite for specifying artifact uploads. 
+
+The source path you supply to the upload command will be replicated exactly at the destination. If you run:
+
+```bash
+buildkite-agent artifact upload log/test.log
+```
+
+Buildkite will store the file at `log/test.log`. If you want it to be stored as `test.log` without the full path, then you'll need to change into the file's directory before running your upload command:
+
+```bash
+cd log
+buildkite-agent artifact upload test.log
+```
+
+Keep in mind while you’re writing your path pattern:
+
+- patterns must match whole path strings, not just substrings
+- there are two wildcards available that match non-separator characters (on Linux `/` is a separator character, and on Windows `\` is a separator character):
+  + `*` to match a sequence of characters
+  + `?` to match a single character
+- character ranges surrounded by `[]` support the `^` as a negator
+- special characters can be escaped with `\\`
+- multiple paths are separated with `;`
+- surround the pattern with quotes
+
+
+## Downloading artifacts
 
 Use this command in your build scripts to download artifacts.
-
-The path pattern for downloading artifacts supports a subset of the upload syntax. The only supports text matching and the single wildcard syntax `*`. 
-
-e.g. The path `foo/*/bar/hello.txt` would be translated to `foo/%/bar/hello.txt` on the backend to query our artifact database.
-
-If you don't want the full path of your download source to be replicated in your destination directory, use wildcards rather that specific directory names in your source path. This will replicate unix-style file access.
-
-Path merging will occur if you have the same directory names in the download source and destination paths. 
-
-e.g. If you're downloading `dist/my-file.txt` to `Desktop` then it will create a directory called `dist` and your file will end up in `Desktop/dist/my-file.txt`. However, if you are downloading `dist/my-file.txt` to `dist`, then the downloader will merge those two path names and your file will end up in `dist/my-file.txt` on your destination machine.  
 
 ```
 Usage:
@@ -139,29 +131,64 @@ Example:
    The first argument is the search query, and the second argument is the download destination.
 
    If you're trying to download a specific file, and there are multiple artifacts from different
-   steps, you can target the particular step you want to download the artifact from:
+   jobs, you can target the particular job you want to download the artifact from:
 
    $ buildkite-agent artifact download "pkg/*.tar.gz" . --step "tests" --build xxx
 
-   You can also use the steps job id (provided by the environment variable $BUILDKITE_JOB_ID)
+   You can also use the step's jobs id (provided by the environment variable $BUILDKITE_JOB_ID)
 
 Options:
 
-   --step               Used to target a specific step to download artifacts from
-   --build              Which build should the artifacts be downloaded from [$BUILDKITE_BUILD_ID]
-   --agent-access-token          The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
-   --endpoint 'https://agent.buildkite.com/v3'  The agent API endpoint [$BUILDKITE_AGENT_ENDPOINT]
-   --debug              Enable debug mode [$BUILDKITE_AGENT_DEBUG]
-   --no-color              Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --step value                Scope the search to a paticular step by using either it's name or job ID
+   --build value               The build that the artifacts were uploaded to [$BUILDKITE_BUILD_ID]
+   --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
+   --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
+   --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
+   --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
 ```
 
-## Downloading Artifacts Outside a Running Build
+### Artifact download examples
+
+Downloading a specific file into the current directory:
+
+```bash
+buildkite-agent artifact download build.zip .
+```
+
+Downloading a specific file into a specific directory (note the trailing slash):
+
+```bash
+buildkite-agent artifact download build.zip tmp/
+```
+
+Downloading all the files uploaded to `log` into a local `log` directory (note that local directories will be created to match the uploaded file paths):
+
+```bash
+buildkite-agent artifact download "log/*" .
+```
+
+Downloading all the files uploaded to `coverage` into a local `tmp/coverage` directory (note that local directories are created to match the uploaded file path):
+
+```bash
+buildkite-agent artifact download "coverage/*" tmp/
+```
+
+### Artifact download pattern syntax
+
+Artifact downloads support pattern-matching using the `*` character.
+
+Unlike artifact upload glob patterns, these operate over the entire path and not just between separator characters. For example, a download path pattern of `log/*` matches all files under the log directory and all subdirectories.
+
+There is no need to escape characters such as `?`, `[` and `]`.
+
+## Downloading artifacts outside a running build
 
 The `buildkite-agent artifact download` command only works within the context of a running build.
 
 If you want to download an artifact from outside a build use our [Artifact Download API](/docs/api/artifacts#download-an-artifact).
 
-## Fetching the SHA of an Artifact
+## Fetching the SHA of an artifact
 
 Use this command in your build scripts to verify downloaded artifacts against the original SHA-1 of the file.
 
@@ -191,19 +218,20 @@ Example:
 
    $ buildkite-agent artifact shasum "pkg/release.tar.gz" --step "release" --build xxx
 
-   You can also use the steps job id (provided by the environment variable $BUILDKITE_JOB_ID)
+   You can also use the step's job id (provided by the environment variable $BUILDKITE_JOB_ID)
 
 Options:
 
-   --step                Used to target a specific step to download artifacts from
-   --build              Which build should the artifacts be downloaded from [$BUILDKITE_BUILD_ID]
-   --agent-access-token          The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
-   --endpoint 'https://agent.buildkite.com/v3'  The agent API endpoint [$BUILDKITE_AGENT_ENDPOINT]
-   --debug              Enable debug mode [$BUILDKITE_AGENT_DEBUG]
-   --no-color              Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --step value                Scope the search to a paticular step by using either it's name of job ID
+   --build value               The build that the artifacts were uploaded to [$BUILDKITE_BUILD_ID]
+   --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
+   --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
+   --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
+   --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
 ```
 
-## Using Your Own S3 Bucket
+## Using your own S3 bucket
 
 If you’d like to upload artifacts to your own Amazon S3 bucket you’ll need to export the following environment variables using an [environment agent hook](/docs/agent/hooks) (this can not be set via the Buildkite web interface, API, or during pipeline upload):
 

--- a/pages/builds/artifacts.md.erb
+++ b/pages/builds/artifacts.md.erb
@@ -11,8 +11,6 @@ step’s “Artifact Uploading” pattern:
 
 <%= image 'artifact_pattern.png', size: '390x125', alt: 'Artifact pattern configuration' %>
 
-For a detailed description of what path patterns are supported for artifact uploading, see the [Glob Path Pattern documentation](/docs/rest-api/artifacts#glob-path-pattern). 
-
 You can also upload your own artifacts from your build scripts using
 the `buildkite-agent artifact` command.
 
@@ -22,25 +20,27 @@ buildkite-agent artifact upload pkg/build.tar.gz
 
 You can then download the artifact in subsequent build steps (even if the build step is running on a different build server).
 
+For full documentation, and examples of supported glob patterns, see the [buildkite-agent artifact upload documentation](/docs/agent/cli-artifact#uploading-artifacts).
+
 ## Downloading Artifacts
 
-You can download artifacts created by a build step using the `buildkite-agent artifact download` command. For example:
+You can download artifacts created by a build job using the `buildkite-agent artifact download` command. For example:
 
 ```bash
 buildkite-agent artifact download pkg/build.tar.gz pkg/
 ```
 
-If an artifact exists at `pkg/build.tar.gz`, the above command will download it to the `pkg` directory at your destination. 
+If an artifact was previously uploaded at `pkg/build.tar.gz`, the above command will download it to the `pkg` directory.
 
-The path pattern for downloading artifacts differs slightly to those supported for uploading. For a detailed description of the syntax, see the [Glob Path Pattern documentation](/docs/rest-api/artifacts#glob-path-pattern). 
-
-The `buildkite-agent artifact` command will find the last file uploaded with the matching filename, no matter which build step uploaded it. If you want to target an artifact from a particular build step use the `--job` argument. For example:
+The `buildkite-agent artifact` command will find the last file uploaded with the matching filename, no matter which build step uploaded it. If you want to target an artifact from a particular build step use the `--step` argument. For example:
 
 ```bash
-buildkite-agent artifact download build.zip tmp/ --job build
+buildkite-agent artifact download build.zip tmp/ --step build
 ```
 
 This will download the `build.zip` file from the pipeline step with the label "build".
+
+For full documentation and examples, see the [buildkite-agent artifact download documentation](/docs/agent/cli-artifact#downloading-artifacts).
 
 ## Downloading Artifacts Outside a Running Build
 


### PR DESCRIPTION
This aims to clean up a few mistakes in our artifact documentation that are tripping people up, and tries to make the artifact upload/download CLI documentation a little clearer. It covers:

* Fixes the incorrect `--job` argument to artifact download (the correct argument is `--step`)
* Avoids using the word "glob" to describe the download wildcard syntax
* Adds download examples that match the upload examples (as often, that's what you want to do… upload in one step, download in another)
* Fixes the broken links to the old `/docs/rest-api/artifacts#glob-path-pattern` URL
* Removes the link to our source code implementation of glob matching
* Removes the mentioning of the `%` SQL LIKE function
* Puts the upload/download examples before the technical/full definition of the pattern