### PR TITLE
Call out the top level yaml overrides

### DIFF
--- a/pages/builds/environment_variables.md.erb
+++ b/pages/builds/environment_variables.md.erb
@@ -201,7 +201,11 @@ There are two places in a pipeline.yml file that you can set environment variabl
   1. In the `env` attribute of command and trigger steps.
   2. At the top of the yaml file, before you define your pipeline's steps.
 
-Defining an environment variable at the top of your yaml file will set that variable on each of the command steps in the pipeline, and is equivalent to setting the `env` attribute on every step. This will override what is set in the `env` attribute of an individual step.
+Defining an environment variable at the top of your yaml file will set that variable on each of the command steps in the pipeline, and is equivalent to setting the `env` attribute on every step.
+
+<div class="Docs__note">
+  <p>Top level pipeline environment variables will override what is set in the <code>env</code> attribute of an individual step.</p>
+</div>
 
 **Setting variables in a Trigger step**
 


### PR DESCRIPTION
This behaviour is counteruntuitive, and we'd love to change it for future pipeline.yml versions, but for now maybe let's call it out more strongly?