### PR TITLE
Add an out-of-date agent warning to v2 docs pages

### DIFF
--- a/pages/agent/v2/aws.md.erb
+++ b/pages/agent/v2/aws.md.erb
@@ -1,5 +1,10 @@
 # Running Buildkite Agent on AWS
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/aws">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent can be run easily on AWS using our Elastic CI Stack for AWS.
 
 <%= toc %>

--- a/pages/agent/v2/cli_artifact.md.erb
+++ b/pages/agent/v2/cli_artifact.md.erb
@@ -1,8 +1,8 @@
 # buildkite-agent artifact
 
 <section class="Docs__troubleshooting-note">
-  <p>This documentation is for the out-of-date Buildkite Agent v2.</p>
-  <p><a href="/docs/agent/v3/cli_artifact">See the Buildkite Agent v3 version of this document</a>
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_artifact">see the latest version of this document</a>.
 </section>
 
 The Buildkite Agent’s `artifact` command provides support for uploading and downloading of build artifacts, allowing you to share binary data between build steps no matter the machine or network.

--- a/pages/agent/v2/cli_artifact.md.erb
+++ b/pages/agent/v2/cli_artifact.md.erb
@@ -1,5 +1,10 @@
 # buildkite-agent artifact
 
+<section class="Docs__troubleshooting-note">
+  <p>This documentation is for the out-of-date Buildkite Agent v2.</p>
+  <p><a href="/docs/agent/v3/cli_artifact">See the Buildkite Agent v3 version of this document</a>
+</section>
+
 The Buildkite Agent’s `artifact` command provides support for uploading and downloading of build artifacts, allowing you to share binary data between build steps no matter the machine or network.
 
 See the [Using Build Artifacts](/docs/builds/artifacts) guide for a step-by-step example.

--- a/pages/agent/v2/cli_meta_data.md.erb
+++ b/pages/agent/v2/cli_meta_data.md.erb
@@ -1,5 +1,10 @@
 # buildkite-agent meta-data
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_meta_data">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent’s `meta-data` command provides your build pipeline with a powerful key/value data-store that works across build steps and build agents, no matter the machine or network.
 
 See the [Using Build Metadata](/docs/builds/build-meta-data) guide for a step-by-step example.

--- a/pages/agent/v2/cli_pipeline.md.erb
+++ b/pages/agent/v2/cli_pipeline.md.erb
@@ -1,5 +1,10 @@
 # buildkite-agent pipeline
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_pipeline">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent’s `pipeline` command allows you to add and replace build steps in the running build. The steps are defined using YML or JSON and can be read from a file or streamed from the output of a script.
 
 See the [Defining Your Pipeline Steps](/docs/pipelines/uploading-pipelines) guide for a step-by-step example and list of step types.

--- a/pages/agent/v2/cli_start.md.erb
+++ b/pages/agent/v2/cli_start.md.erb
@@ -1,5 +1,10 @@
 # buildkite-agent start
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_start">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent’s `start` command is used to manually start an agent and register it with Buildkite.
 
 <%= toc %>

--- a/pages/agent/v2/configuration.md.erb
+++ b/pages/agent/v2/configuration.md.erb
@@ -1,5 +1,10 @@
 # Buildkite Agent Configuration
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/configuration">see the latest version of this document</a>.
+</section>
+
 Every agent installer comes with a configuration file. You can also customize many of the configuration values using environment variables.
 
 You can find the location of your configuration file in your platform’s installation documentation, or you can set it using the `BUILDKITE_AGENT_CONFIG` environment variable or the `--config` command line argument.

--- a/pages/agent/v2/debian.md.erb
+++ b/pages/agent/v2/debian.md.erb
@@ -1,5 +1,10 @@
 # Installing Buildkite Agent on Debian
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/debian">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent can be installed on on Debian versions 7.x and 8.x using our signed apt repository.
 
 <%= toc %>

--- a/pages/agent/v2/docker.md.erb
+++ b/pages/agent/v2/docker.md.erb
@@ -1,5 +1,10 @@
 # Running Buildkite Agent with Docker
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/docker">see the latest version of this document</a>.
+</section>
+
 You can run the Buildkite Agent inside a Docker container using the official Docker images.
 
 <div class="Docs__note">

--- a/pages/agent/v2/freebsd.md.erb
+++ b/pages/agent/v2/freebsd.md.erb
@@ -1,5 +1,10 @@
 # Installing Buildkite Agent on FreeBSD
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/freebsd">see the latest version of this document</a>.
+</section>
+
 You can install Buildkite Agent on most FreeBSD systems.
 
 <%= toc %>

--- a/pages/agent/v2/gcloud.md.erb
+++ b/pages/agent/v2/gcloud.md.erb
@@ -1,5 +1,10 @@
 # Running Buildkite Agent on Google Cloud Platform
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/gcloud">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent can be run on [Google Cloud Platform](https://cloud.google.com). For fine control over long–lived agents, you might like to run the agent using individual VM instances on Google Compute Engine. Or run Docker–based builds using a scalable cluster of agents on the Google Container Engine via Kubernetes.
 
 <%= toc %>

--- a/pages/agent/v2/github_ssh_keys.md.erb
+++ b/pages/agent/v2/github_ssh_keys.md.erb
@@ -1,5 +1,10 @@
 # GitHub SSH Keys
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/github_ssh_keys">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent clones your source code directly from GitHub or GitHub Enterprise. The easiest way to provide it with access is by creating a “Buildkite Agent” machine user in your organization, and adding it to a team that has access to the relevant repositories.
 
 <div class="Docs__note">

