### PR TITLE
Remove start command source link from env doc

### DIFF
--- a/pages/builds/environment_variables.md.erb
+++ b/pages/builds/environment_variables.md.erb
@@ -233,8 +233,7 @@ Separate to the job's base environment, your `buildkite-agent` process has an en
 - any variables you set on your agent when you started it
 - any environment variables that were inherited from how you started the process (i.e. systemd sets some env vars for you)
 
-For a list of variables/flags you can set on your agent, see the [`buildkite-agent start` page](/docs/agent/v2/cli-start).
-For a deeper look at what's involved in starting the agent, you can see the the [`buildkite-agent start` code on github](https://github.com/buildkite/agent/blob/master/clicommand/agent_start.go).
+For a list of variables and configuration flags you can set on your agent, see the Buildkite Agent’s [start command documentation](/docs/agent/v3/cli-start).
 
 ### Job accepted by an agent
 


### PR DESCRIPTION
The source code is super hard to read, and I'm not entirely sure it's useful for people, given we list them all on the `buildkite-agent start` docs page?