### PR TITLE
Add file:// plugin URL example

### DIFF
--- a/pages/agent/v3/plugins.md.erb
+++ b/pages/agent/v3/plugins.md.erb
@@ -62,7 +62,7 @@ docker environment variables, or writing a custom script.
 If you refer to a plugin just by name (say `detect-clowns`), it defaults to
 https://github.com/buildkite-plugins/detect-clowns-buildkite-plugin. If you used `myorg/detect-clowns` it would refer to https://github.com/myorg/detect-clowns-buildkite-plugin.
 
-You can also use a fully qualified git repository name like `https://github.com/buildkite-plugins/detect-clowns-buildkite-plugin.git` or `git@github.com:foo/bar.git#v1.3`, which
+You can also use a fully qualified git URL like `https://github.com/my-org/my-plugin.git#v1.0.0`, `git@github.com:my-org/my-plugin.git#v1.0.0`, or `file:///a-local-path/my-plugin.git#v1.0.0` which
 lets you refer to your own private git repositories. Branches, tags and commits
 are all valid after the `#`.
 


### PR DESCRIPTION
This adds mention of the `file://` plugin URL format, which people have asked about on support for how to refer to plugins which might have been pre-baked or installed on the agent machine.

It also updates it from "git repository name" to "git repository URL", because that's the [Git lingo for it](https://git-scm.com/docs/git-clone#URLS).