### PR TITLE
V3ify docker docs

### DIFF
--- a/pages/builds/docker_containerized_builds.md.erb
+++ b/pages/builds/docker_containerized_builds.md.erb
@@ -75,10 +75,17 @@ At the start of your `pipeline.yml`, add a step to build an image with the docke
 steps:
   - name: "Docker Build"
     plugins:
-      docker-compose#v1.3.2:
+      docker-compose#v2.0.0:
         build: app
         image-repository: index.docker.io/org/repo
 ```
+
+If you don't have a registry set up, [Docker Hub](https://hub.docker.com/) provides both public and private registries for free.  
+
+<div class="Docs__note">
+<p class="Docs__note__heading">Pinning plugin versions</p>
+<p>Specifying the version of your plugin using the <code>plugin-name#vx.x.x</code> format is recommended, to ensure that no changes are introduced without your knowledge.</p>
+</div>
 
 To run later steps in the image you have built, use the `plugins` attribute on command steps. This example runs a test suite concurrently in the `app` image that was built in the previous example:
 
@@ -87,7 +94,7 @@ To run later steps in the image you have built, use the `plugins` attribute on c
     command: test.sh
     parallelism: 25
     plugins:
-      docker-compose#v1.3.2:
+      docker-compose#v2.0.0:
         run: app
 ```
 
