### PR TITLE
Documentation on latest retry changes

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -161,6 +161,96 @@ _Optional attributes:_
   </tr>
 </table>
 
+## Retry Attributes
+
+<div class="Docs__note">
+<p class="Docs__note__heading">At least one of the following attributes is required.</p>
+<p>You don't have to set both <em>automatic</em> and <em>manual</em> set on your retry attribute, but you can choose to set both.</p>
+</div>
+
+<table>
+  <tr>
+    <td><code>automatic</code></td>
+    <td>
+      Whether to allow a job to retry automatically. This field accepts a boolean value, individual retry conditions, or a list of multiple allowed retry conditions.<br> If set to <code>true</code>, the retry conditions are set to the default value.<br>
+      <em>Default value:</em><br><code>retry:</code>
+      <br><code>  automatic:</code>
+      <br><code>    exit_status: "*"</code>
+      <br><code>    limit: 2</code>
+      <em>Example:</em> <code>true</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>manual</code></td>
+    <td>
+      Whether to allow a job to be retried manually. This field accepts a boolean value, or a single retry condition.<br>
+      <em>Default value:</em> <code>true</code>
+      <em>Example:</em> <code>false</code>
+    </td>
+  </tr>
+</table>
+
+```yml
+steps:
+  - label: "Linting"
+    command: "lint.sh"
+    retry:
+      manual: false
+  - label: "Tests"
+    command: "tests.sh"
+    retry:
+      automatic: true
+```
+
+
+## Automatic Retry Attributes
+
+_Optional Attributes_
+
+<table>
+  <tr>
+    <td><code>exit_status</code></td>
+    <td>
+      The exit status number that will cause this job to retry. 
+      <em>Example:</em> <code>"*"</code>
+      <em>Example:</em> <code>2</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>limit</code></td>
+    <td>
+      The maximum number of times this job can be retried.
+      <em>Example:</em> <code>3</code>
+    </td>
+  </tr>
+</table>
+
+```yml
+steps:
+  - label: "Linting"
+    command: "lint.sh"
+    retry:
+      automatic:
+        limit: 3
+  - label: "Linting"
+    command: "lint.sh"
+    retry:
+      automatic:
+        limit: 3
+  - label: "Tests"
+    command: "tests.sh"
+    retry:
+      automatic:
+        - exit_status: 5
+          limit: 2
+        - exit_status: "*"
+          limit: 4
+```
+
+## Manual Retry Attributes
+
+## Examples
+
 ```yml
 steps:
   - label: "\:hammer\: Tests"

--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -180,18 +180,22 @@ _Optional Attributes_
     <td>
       The exit status number that will cause this job to retry. <br>
       <em>Example:</em> <code>"*"</code><br>
-      <em>Example:</em> <code>2</code><br>
-      <em>Example:</em> <code>-1</code>
+      <em>Example:</em> <code>2</code>
     </td>
   </tr>
   <tr>
     <td><code>limit</code></td>
     <td>
-      The maximum number of times this job can be retried.<br>
+      The number of times this job can be retried. The maximum value this can be set to is 10.<br>
       <em>Example:</em> <code>3</code>
     </td>
   </tr>
 </table>
+
+<div class="Docs__note">
+<p class="Docs__note__heading">-1 Exit Status</p>
+<p>An exit status of -1 results when a job loses connection with the agent running it. Jobs that exit with -1 will be automatically retried, unless you have overridden the retry behaviour in the <code>pipeline.yml</code> file.</p>
+</div>
 
 ```yml
 steps:

--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -141,10 +141,9 @@ _Optional attributes:_
     <td><code>automatic</code></td>
     <td>
       Whether to allow a job to retry automatically. This field accepts a boolean value, individual retry conditions, or a list of multiple different retry conditions.<br> If set to <code>true</code>, the retry conditions are set to the default value.<br>
-      <em>Default value:</em><br><code>retry:</code>
-      <br><code>  automatic:</code>
-      <br><code>    exit_status: "*"</code>
-      <br><code>    limit: 2</code>
+      <em>Default value:</em><br>
+      <code>exit_status: "*"</code><br>
+      <code>limit: 2</code><br>
       <em>Example:</em> <code>true</code>
     </td>
   </tr>
