### PR TITLE
Improve/make accurate info about automatic artifact uploads

### DIFF
--- a/pages/builds/artifacts.md.erb
+++ b/pages/builds/artifacts.md.erb
@@ -1,18 +1,30 @@
 # Using Build Artifacts
 
-In this guide we’ll walk through using the Buildkite Agent’s [artifact support](/docs/agent/v2/cli-artifact) to store and retrieve files between different steps in a build pipeline.
+In this guide we’ll walk through using the Buildkite Agent’s [artifact support](/docs/agent/v3/cli-artifact) to store and retrieve files between different steps in a build pipeline.
 
 <%= toc %>
 
 ## Uploading Artifacts
 
-By default the agent will upload any artifacts you’ve specified in your build
-step’s “Artifact Uploading” pattern:
+To automatically upload artifacts created in a build step, set the `artifact-paths` atrribute on your command step. In this example, any artifacts that are created two levels deep under the `logs` or `coverage` directories will be uploaded automatically: 
 
-<%= image 'artifact_pattern.png', size: '390x125', alt: 'Artifact pattern configuration' %>
+```yaml
+steps:
+  - label: ":hammer: Tests"
+    command:
+      - "npm install"
+      - "tests.sh"
+    artifact_paths:
+      - "logs/**/*"
+      - "coverage/**/*"
+```
 
-You can also upload your own artifacts from your build scripts using
-the `buildkite-agent artifact` command.
+You can also set this field in Buildkite using the “Automatic Artifact Uploading” option on a step:
+
+<%= image 'artifact_pattern.png', size: '390x125', alt: 'Artifact pattern configuration' %> 
+
+You can also perform an artifact upload manually in your build scripts with
+the `buildkite-agent artifact` command. In this example, the file `build.tar.gz` from the `pkg` directory will be uploaded to the default destination. 
 
 ```bash
 buildkite-agent artifact upload pkg/build.tar.gz
@@ -20,7 +32,7 @@ buildkite-agent artifact upload pkg/build.tar.gz
 
 You can then download the artifact in subsequent build steps (even if the build step is running on a different build server).
 
-For full documentation, and examples of supported glob patterns, see the [buildkite-agent artifact upload documentation](/docs/agent/v2/cli-artifact#uploading-artifacts).
+For full documentation of the `buildkite-agent artifact upload` command, and examples of supported glob patterns, see the [buildkite-agent artifact upload documentation](/docs/agent/v3/cli-artifact#uploading-artifacts).
 
 ## Downloading Artifacts
 
@@ -40,7 +52,7 @@ buildkite-agent artifact download build.zip tmp/ --step build
 
 This will download the `build.zip` file from the pipeline step with the label "build".
 
-For full documentation and examples, see the [buildkite-agent artifact download documentation](/docs/agent/v2/cli-artifact#downloading-artifacts).
+For full documentation and examples, see the [buildkite-agent artifact download documentation](/docs/agent/v3/cli-artifact#downloading-artifacts).
 
 ## Downloading Artifacts Outside a Running Build
 
@@ -50,4 +62,4 @@ If you want to download an artifact from outside a build use our [Artifact Downl
 
 ## Further documentation
 
-See the [Buildkite Agent artifact documentation](/docs/agent/v2/cli-artifact) for a full list of options and details of Buildkite’s artifact support.
+See the [Buildkite Agent artifact documentation](/docs/agent/v3/cli-artifact) for a full list of options and details of Buildkite’s artifact support.

--- a/pages/builds/artifacts.md.erb
+++ b/pages/builds/artifacts.md.erb
@@ -6,7 +6,7 @@ In this guide we’ll walk through using the Buildkite Agent’s [artifact suppo
 
 ## Uploading Artifacts
 
-To automatically upload artifacts created in a build step, set the `artifact-paths` atrribute on your command step. In this example, any artifacts that are created two levels deep under the `logs` or `coverage` directories will be uploaded automatically: 
+To automatically upload artifacts created by a build step, set the `artifact-paths` attribute on your command step. In this example, any artifacts that are created in the `logs` or `coverage` directories, as well as any of their subdirectories, will be uploaded automatically: 
 
 ```yaml
 steps:
