### PR TITLE
Fixup junit-annotate plugin example.

### DIFF
--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -114,6 +114,6 @@ steps:
   - wait: ~
     continue_on_failure: true
   - plugins:
-      junit-annotate#v0.0.1:
+      junit-annotate#v1.2.0:
         artifacts: tmp/junit-*.xml
 ```


### PR DESCRIPTION
Fixes minor error in junit-annotate plugin example, updating to valid plugin version.