@@ -152,7 +151,7 @@ _Optional attributes:_
     <td><code>manual</code></td>
     <td>
       Whether to allow a job to be retried manually. This field accepts a boolean value, or a single retry condition.<br>
-      <em>Default value:</em> <code>true</code>
+      <em>Default value:</em> <code>true</code><br>
       <em>Example:</em> <code>false</code>
     </td>
   </tr>
@@ -179,16 +178,16 @@ _Optional Attributes_
   <tr>
     <td><code>exit_status</code></td>
     <td>
-      The exit status number that will cause this job to retry. 
-      <em>Example:</em> <code>"*"</code>
-      <em>Example:</em> <code>2</code>
+      The exit status number that will cause this job to retry. <br>
+      <em>Example:</em> <code>"*"</code><br>
+      <em>Example:</em> <code>2</code><br>
       <em>Example:</em> <code>-1</code>
     </td>
   </tr>
   <tr>
     <td><code>limit</code></td>
     <td>
-      The maximum number of times this job can be retried.
+      The maximum number of times this job can be retried.<br>
       <em>Example:</em> <code>3</code>
     </td>
   </tr>
@@ -225,22 +224,22 @@ _Optional Attributes_
   <tr>
     <td><code>allowed</code></td>
     <td>
-      A boolean value that defines whether or not this job can be retried manually.
-      <em>Default value:</em> <code>true</code>
+      A boolean value that defines whether or not this job can be retried manually.<br>
+      <em>Default value:</em> <code>true</code><br>
       <em>Example:</em> <code>false</code>
     </td>
   </tr>
   <tr>
     <td><code>reason</code></td>
     <td>
-      A string that will be displayed in a tooltip on the Retry button in Buildkite. This will only be displayed if the <code>allowed</code> attribute is set to false. 
+      A string that will be displayed in a tooltip on the Retry button in Buildkite. This will only be displayed if the <code>allowed</code> attribute is set to false. <br>
       <em>Example:</em> <code>"No retries allowed on deploy steps"</code>
     </td>
   </tr>
   <tr>
     <td><code>permit_on_passed</code></td>
     <td>
-      A boolean value that defines whether or not this job can be retried after it has passed.
+      A boolean value that defines whether or not this job can be retried after it has passed.<br>
       <em>Example:</em> <code>false</code>
     </td>
   </tr>

--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -38,7 +38,7 @@ steps:
 ```yml
 steps:
   - command:
-    - "npm install && npm test" 
+    - "npm install && npm test"
     - "moretests.sh"
     - "build.sh"
 ```
@@ -70,7 +70,7 @@ _Optional attributes:_
   <tr>
     <td><code>agents</code></td>
     <td>
-      A map of <a href="/docs/agent/cli-meta-data">meta-data</a> keys to values to <a href="/docs/agent/cli-start#agent-targeting">target specific agents</a> for this step. <br> 
+      A map of <a href="/docs/agent/cli-meta-data">meta-data</a> keys to values to <a href="/docs/agent/cli-start#agent-targeting">target specific agents</a> for this step. <br>
       <em>Example:</em> <code>npm: "true"</code>
     </td>
   </tr>
@@ -120,12 +120,51 @@ _Optional attributes:_
       <em>Example:</em> <code>"My reason"</code>
     </td>
   </tr>