@@ -128,6 +135,11 @@ To do this see the [agent hooks](/docs/agent/v2/hooks) and [parallelizing builds
 
 ## Using Docker Compose without plugins
 
+<div class="Docs__troubleshooting-note">
+<h1>Deprecation Notice</h1>
+<p>Using Docker Compose with environment variables is a deprecated pattern. The recommended way to use Docker Compose in your pipeline is with <a href="/docs/agent/v3/plugins">plugins</a>.</p>
+</div>
+
 You can use Docker in your pipelines without using plugins by using environment variables. 
 
 Firstly we need to add the following environment variable to our build, either on an individual build step or as a pipeline-level environment variable:
@@ -149,6 +161,11 @@ BUILDKITE_DOCKER_COMPOSE_FILE=docker-compose.buildkite.yml
 ```
 
 ## Using Docker without plugins
+
+<div class="Docs__troubleshooting-note">
+<h1>Deprecation Notice</h1>
+<p>Using Docker with environment variables is a deprecated pattern. The recommended way to use Docker in your pipeline is with <a href="/docs/agent/v3/plugins">plugins</a>.</p>
+</div>
 
 To use plain Docker instead of Docker Compose, add the following environment variable in your build step configuration:
 

--- a/pages/builds/docker_containerized_builds.md.erb
+++ b/pages/builds/docker_containerized_builds.md.erb
@@ -2,17 +2,13 @@
 
 The Buildkite Agent ships with built-in support for running your builds in Docker containers. Running your builds with Docker allows each pipeline to define and document its testing environment, greatly simplifying your build servers, and provides build isolation when [parallelizing your build](parallelizing-builds).
 
-<div class="Docs__note">
-<p>These instructions are for the current Buildkite Agent v2 stable series. For the v3 beta please use the <a href="https://github.com/buildkite-plugins/docker-buildkite-plugin">Docker Buildkite Plugin</a>.</p>
-</div>
-
 <%= toc %>
 
 ## Creating a Docker Compose config
 
 For Docker-based builds we recommend using [Docker Compose](https://docs.docker.com/compose/) as it allows each pipeline to define its own `docker-compose.yml` with dependent containers and environment variables to be passed through.
 
-Here's a example of a docker-compose.yml file for Ruby on Rails application that depends on Postgres, Redis and Memcache:
+Here's a example of a docker-compose.yml file for a Ruby on Rails application that depends on Postgres, Redis and Memcache:
 
 ```yml
 version: '2'
@@ -45,23 +41,19 @@ Mounting `.` (the directory of current build) as a volume in the container allow
 Another example of a production docker-compose configuration is from the [buildkite-agent Golang source code](https://github.com/buildkite/agent):
 
 ```
-version: '2'
+version: '2.1'
 services:
-  app:
+  agent:
     build: .
+    working_dir: /go/src/github.com/buildkite/agent
     volumes:
-      - .:/go/src/github.com/buildkite/agent
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
+      - ./:/go/src/github.com/buildkite/agent:cached
     environment:
-      - BUILDKITE_AGENT_ACCESS_TOKEN
-      - BUILDKITE_JOB_ID
-      - BUILDKITE_BUILD_ID
       - BUILDKITE_BUILD_NUMBER
-      - GITHUB_RELEASE_ACCESS_TOKEN
-      - DOCKER_HUB_TRIGGER_TOKEN
+      - BUILDKITE_JOB_ID
 ```
 
-The above example has an additional volume: the `buildkite-agent` binary itself, so the build scripts can use the `buildkite-agent artifact` and `buildkite-agent meta-data` commands. It also passes through environment variables needed for the artifact command, as well as two secret keys set up by an [environment hook](/docs/agent/v2/hooks).
+The above example has an additional volume: the `buildkite-agent` binary itself, so the build scripts can use the `buildkite-agent artifact` and `buildkite-agent meta-data` commands. It also passes through environment variables needed for the artifact command.
 
 ## Testing the config
 
@@ -75,22 +67,27 @@ Once you've got everything working, you can configure your build pipeline and ru
 
 ## Configuring the build step
 
-Firstly we need to add the following environment variable to our build, either on an individual build step or as a pipeline-level environment variable:
+To run your steps in a container, we recommend using [plugins](/docs/agent/v3/plugins). If you want to use docker without plugins, see [Using Docker without plugins](/docs/builds/docker-containerized-builds#using-docker-without-plugins)
 
-```bash
-BUILDKITE_DOCKER_COMPOSE_CONTAINER=app
+At the start of your `pipeline.yml`, add a step to build an image with the docker plugin. This example prebuilds the `app` image and uploads it to a registry:
+```
+steps:
+  - name: "Docker Build"
+    plugins:
+      docker-compose#v1.3.2:
+        build: app
+        image-repository: index.docker.io/org/repo
 ```
 
-This will tell the agent to run each build step like so:
-
-```bash
-docker-compose -f docker-compose.yml run app <command>
-```
-
-If you need, you can also specify an alternate Docker Compose config file:
+To run later steps in the image you have built, use the `plugins` attribute on command steps. This example runs a test suite concurrently in the `app` image that was built in the previous example:
 
 ```
-BUILDKITE_DOCKER_COMPOSE_FILE=docker-compose.buildkite.yml
+- name: "Docker Test %n"
+    command: test.sh
+    parallelism: 25
+    plugins:
+      docker-compose#v1.3.2:
+        run: app
 ```
 
 ## Adding buildkite-agent to the docker group
@@ -101,7 +98,7 @@ To allow buildkite-agent to use the Docker client you’ll need to ensure its us
 
 Even though the buildkite agent cleans up the images after each run, inevitably over time your Docker host can fill up with a lot of unused images.
 
-We recommend running [docker-gc](https://github.com/spotify/docker-gc) or similar tool on a daily basis.
+Docker has released the [system prune](https://docs.docker.com/engine/reference/commandline/system_prune) command that will remove all unused containers, networks, and images from your environment. We recommend running either `docker system prune` or using a similar tool like [docker-gc](https://github.com/spotify/docker-gc) on a daily basis.
 
 ## Docker without Docker Compose
 
@@ -124,3 +121,25 @@ BUILDKITE_DOCKER_FILE=Dockerfile.ci
 If your team has significant Docker experience you might find it worthwhile invoking your own runner scripts rather than using the simpler built-in Docker support.
 
 To do this see the [agent hooks](/docs/agent/v2/hooks) and [parallelizing builds](parallelizing-builds) documentation.
+
+## Using Docker without plugins
+
+You can use Docker in your pipelines without using plugins by using environment variables. 
+
+Firstly we need to add the following environment variable to our build, either on an individual build step or as a pipeline-level environment variable:
+
+```bash
+BUILDKITE_DOCKER_COMPOSE_CONTAINER=app
+```
+
+This will tell the agent to run each build step like so:
+
+```bash
+docker-compose -f docker-compose.yml run app <command>
+```
+
+If you need, you can also specify an alternate Docker Compose config file:
+
+```
+BUILDKITE_DOCKER_COMPOSE_FILE=docker-compose.buildkite.yml
+```

--- a/pages/builds/docker_containerized_builds.md.erb
+++ b/pages/builds/docker_containerized_builds.md.erb
@@ -69,7 +69,8 @@ Once you've got everything working, you can configure your build pipeline and ru
 
 To run your steps in a container, we recommend using [plugins](/docs/agent/v3/plugins). If you want to use docker without plugins, see [Using Docker without plugins](/docs/builds/docker-containerized-builds#using-docker-without-plugins)
 
-At the start of your `pipeline.yml`, add a step to build an image with the docker plugin. This example prebuilds the `app` image and uploads it to a registry:
+At the start of your `pipeline.yml`, add a step to build an image with the docker plugin. In this example, we use the `docker-compose` plugin to prebuild the `app` image and upload it to a registry:
+
 ```
 steps:
   - name: "Docker Build"
@@ -90,6 +91,8 @@ To run later steps in the image you have built, use the `plugins` attribute on c
         run: app
 ```
 
+For more examples and information on using this plugin, have a look at the [docker compose plugin on GitHub](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin).
+
 ## Adding buildkite-agent to the docker group
 
 To allow buildkite-agent to use the Docker client you’ll need to ensure its user has the necessary permissions. For most platforms this means adding the `buildkite-agent` user to your system’s `docker` group, and then restarting the Buildkite Agent to ensure it is running with the correct permissions. See your platform’s [Docker installation instructions](https://docs.docker.com/installation/) for more details.
@@ -102,19 +105,20 @@ Docker has released the [system prune](https://docs.docker.com/engine/reference/
 
 ## Docker without Docker Compose
 
-The Buildkite Agent also has support for running builds for pipelines that only need a single container and Dockerfile to run. To use plain Docker instead of Docker Compose, add the following environment variable in your build step configuration:
+The Buildkite Agent also has support for running builds for pipelines that only need a single container and Dockerfile to run. The [Docker Buildkite Plugin](https://github.com/buildkite-plugins/docker-buildkite-plugin) provides a Docker Compose file and a set of hooks to your pipeline.
+
+To use the Docker plugin, add the `plugins` attribute to your command step. In this example, the `yarn` commands will be run inside a Docker container using the node:7 Docker image:
 
 ```
-BUILDKITE_DOCKER=true
+steps:
+  - command: yarn install && yarn run test
+    plugins:
+      docker#v1.1.1:
+        image: "node:7"
+        workdir: /app
 ```
 
-For each build job the agent will now build a Docker image and run the build step’s command inside a container.
-
-If you need, you can also specify an alternate Dockerfile:
-
-```
-BUILDKITE_DOCKER_FILE=Dockerfile.ci
-```
+There are many configuration options available for the Docker plugin. For the complete list, see the readme for the [Docker Buildkite Plugin on Github](https://github.com/buildkite-plugins/docker-buildkite-plugin).
 
 ## Creating Your Own Docker Infrastructure
 
@@ -122,7 +126,7 @@ If your team has significant Docker experience you might find it worthwhile invo
 
 To do this see the [agent hooks](/docs/agent/v2/hooks) and [parallelizing builds](parallelizing-builds) documentation.
 
-## Using Docker without plugins
+## Using Docker Compose without plugins
 
 You can use Docker in your pipelines without using plugins by using environment variables. 
 
@@ -143,3 +147,20 @@ If you need, you can also specify an alternate Docker Compose config file:
 ```
 BUILDKITE_DOCKER_COMPOSE_FILE=docker-compose.buildkite.yml
 ```
+
+## Using Docker without plugins
+
+To use plain Docker instead of Docker Compose, add the following environment variable in your build step configuration:
+
+```
+BUILDKITE_DOCKER=true
+```
+
+For each build job the agent will now build a Docker image and run the build step’s command inside a container.
+
+If you need, you can also specify an alternate Dockerfile:
+
+```
+BUILDKITE_DOCKER_FILE=Dockerfile.ci
+```
+

--- a/pages/builds/docker_containerized_builds.md.erb
+++ b/pages/builds/docker_containerized_builds.md.erb
@@ -8,7 +8,7 @@ The Buildkite Agent ships with built-in support for running your builds in Docke
 
 For Docker-based builds we recommend using [Docker Compose](https://docs.docker.com/compose/) as it allows each pipeline to define its own `docker-compose.yml` with dependent containers and environment variables to be passed through.
 
-Here's a example of a docker-compose.yml file for a Ruby on Rails application that depends on Postgres, Redis and Memcache:
+Here's a example of a `docker-compose.yml` file for a Ruby on Rails application that depends on Postgres, Redis and Memcache:
 
 ```yml
 version: '2'
@@ -38,7 +38,7 @@ services:
 
 Mounting `.` (the directory of current build) as a volume in the container allows any changes from inside the container to be visible to the outside build agent, which is required if you want the agent to be able to access and upload artifacts created by the build.
 
-Another example of a production docker-compose configuration is from the [buildkite-agent Golang source code](https://github.com/buildkite/agent):
+Another example of a production `docker-compose.yml` configuration is from the [buildkite-agent Golang source code](https://github.com/buildkite/agent):
 
 ```
 version: '2.1'
@@ -67,9 +67,9 @@ Once you've got everything working, you can configure your build pipeline and ru
 
 ## Configuring the build step
 
-To run your steps in a container, we recommend using [plugins](/docs/agent/v3/plugins). If you want to use docker without plugins, see [Using Docker without plugins](/docs/builds/docker-containerized-builds#using-docker-without-plugins)
+To run your steps in a container, we recommend using [plugins](/docs/agent/v3/plugins). If you want to use Docker without plugins, see [Using Docker without plugins](/docs/builds/docker-containerized-builds#using-docker-without-plugins)
 
-At the start of your `pipeline.yml`, add a step to build an image with the docker plugin. In this example, we use the `docker-compose` plugin to prebuild the `app` image and upload it to a registry:
+At the start of your `pipeline.yml`, add a step to build an image with the Docker plugin. In this example, we use the `docker-compose` plugin to prebuild the `app` image and upload it to a registry:
 
 ```
 steps:
@@ -98,9 +98,9 @@ To run later steps in the image you have built, use the `plugins` attribute on c
         run: app
 ```
 
-For more examples and information on using this plugin, have a look at the [docker compose plugin on GitHub](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin).
+For more examples and information on using this plugin, have a look at the [Docker Compose Plugin on GitHub](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin).
 
-## Adding buildkite-agent to the docker group
+## Adding buildkite-agent to the Docker group
 
 To allow buildkite-agent to use the Docker client you’ll need to ensure its user has the necessary permissions. For most platforms this means adding the `buildkite-agent` user to your system’s `docker` group, and then restarting the Buildkite Agent to ensure it is running with the correct permissions. See your platform’s [Docker installation instructions](https://docs.docker.com/installation/) for more details.
 


### PR DESCRIPTION
Did some updates for the Containerized Builds with Docker doc:
- Moved the env vars info to new sections about using Docker Compose/Docker without plugins
- Update the `docker-compose.yml` example
- Update the "Configuring the build step" section with plugin examples and descriptions
- Update the "Docker without docker compose" section with plugin examples and descriptions
- Add links to the plugins github readmes
- Add info about `docker system prune` to the cleanup section