### PR TITLE
Add example and clarify artifact downloads outside builds

### DIFF
--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -198,7 +198,9 @@ There is no need to escape characters such as `?`, `[` and `]`.
 
 ## Downloading artifacts outside a running build
 
-The `buildkite-agent artifact download` command only works within the context of a running build.
+The `buildkite-agent artifact download` command only works within the context of running builds. It relies on environment variables that are set by the agent while a build is running. 
+
+For example, executing the `buildkite-agent artifact download` command on your local machine would return an error about missing environment variables. However, when this command is executed as part of a build, the agent has set the required variables, and the command will be able to run. 
 
 If you want to download an artifact from outside a build use our [Artifact Download API](/docs/api/artifacts#download-an-artifact).
 

--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -249,7 +249,9 @@ Options:
 
 ## Using your own private AWS S3 bucket
 
-You can use the `buildkite-agent artifact` command to store artifacts in your own private Amazon S3 bucket. To do so, you’ll need to export the following environment variables using an [environment agent hook](/docs/agent/v3/hooks) (this can not be set via the Buildkite web interface, API, or during pipeline upload):
+You can use the `buildkite-agent artifact` command to store artifacts in your own private Amazon S3 bucket. To do so, you’ll need to export some artifact environment variables.
+
+You can set these environment variables from a variety of places, but we recommend storing your exports in an [environment agent hook](/docs/agent/v3/hooks) as a best practice:
 
 ```bash
 export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID"

--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -198,7 +198,7 @@ There is no need to escape characters such as `?`, `[` and `]`.
 
 ## Downloading artifacts outside a running build
 
-The `buildkite-agent artifact download` command only works within the context of running builds. It relies on environment variables that are set by the agent while a build is running. 
+The `buildkite-agent artifact download` command relies on environment variables that are set by the agent while a build is running. 
 
 For example, executing the `buildkite-agent artifact download` command on your local machine would return an error about missing environment variables. However, when this command is executed as part of a build, the agent has set the required variables, and the command will be able to run. 
 

--- a/pages/builds/environment_variables.md.erb
+++ b/pages/builds/environment_variables.md.erb
@@ -211,12 +211,13 @@ If you're using a 3.x agent, you can use variable interpolation to set variables
 
 ```
 env:
-- FOO=bar
+  FOO: bar
+
 steps:
-- trigger: some-pipeline
-  build:
-    env:
-    - FOO=$FOO # triggered build will have `FOO=bar`
+  - trigger: some-pipeline
+    build:
+      env:
+        FOO: $FOO # triggered build will have `FOO: bar`
 ```
 
 <div class="Docs__note">
@@ -249,7 +250,7 @@ At this point we add the following:
 After the agent variables have been merged, the bootstrap script is run. It adds its own variables to the environment, and runs any local and global hooks that have been defined on the agent machine (e.g. plugin, environment etc.) This causes any variables that are set in hooks to be merged in to the environment.
 
 <div class="Docs__troubleshooting-note">
-<p class="Docs__note__heading">Take care with environment variables in hooks</p>
+<h1>Take care with environment variables in hooks</h1>
 <p>Variables that are defined in hooks can override _anything_ that exists in the environment.</p>
 </div>
 


### PR DESCRIPTION
Added @lox's explanatory words about artifact downloads, plus a little example. Does this sound accurate @lox?

Also fixed up the S3 buckets bit - removed an out-of-date caveat about not being able to set env vars in places, added a note that using hooks is best practice, and updated some syntax in the env vars example so that the `env` is a proper hash. 

Fixes #229 and #230