### PR TITLE
Fix typo in team_uuids description

### DIFF
--- a/pages/rest_api/pipelines.md.erb
+++ b/pages/rest_api/pipelines.md.erb
@@ -247,7 +247,7 @@ Optional [request body properties](/docs/api#request-body-properties):
 <tbody>
   <tr><th><code>env</code></th><td>The pipeline environment variables. <p class="Docs__api-param-eg"><em>Example:</em> <code>{"KEY":"value"}</code></p></td></tr>
   <tr><th><code>provider_settings</code></th><td>The source provider settings. <p class="Docs__api-param-eg"><em>Example:</em> <code>{"provider_settings": { "publish_commit_status": true, "build_pull_request_forks": true }}</code></p></td>
-  <tr><th><code>team_uuids</code></th><td>An array of team UUIDs to add this pipeline to. You can find your team’s UUID either via the <a href="/docs/graphql-api">GraphQL API</a>, or on the settings page for a team. This property is only available if you organisation has enabled Teams.<p class="Docs__api-param-eg"><em>Example:</em> <code>{"team_uuids": ["14e9501c-69fe-4cda-ae07-daea9ca3afd3"]}</code></p></td>
+  <tr><th><code>team_uuids</code></th><td>An array of team UUIDs to add this pipeline to. You can find your team’s UUID either via the <a href="/docs/graphql-api">GraphQL API</a>, or on the settings page for a team. This property is only available if your organisation has enabled Teams.<p class="Docs__api-param-eg"><em>Example:</em> <code>{"team_uuids": ["14e9501c-69fe-4cda-ae07-daea9ca3afd3"]}</code></p></td>
 </tbody>
 </table>
 


### PR DESCRIPTION
Missing the 'r' at the end of 'your' 😄