### PR TITLE
Correct name of envvar in documentation

### DIFF
--- a/pages/agent/configuration.md.erb
+++ b/pages/agent/configuration.md.erb
@@ -106,7 +106,7 @@ debug=true
 Most configuration options can be specified as environment variables when starting the agent, for example:
 
 ```sh
-BUILDKITE_META_DATA="queue=deploy,host=$(hostname)" buildkite-agent start
+BUILDKITE_AGENT_META_DATA="queue=deploy,host=$(hostname)" buildkite-agent start
 ```
 
 These variables cannot be modified through the Buildkite web interface, API or via pipeline upload for security reasons. You may be able to modify some of the options, such as `BUILDKITE_GIT_CLONE_FLAGS`, from within [hook scripts](/docs/agent/hooks).


### PR DESCRIPTION
The buildkite agent does not appear to recognise the buildkite_meta_data
env var and it is referred differently above