### PR TITLE
Fix incorrect env for token config

### DIFF
--- a/pages/agent/configuration.md.erb
+++ b/pages/agent/configuration.md.erb
@@ -10,7 +10,7 @@ You can find the location of your configuration file in your platform’s instal
 
 `token`<br>
 The agent token from your organization’s Agents page<br>
-_Environment variable:_ `BUILDKITE_AGENT_ACCESS_TOKEN`
+_Environment variable:_ `BUILDKITE_AGENT_TOKEN`
 
 `name`<br>The name of the agent<br>
 _Default:_ `"%hostname-%n"`<br>


### PR DESCRIPTION
As pointed out by @mistydemeo, this is referring to the wrong env var. `BUILDKITE_AGENT_ACCESS_TOKEN` is the temporary token given to the agent by Buildkite, I'm pretty sure we mean `BUILDKITE_AGENT_TOKEN` here.

Fixes https://github.com/buildkite/agent/issues/490.