+  <tr>
+    <td><code>retry</code></td>
+    <td>
+      Configuration of how retries (either <strong>automatic</strong> or <strong>manual</strong>) operate on this step<br>
+      Note: If automatic retries are enabled, a retry job will be triggered if it fails with any exit status <code>"*"</code> a maximum of 2 times.<br>
+
+      <br/>
+      <em>Example (automatic retries with defaults):</em><br>
+      <code>retry:</code><br>
+      <code>&nbsp;&nbsp;automatic: true</code><br/>
+
+      <br/>
+      <em>Example (different automatic retry rules depending on exit status):</em><br>
+      <code>retry:</code><br>
+      <code>&nbsp;&nbsp;automatic:</code><br/>
+      <code>&nbsp;&nbsp;&nbsp;&nbsp;- exit_status: 5</code><br/>
+      <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;limit: 2</code><br/>
+      <code>&nbsp;&nbsp;&nbsp;&nbsp;- exit_status: "*"</code><br/>
+      <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;limit: 4</code><br/>
+
+      <br/>
+      <em>Example (disabling manual retries):</em><br>
+      <code>retry:</code><br>
+      <code>&nbsp;&nbsp;manual: false</code><br>
+
+      <br/>
+      <em>Example (allowing retries on passed jobs):</em><br>
+      <code>retry:</code><br>
+      <code>&nbsp;&nbsp;manual:</code><br>
+      <code>&nbsp;&nbsp;&nbsp;&nbsp;permit_on_passed: true</code><br/>
+
+      <br/>
+      <em>Example (disabling manual retries and changing the default automatic retry limit to 5):</em><br>
+      <code>retry:</code><br>
+      <code>&nbsp;&nbsp;manual: false</code><br>
+      <code>&nbsp;&nbsp;automatic:</code><br>
+      <code>&nbsp;&nbsp;&nbsp;&nbsp;limit: 5</code><br/>
+    </td>
+  </tr>
 </table>
 
 ```yml
 steps:
   - label: "\:hammer\: Tests"
-    command: 
+    command:
       - "npm install"
       - "tests.sh"
     branches: "master"
@@ -140,12 +179,22 @@ steps:
       - "coverage/**/*"
     parallelism: 1
     timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: 1
+          limit: 3
+        - exit_status: 75
+          limit: 5
   - wait
   - label: "\:shipit\: Deploy"
     command: "deploy.sh"
     branches: "master"
     concurrency: 1
     concurrency_group: "my-app/deploy"
+    retry:
+      manual:
+        allowed: false
+        reason: "Don't retry deploys please!"
   - label: "Skipped job"
     command: "my_command.sh"
     skip: "Didn't feel like it"

--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -123,40 +123,8 @@ _Optional attributes:_
   <tr>
     <td><code>retry</code></td>
     <td>
-      Configuration of how retries (either <strong>automatic</strong> or <strong>manual</strong>) operate on this step<br>
-      Note: If automatic retries are enabled, a retry job will be triggered if it fails with any exit status <code>"*"</code> a maximum of 2 times.<br>
-
-      <br/>
-      <em>Example (automatic retries with defaults):</em><br>
-      <code>retry:</code><br>
-      <code>&nbsp;&nbsp;automatic: true</code><br/>
-
-      <br/>
-      <em>Example (different automatic retry rules depending on exit status):</em><br>
-      <code>retry:</code><br>
-      <code>&nbsp;&nbsp;automatic:</code><br/>
-      <code>&nbsp;&nbsp;&nbsp;&nbsp;- exit_status: 5</code><br/>
-      <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;limit: 2</code><br/>
-      <code>&nbsp;&nbsp;&nbsp;&nbsp;- exit_status: "*"</code><br/>
-      <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;limit: 4</code><br/>
-
-      <br/>
-      <em>Example (disabling manual retries):</em><br>
-      <code>retry:</code><br>
-      <code>&nbsp;&nbsp;manual: false</code><br>
-
-      <br/>
-      <em>Example (allowing retries on passed jobs):</em><br>
-      <code>retry:</code><br>
-      <code>&nbsp;&nbsp;manual:</code><br>
-      <code>&nbsp;&nbsp;&nbsp;&nbsp;permit_on_passed: true</code><br/>
-
-      <br/>
-      <em>Example (disabling manual retries and changing the default automatic retry limit to 5):</em><br>
-      <code>retry:</code><br>
-      <code>&nbsp;&nbsp;manual: false</code><br>
-      <code>&nbsp;&nbsp;automatic:</code><br>
-      <code>&nbsp;&nbsp;&nbsp;&nbsp;limit: 5</code><br/>
+      The conditions for retrying this step.<br>
+      Available retry types: <code>automatic</code>,<code>manual</code>
     </td>
   </tr>
 </table>
@@ -165,14 +133,14 @@ _Optional attributes:_
 
 <div class="Docs__note">
 <p class="Docs__note__heading">At least one of the following attributes is required.</p>
-<p>You don't have to set both <em>automatic</em> and <em>manual</em> set on your retry attribute, but you can choose to set both.</p>
+<p>You don't have to set both the <em>automatic</em> and <em>manual</em> attributes on <code>retry</code>, but you can choose to set both.</p>
 </div>
 
 <table>
   <tr>
     <td><code>automatic</code></td>
     <td>
-      Whether to allow a job to retry automatically. This field accepts a boolean value, individual retry conditions, or a list of multiple allowed retry conditions.<br> If set to <code>true</code>, the retry conditions are set to the default value.<br>
+      Whether to allow a job to retry automatically. This field accepts a boolean value, individual retry conditions, or a list of multiple different retry conditions.<br> If set to <code>true</code>, the retry conditions are set to the default value.<br>
       <em>Default value:</em><br><code>retry:</code>
       <br><code>  automatic:</code>
       <br><code>    exit_status: "*"</code>
@@ -214,6 +182,7 @@ _Optional Attributes_
       The exit status number that will cause this job to retry. 
       <em>Example:</em> <code>"*"</code>
       <em>Example:</em> <code>2</code>
+      <em>Example:</em> <code>-1</code>
     </td>
   </tr>
   <tr>
@@ -232,11 +201,12 @@ steps:
     retry:
       automatic:
         limit: 3
-  - label: "Linting"
-    command: "lint.sh"
+  - label: "Visual Diffs"
+    command: "diffs.sh"
     retry:
       automatic:
-        limit: 3
+        exit_code: 1
+        limit: 1
   - label: "Tests"
     command: "tests.sh"
     retry:
@@ -248,6 +218,52 @@ steps:
 ```
 
 ## Manual Retry Attributes
