### PR TITLE
Fix environment variable for disabling plugins

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -240,7 +240,7 @@ debug=true
       <td>
         Do not load any plugins
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NO_PLUGINS</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PLUGINS</code></p>
       </td>
     </tr>
 


### PR DESCRIPTION
The environment variable for disabling plugins seems to be incorrectly documented. [Here is the exact location in `buildkite/agent` where the environment variable is defined](https://github.com/buildkite/agent/blob/adee22c9d9f102239f2f6271315208f797f89196/clicommand/agent_start.go#L250).