### PR TITLE
Add plugin hooks information

### DIFF
--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -16,17 +16,17 @@ Hooks are called in the following order:
 1. `pre-checkout` (global) - runs before checkout
 1. `checkout` (global) - overrides the default `git checkout` behavior
 1. `post-checkout` (global) - runs after checkout
-1. `post-checkout` (local) - runs after checkout
+1. `post-checkout` (pipeline) - runs after checkout
 1. `pre-command` (global) - runs before the build command
-1. `pre-command` (local) - runs before the build command
+1. `pre-command` (pipeline) - runs before the build command
 1. `command` (global) - overrides the default script running behavior, useful for changing how the command is evaluated (such as running it inside a container)
-1. `post-command` (local) - runs after the command
+1. `post-command` (pipeline) - runs after the command
 1. `post-command` (global) - runs after the command
-1. `pre-artifact` (local) - runs before artifacts are uploaded, if an artifact upload pattern was defined for the job
+1. `pre-artifact` (pipeline) - runs before artifacts are uploaded, if an artifact upload pattern was defined for the job
 1. `pre-artifact` (global) - runs before artifacts are uploaded, if an artifact upload pattern was defined for the job
-1. `post-artifact` (local) - runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job
+1. `post-artifact` (pipeline) - runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job
 1. `post-artifact` (global) - runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job
-1. `pre-exit` (local) - runs before the job finishes, useful for performing cleanup tasks
+1. `pre-exit` (pipeline) - runs before the job finishes, useful for performing cleanup tasks
 1. `pre-exit` (global) - runs before the job finishes, useful for performing cleanup tasks
 
 <div class="Docs__note">

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -1,6 +1,6 @@
 # Buildkite Agent Hooks
 
-Every agent installer comes with a hooks directory which can be used to override and extend the built-in agent behavior. For example you could create an agent `checkout` hook which speeds up a fresh `git clone` on a new build machine, an agent `environment` hook which exports secret API keys as environment variables, or a pipeline `pre-command` hook which sets up some repository-specific environment variables.
+Every agent installer comes with a hooks directory which can be used to override and extend the built-in agent behavior. For example you could create an agent `checkout` hook which speeds up a fresh `git clone` on a new build machine, an agent `environment` hook which exports secret API keys as environment variables, or a repository `pre-command` hook which sets up some repository-specific environment variables.
 
 <%= toc %>
 
