### PR TITLE
Clarify the behaviour of wait steps

### DIFF
--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -21,4 +21,8 @@ You can also configure the *wait* step to continue even if the previous steps fa
 - wait: ~
   continue_on_failure: true
 - command: "echo This runs regardless of the success or failure"
+- wait
+- command: "echo The command passed"
 ```
+
+In this example, if `command.sh` succeeds, both of the following command steps will be run. If `command.sh` fails, only the first will be run, and the build will then be marked as failed.


### PR DESCRIPTION
A customer noted the wait step documentation could be read to suggest that the wait step only considers the success of steps between it and the preceding wait step.

I’ve updated the documentation to explicitly show off the run-collate-deploy wait step technique we use in our own deployments!