### PR TITLE
Add to description of webhook AWS integration

### DIFF
--- a/pages/webhooks/integrations.md.erb
+++ b/pages/webhooks/integrations.md.erb
@@ -4,14 +4,15 @@ There are a number of third party services you can use with Buildkite webhooks. 
 
 <%= toc %>
 
-## AWS SNS + Lambda
+## AWS SNS with AWS Lambda
 
-SNS is an Amazon pub-sub service. See (buildkite-webhook-aws-terraform)[https://github.com/rivethealth/buildkite-webhook-aws-terraform] which uses API Gateway to connect Buildkite webhook events to SNS.
+[AWS SNS](https://aws.amazon.com/sns/) is an Amazon pub-sub service providing messaging and mobile notifications. [AWS Lambda](https://aws.amazon.com/lambda/) is an Amazon service for running code functions in response to events like SNS messages or HTTP requests.
 
-Examples of using [AWS Lambda](https://aws.amazon.com/lambda/) for processing SNS messages:
+There are many ways to integrate webhooks with SNS. The following examples show a variety of ways to use Lambda to process SNS messages:
 
-* AWS's [GitHub webhook guide](https://aws.amazon.com/blogs/compute/dynamic-github-actions-with-aws-lambda/)
-* (buildkite-bitbucket-aws-terraform)[https://github.com/rivethealth/buildkite-bitbucket-aws-terraform] for sending build statuses to Atlassian Bitbucket Server.
+* AWS's [GitHub webhook guide](https://aws.amazon.com/blogs/compute/dynamic-github-actions-with-aws-lambda/) provides an example of publishing webhook events as SNS topics and then processing them using AWS Lambda
+* Rivet's [buildkite-webhook-aws-terraform](https://github.com/rivethealth/buildkite-webhook-aws-terraform) uses API Gateway to publish Buildkite webhook events to SNS
+* Rivet's [buildkite-bitbucket-aws-terraform](https://github.com/rivethealth/buildkite-bitbucket-aws-terraform) demonstrates a more complex setup, using SNS and webhooks to send build statuses to Atlassian Bitbucket Server
 
 ## Google Cloud Functions
 

--- a/pages/webhooks/integrations.md.erb
+++ b/pages/webhooks/integrations.md.erb
@@ -4,9 +4,14 @@ There are a number of third party services you can use with Buildkite webhooks. 
 
 <%= toc %>
 
-## AWS Lambda
+## AWS SNS + Lambda
 
-[AWS Lambda](https://aws.amazon.com/lambda/) is an Amazon service for hosted Javascript execution, and supports exposing functions via URLs. You can follow their [GitHub webhook guide](https://aws.amazon.com/blogs/compute/dynamic-github-actions-with-aws-lambda/) for an example of how to publish Buildkite webhook events as SNS topics and then process them using AWS Lambda.
+SNS is an Amazon pub-sub service. See (buildkite-webhook-aws-terraform)[https://github.com/rivethealth/buildkite-webhook-aws-terraform] which uses API Gateway to connect Buildkite webhook events to SNS.
+
+Examples of using [AWS Lambda](https://aws.amazon.com/lambda/) for processing SNS messages:
+
+* AWS's [GitHub webhook guide](https://aws.amazon.com/blogs/compute/dynamic-github-actions-with-aws-lambda/)
+* (buildkite-bitbucket-aws-terraform)[https://github.com/rivethealth/buildkite-bitbucket-aws-terraform] for sending build statuses to Atlassian Bitbucket Server.
 
 ## Google Cloud Functions
 


### PR DESCRIPTION
IDK what exactly needs to be said here, but unlike Github, Buildkite does not have SNS publishing, so the AWS Github guide is only a piece of the puzzle.