### PR TITLE
Update meta-data doc

### DIFF
--- a/pages/agent/cli_meta_data.md.erb
+++ b/pages/agent/cli_meta_data.md.erb
@@ -13,23 +13,29 @@ Use this command in your build scripts to save simple string data to the build f
 ```
 Usage:
 
-   buildkite-agent meta-data set <key> <value> [arguments...]
+   buildkite-agent meta-data set <key> [<value>] [arguments...]
 
 Description:
 
    Set arbitrary data on a build using a basic key/value store.
 
+   You can supply the value as an argument to the command, or pipe in a file or
+   script output.
+
 Example:
 
    $ buildkite-agent meta-data set "foo" "bar"
+   $ buildkite-agent meta-data set "foo" < ./tmp/meta-data-value
+   $ ./script/meta-data-generator | buildkite-agent meta-data set "foo"
 
 Options:
 
-   --job          Which job should the artifacts be downloaded from [$BUILDKITE_JOB_ID]
-   --agent-access-token       The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
-   --endpoint 'https://agent.buildkite.com/v3'  The agent API endpoint [$BUILDKITE_AGENT_ENDPOINT]
-   --debug          Enable debug mode [$BUILDKITE_AGENT_DEBUG]
-   --no-color         Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --job value                 Which job should the meta-data be set on [$BUILDKITE_JOB_ID]
+   --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
+   --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
+   --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
+   --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
 ```
 
 ## Getting Data
@@ -49,9 +55,11 @@ Example:
 
 Options:
 
-   --job          Which job should the data be retrieved from [$BUILDKITE_JOB_ID]
-   --agent-access-token       The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
-   --endpoint 'https://agent.buildkite.com/v3'  The agent API endpoint [$BUILDKITE_AGENT_ENDPOINT]
-   --debug          Enable debug mode [$BUILDKITE_AGENT_DEBUG]
-   --no-color         Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --default value             If the meta-data value doesn't exist return this instead
+   --job value                 Which job should the meta-data be retrieved from [$BUILDKITE_JOB_ID]
+   --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
+   --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
+   --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
+   --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
 ```


### PR DESCRIPTION
An update for the doc on the agent meta-data to reflect the latest from the man page. 

This page now includes the `--default` flag, as was requested in https://github.com/buildkite/docs/issues/139 🙌🏻