@@ -9,8 +9,8 @@ Every agent installer comes with a hooks directory which can be used to override
 There are three types of hooks:
 
 1. [Agent hooks](#agent-hooks) - these exist on the agent’s machine, and are run for every job on any pipeline.
-1. [Pipeline hooks](#pipeline-hooks) - these exist in the pipeline repository’s `.buildkite/hooks` directory.
-1. [Plugin hooks](#plugin-hooks) - these are provided by any [plugins](/docs/agent/v3/plugins) defined in your pipeline repository’s `pipeline.yml`.
+1. [Repository hooks](#repository-hooks) - these exist in your pipeline repository’s `.buildkite/hooks` directory.
+1. [Plugin hooks](#plugin-hooks) - these are provided by any [plugins](/docs/agent/v3/plugins) you've defined in your `pipeline.yml`.
 
 ## Available hooks
 
@@ -21,16 +21,16 @@ The following is a complete list of hooks that can be implemented, and the order
     <tr><th>Hook</th><th>Order</th></th><th>Description</th></tr>
   </thead>
   <tbody>
-    <tr><td style="white-space: nowrap"><code>environment</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before all other commands, useful for <a href="/docs/agent/v3/securing#using-environment-hooks-for-secrets">exporting secret keys</a> etc.</td></tr>
+    <tr><td style="white-space: nowrap"><code>environment</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before all other commands. Useful for <a href="/docs/agent/v3/securing#using-environment-hooks-for-secrets">exporting secret keys</a>, <a href="/docs/agent/v3/securing#whitelisting">security whitelisting</a>, etc.</td></tr>
     <tr><td style="white-space: nowrap"><code>pre-checkout</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before checkout.</td></tr>
-    <tr><td style="white-space: nowrap"><code>checkout</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Overrides the default <code>git checkout</code> behavior.</td></tr>
-    <tr><td style="white-space: nowrap"><code>post-checkout</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs after checkout.</td></tr>
-    <tr><td style="white-space: nowrap"><code>pre-command</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs before the build command.</td></tr>
-    <tr><td style="white-space: nowrap"><code>command</code></td><td style="white-space: nowrap">Plugin, Pipeline, Agent</td><td>Overrides the default script running behavior, useful for changing how the command is evaluated (such as running it inside a container). <em>Note:</em> Unlike other hooks, if multiple command hooks are found only the first of Plugin, Pipeline or Agent hook type will be run.</td></tr>
-    <tr><td style="white-space: nowrap"><code>post-command</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs after the command.</td></tr>
-    <tr><td style="white-space: nowrap"><code>pre-artifact</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs before artifacts are uploaded, if an artifact upload pattern was defined for the job.</td></tr>
-    <tr><td style="white-space: nowrap"><code>post-artifact</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job.</td></tr>
-    <tr><td style="white-space: nowrap"><code>pre-exit</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs before the job finishes, useful for performing cleanup tasks.</td></tr>
+    <tr><td style="white-space: nowrap"><code>checkout</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Overrides the default <code>git checkout</code> behavior. <em>Note:</em> If multiple checkout hooks are found, only the first will be run.</td></tr>
+    <tr><td style="white-space: nowrap"><code>post-checkout</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs after checkout.</td></tr>
+    <tr><td style="white-space: nowrap"><code>pre-command</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs before the build command.</td></tr>
+    <tr><td style="white-space: nowrap"><code>command</code></td><td style="white-space: nowrap">Plugin, Repository, Agent</td><td>Overrides the default command running behavior. <em>Note:</em> If multiple command hooks are found, only the first will be run.</td></tr>
+    <tr><td style="white-space: nowrap"><code>post-command</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs after the command.</td></tr>
+    <tr><td style="white-space: nowrap"><code>pre-artifact</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs before artifacts are uploaded, if an artifact upload pattern was defined for the job.</td></tr>
+    <tr><td style="white-space: nowrap"><code>post-artifact</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job.</td></tr>
+    <tr><td style="white-space: nowrap"><code>pre-exit</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs before the job finishes, useful for performing cleanup tasks.</td></tr>
   </tbody>
 </table>
 
@@ -62,9 +62,9 @@ Each agent installer comes with a hooks directory containing a set of sample hoo
 
 To get started with agent hooks copy the relevant example script and remove the `.sample` file extension.
 
-## Pipeline hooks
+## Repository hooks
 
-Pipeline hooks allow you to execute pipeline-specific scripts. Pipeline hooks live alongside your pipeline’s source code under the directory `.buildkite/hooks`.
+Repository hooks allow you to execute repository-specific scripts. Repository hooks live alongside your repository’s source code under the directory `.buildkite/hooks`.
 
 To get started create a `.buildkite/hooks` directory, add your hook script, and make it executable.
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -1,40 +1,40 @@
 # Buildkite Agent Hooks
 
-Every agent installer comes with a hooks directory which can be used to override and extend the built-in agent behavior. For example you could create a global `checkout` hook which speeds up a fresh `git clone` on a new build machine, a global `environment` hook which exports secret API keys as environment variables, or a pipeline-level `command` hook which runs the pipeline’s steps inside a custom containerized environment.
+Every agent installer comes with a hooks directory which can be used to override and extend the built-in agent behavior. For example you could create an agent `checkout` hook which speeds up a fresh `git clone` on a new build machine, an agent `environment` hook which exports secret API keys as environment variables, or a pipeline `pre-command` hook which sets up some repository-specific environment variables.
 
 <%= toc %>
 
-## Overview
+## Types of hooks
 
-There are two types of hooks: global hooks which exist on the agent’s machine and are the same for every pipeline, and pipeline level hooks which exist in each repository in the `.buildkite/hooks` directory.
+There are three types of hooks:
 
-## Available Hooks
+1. [Agent hooks](#agent-hooks) - these exist on the agent’s machine, and are run for every job on any pipeline.
+1. [Pipeline hooks](#pipeline-hooks) - these exist in the pipeline repository’s `.buildkite/hooks` directory.
+1. [Plugin hooks](#plugin-hooks) - these are provided by any [plugins](/docs/agent/v3/plugins) defined in your pipeline repository’s `pipeline.yml`.
 
-Hooks are called in the following order:
+## Available hooks
 
-1. `environment` (global) - runs before all other commands, useful for [exporting secret keys](/docs/agent/v3/securing#using-environment-hooks-for-secrets) etc.
-1. `pre-checkout` (global) - runs before checkout
-1. `checkout` (global) - overrides the default `git checkout` behavior
-1. `post-checkout` (global) - runs after checkout
-1. `post-checkout` (pipeline) - runs after checkout
-1. `pre-command` (global) - runs before the build command
-1. `pre-command` (pipeline) - runs before the build command
-1. `command` (global) - overrides the default script running behavior, useful for changing how the command is evaluated (such as running it inside a container)
-1. `post-command` (pipeline) - runs after the command
-1. `post-command` (global) - runs after the command
-1. `pre-artifact` (pipeline) - runs before artifacts are uploaded, if an artifact upload pattern was defined for the job
-1. `pre-artifact` (global) - runs before artifacts are uploaded, if an artifact upload pattern was defined for the job
-1. `post-artifact` (pipeline) - runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job
-1. `post-artifact` (global) - runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job
-1. `pre-exit` (pipeline) - runs before the job finishes, useful for performing cleanup tasks
-1. `pre-exit` (global) - runs before the job finishes, useful for performing cleanup tasks
+The following is a complete list of hooks that can be implemented, and the order in which they are called:
 
-<div class="Docs__note">
-<p class="Docs__note__heading">Windows hooks</p>
-These hooks work on unix-based systems with bash in the path. If you're running Windows agents, you'll need some Windows-specific additions to get your hooks running. See <a href="hooks#hooks-on-windows">Hooks on Windows</a> for a detailed description.</p>
-</div>
+<table>
+  <thead>
+    <tr><th>Hook</th><th>Order</th></th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td style="white-space: nowrap"><code>environment</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before all other commands, useful for <a href="/docs/agent/v3/securing#using-environment-hooks-for-secrets">exporting secret keys</a> etc.</td></tr>
+    <tr><td style="white-space: nowrap"><code>pre-checkout</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before checkout.</td></tr>
+    <tr><td style="white-space: nowrap"><code>checkout</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Overrides the default <code>git checkout</code> behavior.</td></tr>
+    <tr><td style="white-space: nowrap"><code>post-checkout</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs after checkout.</td></tr>
+    <tr><td style="white-space: nowrap"><code>pre-command</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs before the build command.</td></tr>
+    <tr><td style="white-space: nowrap"><code>command</code></td><td style="white-space: nowrap">Plugin, Pipeline, Agent</td><td>Overrides the default script running behavior, useful for changing how the command is evaluated (such as running it inside a container). <em>Note:</em> Unlike other hooks, if multiple command hooks are found only the first of Plugin, Pipeline or Agent hook type will be run.</td></tr>
+    <tr><td style="white-space: nowrap"><code>post-command</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs after the command.</td></tr>
+    <tr><td style="white-space: nowrap"><code>pre-artifact</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs before artifacts are uploaded, if an artifact upload pattern was defined for the job.</td></tr>
+    <tr><td style="white-space: nowrap"><code>post-artifact</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job.</td></tr>
+    <tr><td style="white-space: nowrap"><code>pre-exit</code></td><td style="white-space: nowrap">Agent, Pipeline, Plugin</td><td>Runs before the job finishes, useful for performing cleanup tasks.</td></tr>
+  </tbody>
+</table>
 
-## Creating Hook Scripts
+## Creating hook scripts
 
 Hooks are bash scripts you can use to execute commands and export environment variables. All the standard [Buildkite environment variables](/docs/builds/environment-variables) are available to be used inside your hook scripts.
 
@@ -56,30 +56,23 @@ echo '--- \:sparkles\: Changing to the CI directory'
 cd ci
 ```
 
-## Global Hooks
+## Agent hooks
 
-Each agent installer comes with a hooks directory containing a sample set of hooks. You can find the location of your global hooks directory in your platform’s installation documentation.
+Each agent installer comes with a hooks directory containing a set of sample hooks. You can find the location of your agent hooks directory in your platform’s installation documentation.
 
-To get started with global hooks copy the relevant example script and remove the `.sample` file extension.
+To get started with agent hooks copy the relevant example script and remove the `.sample` file extension.
 
-## Pipeline Hooks
+## Pipeline hooks
 
 Pipeline hooks allow you to execute pipeline-specific scripts. Pipeline hooks live alongside your pipeline’s source code under the directory `.buildkite/hooks`.
 
-To get started create a `.buildkite/hooks` directory, and your hook script, and make it executable, for example:
+To get started create a `.buildkite/hooks` directory, add your hook script, and make it executable.
 
-```bash
-mkdir -p .buildkite/hooks
+## Plugin hooks
 
-cat << 'HOOK_SCRIPT' > .buildkite/hooks/pre-command
-set -eu
-echo "--- \:checkered_flag\: Running pre-command"
+Plugin hooks allow any plugins you’ve defined to execute and override any of the default behaviour.
 
-echo "About to run command: $BUILDKITE_COMMAND"
-HOOK_SCRIPT
-
-chmod +x .buildkite/hooks/pre-command
-```
+See the [plugin documentation](/docs/agent/v3/plugins) for how to implement plugin hooks.
 
 ## Hooks on Windows
 
@@ -92,7 +85,6 @@ An example of a windows `environment.bat` hook:
 
 ```batch
 @ECHO OFF
-ECHO "--- :house_with_garden: Setting up the environment"
+ECHO "--- \:house_with_garden\: Setting up the environment"
 SET GITHUB_RELEASE_ACCESS_KEY='xxx'
 ```
-

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -21,7 +21,7 @@ The following is a complete list of hooks that can be implemented, and the order
     <tr><th>Hook</th><th>Order</th></th><th>Description</th></tr>
   </thead>
   <tbody>
-    <tr><td style="white-space: nowrap"><code>environment</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before all other commands. Useful for <a href="/docs/agent/v3/securing#using-environment-hooks-for-secrets">exporting secret keys</a>, <a href="/docs/agent/v3/securing#whitelisting">security whitelisting</a>, etc.</td></tr>
+    <tr><td style="white-space: nowrap"><code>environment</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before all other commands. Useful for <a href="/docs/agent/v3/securing#using-environment-hooks-for-secrets">exposing secret keys</a> and <a href="/docs/agent/v3/securing#whitelisting">security whitelisting</a>.</td></tr>
     <tr><td style="white-space: nowrap"><code>pre-checkout</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before checkout.</td></tr>
     <tr><td style="white-space: nowrap"><code>checkout</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Overrides the default <code>git checkout</code> behavior. <em>Note:</em> If multiple checkout hooks are found, only the first will be run.</td></tr>
     <tr><td style="white-space: nowrap"><code>post-checkout</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs after checkout.</td></tr>
@@ -30,7 +30,7 @@ The following is a complete list of hooks that can be implemented, and the order
     <tr><td style="white-space: nowrap"><code>post-command</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs after the command.</td></tr>
     <tr><td style="white-space: nowrap"><code>pre-artifact</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs before artifacts are uploaded, if an artifact upload pattern was defined for the job.</td></tr>
     <tr><td style="white-space: nowrap"><code>post-artifact</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job.</td></tr>
-    <tr><td style="white-space: nowrap"><code>pre-exit</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs before the job finishes, useful for performing cleanup tasks.</td></tr>
+    <tr><td style="white-space: nowrap"><code>pre-exit</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs before the job finishes. Useful for performing cleanup tasks.</td></tr>
   </tbody>
 </table>
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -23,7 +23,7 @@ The following is a complete list of hooks that can be implemented, and the order
   <tbody>
     <tr><td style="white-space: nowrap"><code>environment</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before all other commands. Useful for <a href="/docs/agent/v3/securing#using-environment-hooks-for-secrets">exposing secret keys</a> and <a href="/docs/agent/v3/securing#whitelisting">security whitelisting</a>.</td></tr>
     <tr><td style="white-space: nowrap"><code>pre-checkout</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before checkout.</td></tr>
-    <tr><td style="white-space: nowrap"><code>checkout</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Overrides the default <code>git checkout</code> behavior. <em>Note:</em> If multiple checkout hooks are found, only the first will be run.</td></tr>
+    <tr><td style="white-space: nowrap"><code>checkout</code></td><td style="white-space: nowrap">Plugin, Agent</td><td>Overrides the default <code>git checkout</code> behavior. <em>Note:</em> If multiple checkout hooks are found, only the first will be run.</td></tr>
     <tr><td style="white-space: nowrap"><code>post-checkout</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs after checkout.</td></tr>
     <tr><td style="white-space: nowrap"><code>pre-command</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs before the build command.</td></tr>
     <tr><td style="white-space: nowrap"><code>command</code></td><td style="white-space: nowrap">Plugin, Repository, Agent</td><td>Overrides the default command running behavior. <em>Note:</em> If multiple command hooks are found, only the first will be run.</td></tr>


### PR DESCRIPTION
This reworks our hooks page to include information about plugin hooks.

The "Available hooks" have been redone to be in a table just like environment variables. Hopefully this makes it much easier to read and scan, and explicitly states the order that the hooks are run in.

<img width="748" alt="list-of-hooks" src="https://user-images.githubusercontent.com/153/40107358-5a67ac40-593b-11e8-9ec4-391d4ed0557e.png">

It also updates the plugin doc to link back to the hooks page in lots of places, because it's important for plugin authors to understand hooks, and how they're run in order and relation to all the other hooks.

You might need to check this one out locally @harrietgrace.