@@ -19,12 +19,12 @@ steps:
       - "coverage/**/*"
 ```
 
-You can also set this field in Buildkite using the “Automatic Artifact Uploading” option on a step:
+If you've defined your pipeline in Buildkite, you can set this field on a command step using the “Automatic Artifact Uploading” option:
 
 <%= image 'artifact_pattern.png', size: '390x125', alt: 'Artifact pattern configuration' %> 
 
-You can also perform an artifact upload manually in your build scripts with
-the `buildkite-agent artifact` command. In this example, the file `build.tar.gz` from the `pkg` directory will be uploaded to the default destination. 
+You can also perform an artifact upload manually in your build scripts by using
+the `buildkite-agent artifact` command. In this example, the file `build.tar.gz` from the `pkg` directory will be uploaded to the default destination: 
 
 ```bash
 buildkite-agent artifact upload pkg/build.tar.gz

--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -70,14 +70,14 @@ _Optional attributes:_
   <tr>
     <td><code>agents</code></td>
     <td>
-      A map of <a href="/docs/agent/v2/cli-meta-data">meta-data</a> keys to values to <a href="/docs/agent/v2/cli-start#agent-targeting">target specific agents</a> for this step. <br>
+      A map of <a href="/docs/agent/v3/cli-meta-data">meta-data</a> keys to values to <a href="/docs/agent/v3/cli-start#agent-targeting">target specific agents</a> for this step. <br>
       <em>Example:</em> <code>npm: "true"</code>
     </td>
   </tr>
   <tr>
     <td><code>artifact_paths</code></td>
     <td>
-      The <a href="/docs/agent/v2/cli-artifact#glob-path-pattern">glob path</a> or paths where <a href="/docs/agent/v2/cli-artifact">artifacts</a> from this step will be uploaded. This can be a single line of paths separated by semicolons, or a YAML list.<br>
+      The <a href="/docs/agent/v3/cli-artifact#glob-path-pattern">glob path</a> or paths of <a href="/docs/agent/v3/cli-artifact">artifacts</a> to upload from this step. This can be a single line of paths separated by semicolons, or a YAML list.<br>
       <em>Example:</em> <code>"logs/**/*;coverage/**/*"</code><br>
       <em>Example:</em><br><code>- "logs/**/*"</code><br><code>- "coverage/**/*"</code>
     </td>

--- a/pages/pipelines/defining_steps.md.erb
+++ b/pages/pipelines/defining_steps.md.erb
@@ -30,7 +30,7 @@ To test your `.buildkite/pipeline.yml` file, commit the pipeline file and push i
 
 ## Example pipeline
 
-Here’s a more complete example based on [our own Buildkite Agent’s build pipeline](https://github.com/buildkite/agent/blob/master/.buildkite/pipeline.yml). It contains script commands, wait steps, block steps, and artifact uploading:
+Here’s a more complete example based on [our Buildkite Agent’s build pipeline](https://github.com/buildkite/agent/blob/master/.buildkite/pipeline.yml). It contains script commands, wait steps, block steps, and automatic artifact uploading:
 
 ```yaml
 steps:
@@ -75,7 +75,7 @@ steps:
 
 ## Step types
 
-There are four different step types you can use in your Buildkite pipelines. See each step type for full documentation:
+There are four different step types you can use in your Buildkite pipelines. See each step type for detailed usage documentation:
 
 * [Command Step](/docs/pipelines/command-step)
 * [Wait Step](/docs/pipelines/wait-step)
@@ -100,7 +100,7 @@ And your deployment pipeline’s upload command could be:
 buildkite-agent pipeline upload .buildkite/pipeline.deploy.yml
 ```
 
-For a list of all command line options, see the [buildkite-agent pipeline upload](/docs/agent/v2/cli-pipeline#uploading-pipelines) documentation.
+For a list of all command line options, see the [buildkite-agent pipeline upload](/docs/agent/v3/cli-pipeline#uploading-pipelines) documentation.
 
 ## Dynamic pipelines
 
@@ -146,4 +146,4 @@ This line of code will check if the pipeline file exists and, if it does, execut
 
 ## Further documentation
 
-See the [buildkite-agent pipeline documentation](/docs/agent/v2/cli-pipeline) for a full list of options.
+See the [buildkite-agent pipeline documentation](/docs/agent/v3/cli-pipeline) for a full list of options.


### PR DESCRIPTION
Adding some info to the Artifacts page that more clearly describes how to do automatic artifact uploading from a pipeline vs from the UI, and manually from a script. Fixes up the command step info about `artifact-paths`, so it talks about the upload pattern instead of the destination. 

Also fixes up a bunch of links that point to the v2 agent docs.

Fixes #235