+
+_Optional Attributes_
+
+<table>
+  <tr>
+    <td><code>allowed</code></td>
+    <td>
+      A boolean value that defines whether or not this job can be retried manually.
+      <em>Default value:</em> <code>true</code>
+      <em>Example:</em> <code>false</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>reason</code></td>
+    <td>
+      A string that will be displayed in a tooltip on the Retry button in Buildkite. This will only be displayed if the <code>allowed</code> attribute is set to false. 
+      <em>Example:</em> <code>"No retries allowed on deploy steps"</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>permit_on_passed</code></td>
+    <td>
+      A boolean value that defines whether or not this job can be retried after it has passed.
+      <em>Example:</em> <code>false</code>
+    </td>
+  </tr>
+</table>
+
+```yml
+steps:
+  - label: "Linting"
+    command: "lint.sh"
+    retry:
+      manual: true
+  - label: "Visual Diffs"
+    command: "diffs.sh"
+    retry:
+      manual:
+        allowed: false
+        reason: "Don't run this twice, it's not flaky"
+  - label: "Tests"
+    command: "tests.sh"
+    retry:
+      manual:
+        permit_on_passed: true
+```
 
 ## Examples
 
@@ -275,6 +291,12 @@ steps:
           limit: 3
         - exit_status: 75
           limit: 5
+  - label: "Linting"
+    command: "lint.sh"
+    retry:
+      manual: false
+      automatic:
+        limit: 3
   - wait
   - label: "\:shipit\: Deploy"
     command: "deploy.sh"


### PR DESCRIPTION
I've started on docs on the new syntax I've added for retries.

Here's a rundown of all the changes I've made over the last few weeks. Not all of them in the docs, maybe you can fit them in somewhere else?

- Introduced a new `retry` configuration for steps.
  - Manual retries can be disabled
  - You can optionally provide a `reason` why manual retries are disabled
  - `permit_on_passed` allows manual retries to be performed on passed jobs
  - You can configure the job to automatically retry depending on exit status
  - You can configure how many times a job can be retried (max of 10) depending on exit status
  - If a job gets an exit status of (`-1`) that means we lost connection with the agent. By default, we automatically retry on this exit status as well. So if you `kill -9` an agent half way through a job, it'll automatically retry when our connection with the agent times out. Useful for spot instances that terminate jobs half way though.
- You can now manually cancel a job mid way through, and then retry it right away. This is useful if you know a job is going to fail, or if it hangs. The caveat here is you can only retry a job that was individually cancelled. If you cancel the entire build, no jobs can be retried anymore. We consider a build cancel to be "the last stop, nothing else can happen on this build"
- Instead of deleting logs/artifacts when retrying a job, we create a new job right next to the old one. By default, we hide the retried jobs in the build header. You need to hit the eyeball on the right hand side to toggle them on/off in that view. Retried jobs are still visible in the details section below the build header. We also now show who retried the job in the UI.
- Retried jobs are excluded from the REST API and web hooks.

