### PR TITLE
Add allowed character set docs for block step key

### DIFF
--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -64,8 +64,8 @@ _Required attributes:_
     <td><code>key</code></td>
     <td>
       The meta-data key that stores the field's input (e.g. via the <a href="/docs/agent/cli-meta-data">buildkite-agent meta-data command</a>)<br>
-      <em>Example:</em> <code>"release-name"</code>
       The key may only contain alphanumeric characters, slashes or dashes.
+      <em>Example:</em> <code>"release-name"</code>
     </td>
   </tr>
 </table>
@@ -124,8 +124,8 @@ _Required attributes:_
     <td><code>key</code></td>
     <td>
       The meta-data key that stores the field's input (e.g. via the <a href="/docs/agent/cli-meta-data">buildkite-agent meta-data command</a>)<br>
-      <em>Example:</em> <code>"release-stream"</code>
       The key may only contain alphanumeric characters, slashes or dashes.
+      <em>Example:</em> <code>"release-stream"</code>
     </td>
   </tr>
   <tr>

--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -65,6 +65,7 @@ _Required attributes:_
     <td>
       The meta-data key that stores the field's input (e.g. via the <a href="/docs/agent/cli-meta-data">buildkite-agent meta-data command</a>)<br>
       <em>Example:</em> <code>"release-name"</code>
+      The key may only contain alphanumeric characters, slashes or dashes.
     </td>
   </tr>
 </table>
@@ -124,6 +125,7 @@ _Required attributes:_
     <td>
       The meta-data key that stores the field's input (e.g. via the <a href="/docs/agent/cli-meta-data">buildkite-agent meta-data command</a>)<br>
       <em>Example:</em> <code>"release-stream"</code>
+      The key may only contain alphanumeric characters, slashes or dashes.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
I ran into this from the API in a pipeline upload, this adds the error the API gives to the docs ahead of time 😸 