--- a/pages/agent/v2/hooks.md.erb
+++ b/pages/agent/v2/hooks.md.erb
@@ -1,5 +1,10 @@
 # Buildkite Agent Hooks
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/hooks">see the latest version of this document</a>.
+</section>
+
 Every agent installer comes with a hooks directory which can be used to override and extend the built-in agent behavior. For example you could create a global `checkout` hook which speeds up a fresh `git clone` on a new build machine, a global `environment` hook which exports secret API keys as environment variables, or a pipeline-level `command` hook which runs the pipeline’s steps inside a custom containerized environment.
 
 

--- a/pages/agent/v2/installation.md.erb
+++ b/pages/agent/v2/installation.md.erb
@@ -1,5 +1,10 @@
 # How to Install Buildkite Agent
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/installation">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent runs on your own machine, whether it's a VPS, server, desktop computer, embedded device. There are installers for:
 
 * [Ubuntu](ubuntu)

--- a/pages/agent/v2/linux.md.erb
+++ b/pages/agent/v2/linux.md.erb
@@ -1,5 +1,10 @@
 # Installing Buildkite Agent on Linux
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/linux">see the latest version of this document</a>.
+</section>
+
 You can install Buildkite Agent on most Linux based systems (including macOS).
 
 <%= toc %>

--- a/pages/agent/v2/osx.md.erb
+++ b/pages/agent/v2/osx.md.erb
@@ -1,5 +1,10 @@
 # Installing Buildkite Agent on macOS
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/osx">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent can be installed on macOS 10.9 or higher using Homebrew or our installer script, and supports pre-release versions of both OS X and Xcode.
 
 <%= toc %>

--- a/pages/agent/v2/prioritization.md.erb
+++ b/pages/agent/v2/prioritization.md.erb
@@ -1,5 +1,10 @@
 # Buildkite Agent Prioritization
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/prioritization">see the latest version of this document</a>.
+</section>
+
 By setting an agent’s priority value you are able to designate which priority it gets for being assigned build jobs to run. Higher priority agents are assigned work first, with the last priority being given to agents with the default value of `null`.
 
 To set an agent’s priority you can set it in the configuration file:

--- a/pages/agent/v2/queues.md.erb
+++ b/pages/agent/v2/queues.md.erb
@@ -1,5 +1,10 @@
 # Buildkite Agent Job Queues
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/queues">see the latest version of this document</a>.
+</section>
+
 Each pipeline has the ability to separate jobs using queues. This allows you isolate a set of jobs and/or agents, making sure they only run jobs that are intended to be assigned to them.
 
 Common use cases for queues include deployment agents, and pools of agents for specific pipelines or teams.

--- a/pages/agent/v2/redhat.md.erb
+++ b/pages/agent/v2/redhat.md.erb
@@ -1,5 +1,10 @@
 # Installing Buildkite Agent on Red Hat, CentOS and Amazon Linux
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/redhat">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent can be installed on Redhat, CentOS and Amazon Linux using our yum repository.
 
 <%= toc %>

--- a/pages/agent/v2/securing.md.erb
+++ b/pages/agent/v2/securing.md.erb
@@ -1,5 +1,10 @@
 # Securing your Buildkite Agent
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/securing">see the latest version of this document</a>.
+</section>
+
 In cases where a Buildkite Agent is being deployed into a sensitive environment there are a few default settings and techniques which may be adjusted.
 
 <%= toc %>

--- a/pages/agent/v2/ssh_keys.md.erb
+++ b/pages/agent/v2/ssh_keys.md.erb
@@ -1,5 +1,10 @@
 # Buildkite Agent SSH Keys
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/ssh_keys">see the latest version of this document</a>.
+</section>
+
 If your agent needs to clone your repositories using git and SSH, you'll need to configure your agent with a valid SSH key.
 
 <%= toc %>

--- a/pages/agent/v2/ubuntu.md.erb
+++ b/pages/agent/v2/ubuntu.md.erb
@@ -1,5 +1,10 @@
 # Installing Buildkite Agent on Ubuntu
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/ubuntu">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent can be installed on on Ubuntu versions 12.04 and above using our signed apt repository.
 
 <%= toc %>

--- a/pages/agent/v2/upgrading_to_v2.md.erb
+++ b/pages/agent/v2/upgrading_to_v2.md.erb
@@ -1,5 +1,10 @@
 # Upgrading to Buildkite Agent v2
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/upgrading">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent has changed a lot in v2 but upgrade process is straight forward. We'll cover what’s changed and how to upgrade to new agents.
 
 <%= toc %>

--- a/pages/agent/v2/windows.md.erb
+++ b/pages/agent/v2/windows.md.erb
@@ -1,5 +1,10 @@
 # Installing Buildkite Agent on Windows
 
+<section class="Docs__troubleshooting-note">
+  <p>This page references the out-of-date Buildkite Agent v2.</p>
+  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/windows">see the latest version of this document</a>.
+</section>
+
 The Buildkite Agent can be installed on both 64bit and 32bit editions of Windows XP and later.
 
 <%= toc %>


### PR DESCRIPTION
This adds a warning to the top of v2 agent docs, directing people to the v3 version:
![v2-notice](https://user-images.githubusercontent.com/153/38541462-7d71792a-3ce2-11e8-8d46-a8bd456d914a.png)

Handy if they've arrived there by Google, or old links, and adds to the internal page rank for the v3 pages.

- [x] First cut, for words feedback
- [ ] Add to all v2 agent docs pages