### PR TITLE
Remove shebangs from hooks

### DIFF
--- a/pages/agent/v2/hooks.md.erb
+++ b/pages/agent/v2/hooks.md.erb
@@ -42,10 +42,6 @@ Hooks are bash scripts you can use to execute commands and export environment va
 The following is an example of a custom `environment` hook which exports a GitHub API key for the pipeline’s release build step:
 
 ```bash
-#!/bin/bash
-
-set -eu
-
 echo '--- \:house_with_garden\: Setting up the environment'
 
 export GITHUB_RELEASE_ACCESS_KEY='xxx'
@@ -54,10 +50,6 @@ export GITHUB_RELEASE_ACCESS_KEY='xxx'
 The following is an example of a custom `pre-command` hook which changes the working directory before the command is run:
 
 ```bash
-#!/bin/bash
-
-set -eu
-
 echo '--- \:sparkles\: Changing to the CI directory'
 
 cd ci
@@ -79,8 +71,6 @@ To get started create a `.buildkite/hooks` directory, and your hook script, and 
 mkdir -p .buildkite/hooks
 
 cat << 'HOOK_SCRIPT' > .buildkite/hooks/pre-command
-#!/bin/bash
-
 echo "--- \:checkered_flag\: Running pre-command"
 
 echo "About to run command: $BUILDKITE_COMMAND"

--- a/pages/agent/v2/hooks.md.erb
+++ b/pages/agent/v2/hooks.md.erb
@@ -42,6 +42,7 @@ Hooks are bash scripts you can use to execute commands and export environment va
 The following is an example of a custom `environment` hook which exports a GitHub API key for the pipeline’s release build step:
 
 ```bash
+set -eu
 echo '--- \:house_with_garden\: Setting up the environment'
 
 export GITHUB_RELEASE_ACCESS_KEY='xxx'
@@ -50,6 +51,7 @@ export GITHUB_RELEASE_ACCESS_KEY='xxx'
 The following is an example of a custom `pre-command` hook which changes the working directory before the command is run:
 
 ```bash
+set -eu
 echo '--- \:sparkles\: Changing to the CI directory'
 
 cd ci
@@ -71,6 +73,7 @@ To get started create a `.buildkite/hooks` directory, and your hook script, and 
 mkdir -p .buildkite/hooks
 
 cat << 'HOOK_SCRIPT' > .buildkite/hooks/pre-command
+set -eu
 echo "--- \:checkered_flag\: Running pre-command"
 
 echo "About to run command: $BUILDKITE_COMMAND"

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -36,6 +36,7 @@ Hooks are bash scripts you can use to execute commands and export environment va
 The following is an example of a custom `environment` hook which exports a GitHub API key for the pipeline’s release build step:
 
 ```bash
+set -eu
 echo '--- \:house_with_garden\: Setting up the environment'
 
 export GITHUB_RELEASE_ACCESS_KEY='xxx'
@@ -44,6 +45,7 @@ export GITHUB_RELEASE_ACCESS_KEY='xxx'
 The following is an example of a custom `pre-command` hook which changes the working directory before the command is run:
 
 ```bash
+set -eu
 echo '--- \:sparkles\: Changing to the CI directory'
 
 cd ci
@@ -65,6 +67,7 @@ To get started create a `.buildkite/hooks` directory, and your hook script, and 
 mkdir -p .buildkite/hooks
 
 cat << 'HOOK_SCRIPT' > .buildkite/hooks/pre-command
+set -eu
 echo "--- \:checkered_flag\: Running pre-command"
 
 echo "About to run command: $BUILDKITE_COMMAND"

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -36,10 +36,6 @@ Hooks are bash scripts you can use to execute commands and export environment va
 The following is an example of a custom `environment` hook which exports a GitHub API key for the pipeline’s release build step:
 
 ```bash
-#!/bin/bash
-
-set -eu
-
 echo '--- \:house_with_garden\: Setting up the environment'
 
 export GITHUB_RELEASE_ACCESS_KEY='xxx'
@@ -48,10 +44,6 @@ export GITHUB_RELEASE_ACCESS_KEY='xxx'
 The following is an example of a custom `pre-command` hook which changes the working directory before the command is run:
 
 ```bash
-#!/bin/bash
-
-set -eu
-
 echo '--- \:sparkles\: Changing to the CI directory'
 
 cd ci
@@ -73,8 +65,6 @@ To get started create a `.buildkite/hooks` directory, and your hook script, and 
 mkdir -p .buildkite/hooks
 
 cat << 'HOOK_SCRIPT' > .buildkite/hooks/pre-command
-#!/bin/bash
-
 echo "--- \:checkered_flag\: Running pre-command"
 
 echo "About to run command: $BUILDKITE_COMMAND"


### PR DESCRIPTION
Hooks are sourced, not executed, so shebangs are misleading.

Closes #79.