### PR TITLE
Update links to config and dockerfile example

### DIFF
--- a/pages/agent/v3/docker.md.erb
+++ b/pages/agent/v3/docker.md.erb
@@ -19,4 +19,4 @@ By default Docker [starts containers on restart](https://docs.docker.com/article
 
 ## SSH Keys, Configuration and Customization
 
-See the [GitHub repository](https://github.com/buildkite/docker-buildkite-agent) for instructions on how to customize the base image. Alternatively you can create your own Docker image using our standard installer packages (see our [Ubuntu Dockerfile](https://github.com/buildkite/docker-buildkite-agent/blob/master/ubuntu/Dockerfile) for an example).
+See the [Dockerhub repository](https://hub.docker.com/r/buildkite/agent/) for instructions on how to customize the base image. Alternatively you can create your own Docker image using our standard installer packages (see our [Ubuntu Dockerfile](https://github.com/buildkite/agent/blob/master/packaging/docker/ubuntu-linux/Dockerfile) for an example).


### PR DESCRIPTION
Changed the link to config info from the old github repo to the dockerhub readme. Updated the ubuntu dockerfile link to point at the right place. 

Fixes #233