### PR TITLE
Make this match the agent v3 code

### DIFF
--- a/pages/builds/environment_variables.md.erb
+++ b/pages/builds/environment_variables.md.erb
@@ -67,7 +67,7 @@ The following environment variables are automatically provided to every job, and
     <td>The commit of the build. <p class="Docs__api-param-eg"><em>Example:</em> <code>"83a20ec058e2fb00e7fa4558c4c6e81e2dcf253d"</code></p></td>
   </tr>
   <tr>
-    <th><code>BUILDKITE_DISABLE_GIT_SUBMODULES</code></th>
+    <th><code>BUILDKITE_GIT_SUBMODULES</code></th>
     <td>When set to `true` prevents fetching of any git submodules during checkout. This variable is used by the `buildkite-agent` bootstrap script. <p class="Docs__api-param-eg"><em>Example:</em> <code>"true"</code></p></td>
   </tr>
   <tr>


### PR DESCRIPTION
https://github.com/buildkite/agent/blob/master/clicommand/bootstrap.go#L217-L221

I'm not sure this is the correct way around to fix this, but at the moment, the docs and code seem to be at odds.

I would find it clearer if the variable indicated positively which way around the boolean should be interpreted. So `BUILDKITE_WILL_FETCH_GIT_SUBMODULES` or similar. But, naming is hard :)