### PR TITLE
Fix typo in retry docs

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -208,7 +208,7 @@ steps:
     command: "diffs.sh"
     retry:
       automatic:
-        exit_code: 1
+        exit_status: 1
         limit: 1
   - label: "Tests"
     command: "tests.sh"


### PR DESCRIPTION
I noticed this while I was checking out the docs on the automatic retry attributes. I'm assuming this is a typo, but please let me know if I'm mistaken :)