### PR TITLE
Add sso guides

### DIFF
--- a/pages/tutorials/adfs.md.erb
+++ b/pages/tutorials/adfs.md.erb
@@ -2,46 +2,48 @@
 
 AD FS can be used as single sign-on to log in to your Buildkite organisation.
 
-## Setting up your AD FS Server
-
-- you must be an admin in your Buildkite organisation, and have __ permissions on the server you're using for AD FS
-- know the slug of the Buildkite organisation for which you'd like to enable SSO 
+Setting up AD FS requires organisation administrator privileges on your AD FS server and in Buildkite. You'll also need to know the slug of the Buildkite organisation for which you'd like to enable SSO.
 
 ## Setup in the AD FS management console
 
-using a series of wizards, you'll:
-- add a 'relying party trust' and
-- add an 'issuance transform rule', a type of 'claim rule'
-- export the token-signing certificate
-- update the authentication policy
+The instructions below will guide you through using a series of wizards to:
+- Add a 'relying party trust'
+- Add an 'issuance transform rule', a type of 'claim rule'
+- Export the token-signing certificate
+- Update the authentication policy
+
+With these wizards, you'll set up your domain for SSO and retreive the information the Buildkite team requires to complete the setup process.
 
 
-- this guide was written for and tested using Windows Server 2016
-- some of the wizard pages and dialog tab names have changed across versions of Windows Server 
-- for a guide written for Windows Server 2012, the [Pagerduty SSO integration guide](https://www.pagerduty.com/docs/guides/adfs-sso-guide/) is very similar to Buildkite
-- you can follow the pagerduty instructions, and subsitute in the Buildkite values from the instructions below
+
+<div class="Docs__note">
+<p class="Docs__note__heading">This guide was written for, and tested using, Windows Server 2016.</p>
+<p>Some of the wizard pages and dialog tab names have changed across versions of Windows Server.</p>
+
+<p>For a guide written for Windows Server 2012, the <a href="https://www.pagerduty.com/docs/guides/adfs-sso-guide/">Pagerduty SSO integration guide</a> is very similar to Buildkite. Follow the Pagerduty instructions, and subsitute in the Buildkite values from the instructions below.</p>
+</div>
 
 ### Add a Relying Party Trust
 
-From the `Actions` sidebar, choose `add relying party trust...` to start the wizard
+From the `Actions` sidebar, click `Add relying party trust...` to start the wizard
 
-1. Welcome: select `Claims aware`
-1. Select data source: select `Enter data about the relying party manually`
-1. Specify display name: call your relying party `Buildkite`
-1. Choose profile: select `AD FS profile`
-1. Configure certificate: skip this step, as you don't need a token encryption certificate
-1. Configure URL: 
+1. <u>Welcome</u>: select `Claims aware`
+1. <u>Select data source</u>: select `Enter data about the relying party manually`
+1. <u>Specify display name</u>: call your relying party `Buildkite`
+1. <u>Choose profile</u>: select `AD FS profile`
+1. <u>Configure certificate</u>: skip this step, as you don't need a token encryption certificate
+1. <u>Configure URL</u>: 
 	select `Enable support for the SAML 2.0 WebSSO protocol` 
 	replace <slug> with your organisation slug in this URL: https://buildkite.com/login/sso/saml/consume?organization=<slug>
 	enter that URL as your `Relying party SAML 2.0 SSO service URL` 
-1. Configure identifiers: 
+1. <u>Configure identifiers</u>: 
 	enter `https://buildkite.com` into the `Relying party trust identifier` field
 	click `add` to add it to the `Relying party trust identifiers` list
-1. Choose Access Control Policy:
+1. <u>Choose Access Control Policy</u>:
 	choose `Permit everyone`
 	you can choose to select specific users, but that will involve further steps that aren't covered by this guide
-1. Ready to add trust: review your settings to make sure all the urls are correct
-1. Finish:
+1. <u>Ready to add trust</u>: review your settings to make sure all the urls are correct
+1. <u>Finish</u>:
 	leave the `configure claims issuance policy for this application` box checked
 	click `close` to close the wizard and save your setup
 
@@ -49,53 +51,100 @@ In the `Actions` sidebar, you should now have a subheading `Buildkite`.
 
 ### Add an issuance transform rule
 
-From the `Buildkite` section of the `Actions` sidebar, select `Edit claim issuance policy...`
+From the `Buildkite` section of the `Actions` sidebar, click `Edit claim issuance policy...`
 
-- we'll be adding three rules
-- on the Issuance transform rules tab: click `add rule`
+Here we're going to add three rules. For each rule, on the Issuance transform rules tab: click `add rule`
 
 Rule 1
-1. Choose rule type: `Send LDAP Attributes as claims`
-1. Configure claim rule:
-	Claim Rule Name: Get Attributes
-	Attribute Store: Active Directory
-	Mapping of LDAP Attributes to outgoing claim types:
-		LDAP Attribute: Email Addresses, Outgoing claim type: Email address
-		LDAP Attribute: Display-Name, Outgoing claim type: Name
+
+1. <u>Choose rule type</u>: `Send LDAP Attributes as claims`
+1. <u>Configure claim rule</u>:
+	- <u>Claim Rule Name</u>: Get Attributes
+	- <u>Attribute Store</u>: Active Directory
+	- <u>Mapping of LDAP Attributes to outgoing claim types</u>:
+		+ <u>LDAP Attribute</u>: Email Addresses, Outgoing claim type: Email address
+		+ <u>LDAP Attribute</u>: Display-Name, Outgoing claim type: Name
 1. Click `Finish` to add the rule
 
 Rule 2
-1. Choose rule type: `Transform an incoming claim`
-1. Configure claim rule:
-	Claim Rule Name: Name ID Transform
-	Incoming Claim Type: Email address
-	Outgoing Claim Type: Name ID
-	Outgoing Name ID Format: Email
-	Select `Pass through all claim values`
+
+1. <u>Choose rule type</u>: `Transform an incoming claim`
+1. <u>Configure claim rule</u>:
+	- <u>Claim Rule Name</u>: Name ID Transform
+	- <u>Incoming Claim Type</u>: Email address
+	- <u>Outgoing Claim Type</u>: Name ID
+	- <u>Outgoing Name ID Format</u>: Email
+	- Select `Pass through all claim values`
 1. Click `Finish` to add the rule
 
 Rule 3
-1. Choose rule type: `Send claims using a custom rule`
-1. Configure claim rule:
-	Claim Rule Name: 'Name' Attribute Name Transform
-	Custom Rule: 
-```
-c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"]
- => issue(Type = "Name", Issuer = c.Issuer, OriginalIssuer = c.OriginalIssuer, Value = c.Value, ValueType = c.ValueType);
-```
-1. Click `Finish` to add the rule
-1. Click `OK` to save and exit the Claim Issuance Policy dialog
+
+<ol>
+	<li><u>Choose rule type</u>: `Send claims using a custom rule`</li>
+	<li><u>Configure claim rule</u>:
+	<ul>
+		<li><u>Claim Rule Name</u>: 'Name' Attribute Name Transform</li>
+		<li><u>Custom Rule</u>: 
+<pre><code>c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"]
+ => issue(Type = "Name", Issuer = c.Issuer, OriginalIssuer = c.OriginalIssuer, Value = c.Value, ValueType = c.ValueType);</code></pre>
+</li>
+	</ul>
+	<li>Click `Finish` to add the rule</li>
+	<li>Click `OK` to save and exit the Claim Issuance Policy dialog</li>
+</ol>
 
 ### Export the token signing certificate
 
+From the `Service` section of the `AD FS` console tree, select the `Certificates` subsection
 
+1.  Click on the certificate listed under the heading `Token-signing`
+2.  In the `CN=ADFS Signing` section of the `Actions` sidebar, click `View Certificate...`
+3.  In the `Certificate` dialog, select the `Details` tab
+4.  Click the `Copy to File...` button
+5.  Start the `Certificate Export Wizard`
+6.  Export File Format: select `Base-64 encoded X.509 (.CER)`
+7.  File to Export: name your file, and choose where you'd like to export the file
+8.  Completing the Certificate Export Wizard: check the settings are correct, and click `Finish`
+9.  Exit the `Certificate` dialog
 
 ### Update the authentication policy
 
-### What the Buildkite team will do
-1. enable sso for the specified organisation
-1. get you to test that it's all working
-1. force a logout for all the users in the organisation, so that everyone will log in via Okta next time they access Buildkite.com
+From the `Service` section of the `AD FS` console tree, select the `Authentication Methods` subsection
+
+1. Under the `Primary Authentication Methods` header, click the `Edit` link
+2. In the `Intranet` section, ensure that the `Forms Authentication` box is checked 
+3. Click `OK` to exit the dialog
+
+### Email the Buildkite team
+
+To complete your SSO setup, the Buildkite team needs some information from your AD FS server. 
+
+Email support@buildkite.com with the following SSO and AD FS information:
+
+<dl>
+    <dt>Domain name</dt>
+    <dd>
+      The domain you use with AD FS for which you want to enable SSO. This must match one of the emails you have verified with your Buildkite account.
+    </dd>
+    <dt>Organisation slug</dt>
+    <dd>
+      The Buildkite organisation for which you want to enable SSO.  
+    </dd>
+    <dt>Login URL</dt>
+    <dd>
+      The URL where you can log in to your AD FS service. Usually your domain name or IP, with <code>/adfs/ls</code> appended.
+    </dd>
+    <dt>x.509 certificate</dt>
+    <dd>
+   	  Attach the x.509 certificate that you downloaded during setup
+    </dd>
+</dl>
+
+When we receive your email, the Buildkite team will:
+
+1. Enable SSO for the specified organisation
+1. Reply to your email and get you to test that it's all working
+1. Force a logout for all the users in the organisation, so that everyone will log in via AD FS next time they attempt to access that organisation on Buildkite.com
 
 
 

--- a/pages/tutorials/adfs.md.erb
+++ b/pages/tutorials/adfs.md.erb
@@ -1,0 +1,66 @@
+# AD FS SSO Setup
+
+- Teams using AD FS can use it to log into Buildkite
+
+## Setting up your AD FS Server
+
+- you must be an admin in your Buildkite organisation, and have __ permissions on the server you're using for AD FS
+- know the slug of the Buildkite organisation for which you'd like to enable SSO 
+
+## Setup in the AD FS management console
+
+using a series of wizards, you'll:
+- add a 'relying party trust' and
+- add an 'issuance transform rule', a type of 'claim rule'
+- export the token-signing certificate
+- update the authentication policy
+
+for screenshots of each of the following instructions, you can have a look at the [Pagerduty SSO integration guide](https://www.pagerduty.com/docs/guides/adfs-sso-guide/)
+
+### Add a Relying Party Trust
+
+From the actions sidebar, choose `add relying party trust...` to start the wizard
+
+1. Select data source: select `Enter data about the relying party manually`
+1. Specify display name: call your relying party `Buildkite`
+1. Choose profile: select `AD FS profile`
+1. Configure certificate: skip this step, as you don't need a token encryption certificate
+1. Configure URL: 
+	select `Enable support for the SAML 2.0 WebSSO protocol` 
+	replace <slug> with your organisation slug in this URL: https://buildkite.com/login/sso/saml/consume?organization=<slug>
+	enter that URL as your `Relying party SAML 2.0 SSO service URL` 
+1. Configure identifiers: 
+	enter `https://buildkite.com` into the `Relying party trust identifier` field
+	click `add` to add it to the `Relying party trust identifiers` list
+1. Configure Multi-factor Authentication Now? 
+	select `I do not want to configure multi-factor authentication settings for this relying part trust at this time`
+1. Choose issuance authorisation rules: select `Permit all users to access this relying party`
+	you can choose to select specific users, but that will involve further steps that aren't covered by this guide
+1. Ready to add trust: review your settings to make sure all the urls are correct
+1. Finish: click `close` to close the wizard and save your setup
+
+### Add an issuance transform rule
+
+<how to get to the `edit claim rules for buildkite` popup>
+- we'll be adding three rules
+- Issuance transform rules tab: click `add rule`
+
+Rule 1
+1. Choose rule type: `Send LDAP Attributes as claims`
+1. Configure claim rule:
+
+Rule 2
+1. Choose rule type: 
+1. Configure claim rule:
+
+Rule 3
+1. Choose rule type: 
+1. Configure claim rule:
+
+### What the Buildkite team will do
+1. enable sso for the specified organisation
+1. get you to test that it's all working
+1. force a logout for all the users in the organisation, so that everyone will log in via Okta next time they access Buildkite.com
+
+
+

--- a/pages/tutorials/adfs.md.erb
+++ b/pages/tutorials/adfs.md.erb
@@ -1,6 +1,6 @@
 # SAML with Active Directory Federation Services (AD FS)
 
-- Teams using AD FS can use it to log into Buildkite
+AD FS can be used as single sign-on to log in to your Buildkite organisation.
 
 ## Setting up your AD FS Server
 

--- a/pages/tutorials/adfs.md.erb
+++ b/pages/tutorials/adfs.md.erb
@@ -19,8 +19,9 @@ for screenshots of each of the following instructions, you can have a look at th
 
 ### Add a Relying Party Trust
 
-From the actions sidebar, choose `add relying party trust...` to start the wizard
+From the `Actions` sidebar, choose `add relying party trust...` to start the wizard
 
+1. Welcome: select `Claims aware`
 1. Select data source: select `Enter data about the relying party manually`
 1. Specify display name: call your relying party `Buildkite`
 1. Choose profile: select `AD FS profile`
@@ -32,30 +33,59 @@ From the actions sidebar, choose `add relying party trust...` to start the wizar
 1. Configure identifiers: 
 	enter `https://buildkite.com` into the `Relying party trust identifier` field
 	click `add` to add it to the `Relying party trust identifiers` list
-1. Configure Multi-factor Authentication Now? 
-	select `I do not want to configure multi-factor authentication settings for this relying part trust at this time`
-1. Choose issuance authorisation rules: select `Permit all users to access this relying party`
+1. Choose Access Control Policy:
+	choose `Permit everyone`
 	you can choose to select specific users, but that will involve further steps that aren't covered by this guide
 1. Ready to add trust: review your settings to make sure all the urls are correct
-1. Finish: click `close` to close the wizard and save your setup
+1. Finish:
+	leave the `configure claims issuance policy for this application` box checked
+	click `close` to close the wizard and save your setup
+
+In the `Actions` sidebar, you should now have a subheading `Buildkite`. 
 
 ### Add an issuance transform rule
 
-<how to get to the `edit claim rules for buildkite` popup>
+From the `Buildkite` section of the `Actions` sidebar, select `Edit claim issuance policy...`
+
 - we'll be adding three rules
-- Issuance transform rules tab: click `add rule`
+- on the Issuance transform rules tab: click `add rule`
 
 Rule 1
 1. Choose rule type: `Send LDAP Attributes as claims`
 1. Configure claim rule:
+	Claim Rule Name: Get Attributes
+	Attribute Store: Active Directory
+	Mapping of LDAP Attributes to outgoing claim types:
+		LDAP Attribute: Email Addresses, Outgoing claim type: Email address
+		LDAP Attribute: Display-Name, Outgoing claim type: Name
+1. Click `Finish` to add the rule
 
 Rule 2
-1. Choose rule type: 
+1. Choose rule type: `Transform an incoming claim`
 1. Configure claim rule:
+	Claim Rule Name: Name ID Transform
+	Incoming Claim Type: Email address
+	Outgoing Claim Type: Name ID
+	Outgoing Name ID Format: Email
+	Select `Pass through all claim values`
+1. Click `Finish` to add the rule
 
 Rule 3
-1. Choose rule type: 
+1. Choose rule type: `Send claims using a custom rule`
 1. Configure claim rule:
+	Claim Rule Name: 'Name' Attribute Name Transform
+	Custom Rule: 
+```
+c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"]
+ => issue(Type = "Name", Issuer = c.Issuer, OriginalIssuer = c.OriginalIssuer, Value = c.Value, ValueType = c.ValueType);
+```
+1. Click `Finish` to add the rule
+1. Click `OK` to save and exit the Claim Issuance Policy dialog
+
+### Export the token signing certificate
+
+
+### Update the authentication policy
 
 ### What the Buildkite team will do
 1. enable sso for the specified organisation

--- a/pages/tutorials/adfs.md.erb
+++ b/pages/tutorials/adfs.md.erb
@@ -1,4 +1,4 @@
-# AD FS SSO Setup
+# SAML with Active Directory Federation Services (AD FS)
 
 - Teams using AD FS can use it to log into Buildkite
 
@@ -15,7 +15,11 @@ using a series of wizards, you'll:
 - export the token-signing certificate
 - update the authentication policy
 
-for screenshots of each of the following instructions, you can have a look at the [Pagerduty SSO integration guide](https://www.pagerduty.com/docs/guides/adfs-sso-guide/)
+
+- this guide was written for and tested using Windows Server 2016
+- some of the wizard pages and dialog tab names have changed across versions of Windows Server 
+- for a guide written for Windows Server 2012, the [Pagerduty SSO integration guide](https://www.pagerduty.com/docs/guides/adfs-sso-guide/) is very similar to Buildkite
+- you can follow the pagerduty instructions, and subsitute in the Buildkite values from the instructions below
 
 ### Add a Relying Party Trust
 
@@ -83,6 +87,7 @@ c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"]
 1. Click `OK` to save and exit the Claim Issuance Policy dialog
 
 ### Export the token signing certificate
+
 
 
 ### Update the authentication policy

--- a/pages/tutorials/custom_saml.md.erb
+++ b/pages/tutorials/custom_saml.md.erb
@@ -1,0 +1,19 @@
+# SAML with a Custom Provider
+
+Teams using a SAML provider that isn't covered by any of the Buildkite SSO guides can manually set up a custom provider.
+
+## Setting up SAML
+
+- meta data is provided for setting up SAML with any provider
+
+1. Fetch the XML from this URL: https://buildkite.com/user/authorize/saml/metadata
+2. Using the meta data from the XML, set up Buildkite in your SAML provider's service
+    - the Buildkite SSO service accepts the `username` and `admin` fields
+3. Email support@buildkite
+
+### What the Buildkite team will do
+1. enable SAML for the specified organisation
+1. get you to test that it's all working
+1. force a logout for all the users in the organisation, so that everyone will log in via your chosen provider next time they access Buildkite.com
+
+

--- a/pages/tutorials/custom_saml.md.erb
+++ b/pages/tutorials/custom_saml.md.erb
@@ -1,19 +1,36 @@
 # SAML with a Custom Provider
 
-Teams using a SAML provider that isn't covered by any of the Buildkite SSO guides can manually set up a custom provider.
+Any SAML provider can be used as single sign-on to log in to your Buildkite organisation. If there isn't a Buildkite guide for your chosen provider, you can set up SAML using the instructions below.
 
 ## Setting up SAML
 
-- meta data is provided for setting up SAML with any provider
+The Buildkite SAML meta data endpoint contains all the information you need to set up SAML with any provider.
 
-1. Fetch the XML from this URL: https://buildkite.com/user/authorize/saml/metadata
-2. Using the meta data from the XML, set up Buildkite in your SAML provider's service
-    - the Buildkite SSO service accepts the `username` and `admin` fields
-3. Email support@buildkite
+1. Fetch the XML from this URL: <a href="https://buildkite.com/user/authorize/saml/metadata">https://buildkite.com/user/authorize/saml/metadata</a>
+2. Using the meta data from the XML, set up Buildkite in your SAML provider's service. The Buildkite SSO service accepts the `username` and `admin` fields.
+3. Email support@buildkite with the following information:
 
-### What the Buildkite team will do
-1. enable SAML for the specified organisation
-1. get you to test that it's all working
-1. force a logout for all the users in the organisation, so that everyone will log in via your chosen provider next time they access Buildkite.com
+    <dl>
+        <dt>Domain name</dt>
+        <dd>
+          The domain you use with your SAML provider for which you want to enable SSO. This must match one of the emails you have verified with your Buildkite account.
+        </dd>
+        <dt>Organisation slug</dt>
+        <dd>
+          The Buildkite organisation for which you want to enable SSO.  
+        </dd>
+        <dt>SAML 2.0 Endpoint (HTTP)</dt>
+        <dd>
+            The SAML endpoint for your chosen provider.
+        </dd>
+        <dt>x.509 certificate</dt>
+        <dd>
+            The public key certificate for your chosen provider.
+        </dd>
+    </dl>
 
+When we receive your email, the Buildkite team will:
 
+1. Enable SSO for the specified organisation
+1. Reply to your email and get you to test that it's all working
+1. Force a logout for all the users in the organisation, so that everyone will log in via your chosen provider next time they attempt to access that organisation on Buildkite.com

--- a/pages/tutorials/google.md.erb
+++ b/pages/tutorials/google.md.erb
@@ -1,0 +1,16 @@
+# OAuth with Google G Suite
+
+- Teams using Google G Suite can use it to log into Buildkite
+
+## Setting up OAuth
+
+### Pre-requisites
+1. send the buildkite team:
+ - your domain name (this is the domain that your team has in their email addresses, and it must be the same domain that uses google g suite)
+ - the slug of the organisation you want to enable oauth for 
+1. ensure your team members have this email address verified in their buildkite account
+
+### What does Buildkite do
+1. enable oauth for the specified organisation
+1. get you to test that it's all working
+1. force a logout for all the users in the organisation, so that everyone will log in via Google next time they access Buildkite.com

--- a/pages/tutorials/google.md.erb
+++ b/pages/tutorials/google.md.erb
@@ -1,6 +1,6 @@
 # OAuth with Google G Suite
 
-Google's G Suite can be used as single sign-on to log in to your organsiation's Buildkite account. G Suite doesn't proivide group management, as it uses OAuth rather than SAML to perform the login.  
+Google's G Suite can be used as single sign-on to log in to your Buildkite organisation. G Suite doesn't proivide group management, as it uses OAuth rather than SAML to perform the login.  
 
 ## Setting up OAuth
 
@@ -9,20 +9,16 @@ Setting up G Suite to log in to Buildkite is a short process, requiring an email
 ### Email the Buildkite team
 1. Send an email to support@buildkite.com with the following information:
 
-    <table>
-      <tr>
-        <td><code>Domain name</code></td>
-        <td>
+    <dl>
+        <dt>Domain name</dt>
+        <dd>
           The domain you use with Google G Suite for which you want to enable OAuth. This must match one of the emails you have verified with your Buildkite account.
-        </td>
-      </tr>
-      <tr>
-        <td><code>Organisation slug</code></td>
-        <td>
+        </dd>
+        <dt>Organisation slug</dt>
+        <dd>
           The Buildkite organisation for which you want to enable OAuth.  
-        </td>
-      </tr>
-    </table>
+        </dd>
+    </dl>
 
 1. Ensure all members of the specified organisation have an email address with that domain verified in their Buildkite account
 

--- a/pages/tutorials/google.md.erb
+++ b/pages/tutorials/google.md.erb
@@ -1,16 +1,19 @@
 # OAuth with Google G Suite
 
-- Teams using Google G Suite can use it to log into Buildkite
+Google's G Suite can be used as single sign-on to log in to your organsiation's Buildkite account. G Suite doesn't proivide group management, as it uses OAuth rather than SAML to perform the login.  
 
 ## Setting up OAuth
 
-### Pre-requisites
-1. send the buildkite team:
- - your domain name (this is the domain that your team has in their email addresses, and it must be the same domain that uses google g suite)
- - the slug of the organisation you want to enable oauth for 
-1. ensure your team members have this email address verified in their buildkite account
+Setting up G Suite to log in to Buildkite is a short process, requiring an email to the Buildkite team and some testing.
 
-### What does Buildkite do
-1. enable oauth for the specified organisation
-1. get you to test that it's all working
-1. force a logout for all the users in the organisation, so that everyone will log in via Google next time they access Buildkite.com
+### Email the Buildkite team
+1. Send an email to support@buildkite.com with the following information:
+ - Your domain name: this is the domain that you have in your email address, and it must be the same domain that uses Google G Suite
+ - The slug of the organisation for which you want to enable OAuth 
+1. Ensure all members of the specified organisation have an email address with that domain verified in their Buildkite account
+
+When we receive your email, the Buildkite team will:
+
+1. Enable OAuth for the specified organisation
+1. Reply to your email and get you to test that it's all working
+1. Force a logout for all the users in the organisation, so that everyone will log in via Google next time they attempt to access that organisation on Buildkite.com

--- a/pages/tutorials/google.md.erb
+++ b/pages/tutorials/google.md.erb
@@ -4,12 +4,26 @@ Google's G Suite can be used as single sign-on to log in to your organsiation's 
 
 ## Setting up OAuth
 
-Setting up G Suite to log in to Buildkite is a short process, requiring an email to the Buildkite team and some testing.
+Setting up G Suite to log in to Buildkite is a short process, requiring an email to the Buildkite team and testing the new login flow.
 
 ### Email the Buildkite team
 1. Send an email to support@buildkite.com with the following information:
- - Your domain name: this is the domain that you have in your email address, and it must be the same domain that uses Google G Suite
- - The slug of the organisation for which you want to enable OAuth 
+
+    <table>
+      <tr>
+        <td><code>Domain name</code></td>
+        <td>
+          The domain you use with Google G Suite for which you want to enable OAuth. This must match one of the emails you have verified with your Buildkite account.
+        </td>
+      </tr>
+      <tr>
+        <td><code>Organisation slug</code></td>
+        <td>
+          The Buildkite organisation for which you want to enable OAuth.  
+        </td>
+      </tr>
+    </table>
+
 1. Ensure all members of the specified organisation have an email address with that domain verified in their Buildkite account
 
 When we receive your email, the Buildkite team will:

--- a/pages/tutorials/okta.md.erb
+++ b/pages/tutorials/okta.md.erb
@@ -1,0 +1,24 @@
+# SSO with Okta
+
+- Teams using Okta can use it to log into Buildkite
+
+## Setting up SSO
+- sso setup ocurrs on both sides, in the okta and buildkite organisations
+- an organisation admin sets up okta with the buildkite app
+- the buildkite team enables sso for your organisation, with the details you provide
+
+### Setup on the Okta website
+1. go to admin section
+1. select 'add applications' to search the Okta application directory
+1. search for Buildkite
+1. add the Buildkite app to your Okta account
+1. fill out the form, entering your Buildkite organisation slug as the 'organisation id' (this is case sensitive)
+
+- in the Buildkite application in Okta, select the 'Sign on' tab
+- In the sign on 'settings' section, click the 'view setup instructions' button
+- follow the configuration instructions 
+
+### What the Buildkite team will do
+1. enable sso for the specified organisation
+1. get you to test that it's all working
+1. force a logout for all the users in the organisation, so that everyone will log in via Google next time they access Buildkite.com

--- a/pages/tutorials/okta.md.erb
+++ b/pages/tutorials/okta.md.erb
@@ -1,24 +1,25 @@
-# SSO with Okta
+# Single Sign-on with Okta
 
-- Teams using Okta can use it to log into Buildkite
+Okta can be used as single sign-on to log in to your organsiation's Buildkite account.
 
 ## Setting up SSO
-- sso setup ocurrs on both sides, in the okta and buildkite organisations
-- an organisation admin sets up okta with the buildkite app
-- the buildkite team enables sso for your organisation, with the details you provide
-- Okta does provide support for 'groups', and this needs to be set up inside Okta
 
-### Setup on the Okta website
-1. go to admin section
-1. select 'add applications' to search the Okta application directory
-1. search for Buildkite
-1. add the Buildkite app to your Okta account
-1. fill out the form, entering your Buildkite organisation slug as the 'organisation id' (this is case sensitive)
-1. in the Buildkite application in Okta, select the 'Sign on' tab
-1. In the sign on 'settings' section, click the 'view setup instructions' button
-1. follow the configuration instructions 
+The instructions below guide you through adding the Buildkite application to your Okta account. The Buildkite team will enable SSO for your organisation, with the details you provide from the end of the setup process.
 
-### What the Buildkite team will do
-1. enable sso for the specified organisation
-1. get you to test that it's all working
-1. force a logout for all the users in the organisation, so that everyone will log in via Okta next time they access Buildkite.com
+Setting up SSO with Okta requires organisation administrator privileges in both Okta and Buildkite. Okta provides support for 'groups', which can be set up inside your Okta account.
+
+### Setup in your Okta organisation
+1. Click the Admin button in Okta to access your Admin dashboard
+1. In the Shortcuts menu, click 'Add Applications' to search the Okta application directory
+1. Search for 'Buildkite'
+1. Click 'Add' to add the Buildkite app to your Okta account
+1. Fill out the 'General Settings' form, entering your case sentitive Buildkite organisation slug as the 'Organisation ID'
+1. In the Buildkite application in Okta, select the tab labelled 'Sign On'
+1. In the Sign On section 'Settings', click the 'view setup instructions' button
+1. Follow the instructions, copying the provided information into an email to support@buildkite.com
+
+When we receive your email, the Buildkite team will:
+
+1. Enable SSO for the specified organisation
+1. Reply to your email and get you to test that it's all working
+1. Force a logout for all the users in the organisation, so that everyone will log in via Okta next time they attempt to access that organisation on Buildkite.com

--- a/pages/tutorials/okta.md.erb
+++ b/pages/tutorials/okta.md.erb
@@ -1,6 +1,6 @@
 # Single Sign-on with Okta
 
-Okta can be used as single sign-on to log in to your organsiation's Buildkite account.
+Okta can be used as single sign-on to log in to your Buildkite organisation.
 
 ## Setting up SSO
 

--- a/pages/tutorials/okta.md.erb
+++ b/pages/tutorials/okta.md.erb
@@ -6,6 +6,7 @@
 - sso setup ocurrs on both sides, in the okta and buildkite organisations
 - an organisation admin sets up okta with the buildkite app
 - the buildkite team enables sso for your organisation, with the details you provide
+- Okta does provide support for 'groups', and this needs to be set up inside Okta
 
 ### Setup on the Okta website
 1. go to admin section
@@ -13,12 +14,11 @@
 1. search for Buildkite
 1. add the Buildkite app to your Okta account
 1. fill out the form, entering your Buildkite organisation slug as the 'organisation id' (this is case sensitive)
-
-- in the Buildkite application in Okta, select the 'Sign on' tab
-- In the sign on 'settings' section, click the 'view setup instructions' button
-- follow the configuration instructions 
+1. in the Buildkite application in Okta, select the 'Sign on' tab
+1. In the sign on 'settings' section, click the 'view setup instructions' button
+1. follow the configuration instructions 
 
 ### What the Buildkite team will do
 1. enable sso for the specified organisation
 1. get you to test that it's all working
-1. force a logout for all the users in the organisation, so that everyone will log in via Google next time they access Buildkite.com
+1. force a logout for all the users in the organisation, so that everyone will log in via Okta next time they access Buildkite.com

--- a/pages/tutorials/okta.md.erb
+++ b/pages/tutorials/okta.md.erb
@@ -4,11 +4,12 @@ Okta can be used as single sign-on to log in to your organsiation's Buildkite ac
 
 ## Setting up SSO
 
-The instructions below guide you through adding the Buildkite application to your Okta account. The Buildkite team will enable SSO for your organisation, with the details you provide from the end of the setup process.
-
 Setting up SSO with Okta requires organisation administrator privileges in both Okta and Buildkite. Okta provides support for 'groups', which can be set up inside your Okta account.
 
 ### Setup in your Okta organisation
+
+The instructions below guide you through adding the Buildkite application to your Okta account. The Buildkite team will enable SSO for your organisation, with the details you provide from the end of the setup process.
+
 1. Click the Admin button in Okta to access your Admin dashboard
 1. In the Shortcuts menu, click 'Add Applications' to search the Okta application directory
 1. Search for 'Buildkite'

--- a/pages/tutorials/onelogin.md.erb
+++ b/pages/tutorials/onelogin.md.erb
@@ -1,6 +1,6 @@
 # SSO with OneLogin
 
-OneLogin can be used as single sign-on to log in to your organsiation's Buildkite account.
+OneLogin can be used as single sign-on to log in to your Buildkite organisation.
 
 ## Setting up SSO
 
@@ -13,18 +13,35 @@ The instructions below guide you through adding the Buildkite app to your OneLog
 1. Search for 'Buildkite'
 1. Add the Buildkite app to your OneLogin account
 1. Email support@buildkite.com with the following SSO and OneLogin information:
-    + Your domain name
-    + Your Buildkite organisation slug
-    + SAML 2.0 Endpoint (HTTP):
-        + In the 'Company Apps' page of OneLogin, click on the Buildkite app 
-        + Click on the 'SSO' tab at the top of the page
-        + Copy the URL labeled `SAML 2.0 Endpoint (HTTP)`
-        + Paste this URL into your email to Buildkite
-    + x.509 certificate:
-        + Also on the SSO tab of the OneLogin Buildkite app, click the 'View Details' link under the 'X.509 certificate'
-        + Under the section 'X.509 Certificate', select `X.509 PEM` from the dropdown list of file types
-        + Click the 'Download' button
-        + Attach the downloaded certificate to your email to Buildkite
+
+    <dl>
+        <dt>Domain name</dt>
+        <dd>
+          The domain you use with OneLogin for which you want to enable SSO. This must match one of the emails you have verified with your Buildkite account.
+        </dd>
+        <dt>Organisation slug</dt>
+        <dd>
+          The Buildkite organisation for which you want to enable SSO.  
+        </dd>
+        <dt>SAML 2.0 Endpoint (HTTP)</dt>
+        <dd>
+            <ol>
+                <li>In the 'Company Apps' page of OneLogin, click on the Buildkite app</li>
+                <li>Click on the 'SSO' tab at the top of the page</li>
+                <li>Copy the URL labeled `SAML 2.0 Endpoint (HTTP)`</li>
+                <li>Paste this URL into your email to Buildkite</li>
+            </ol>
+        </dd>
+        <dt>x.509 certificate</dt>
+        <dd>
+            <ol>
+                <li>Also on the SSO tab of the OneLogin Buildkite app, click the 'View Details' link under the 'X.509 certificate'</li>
+                <li>Under the section 'X.509 Certificate', select `X.509 PEM` from the dropdown list of file types</li>
+                <li>Click the 'Download' button</li>
+                <li>Attach the downloaded certificate to your email to Buildkite</li>
+            </ol>
+        </dd>
+    </dl>
 
 When we receive your email, the Buildkite team will:
 

--- a/pages/tutorials/onelogin.md.erb
+++ b/pages/tutorials/onelogin.md.erb
@@ -1,34 +1,33 @@
 # SSO with OneLogin
 
-- Teams using OneLogin can use it to log into Buildkite
+OneLogin can be used as single sign-on to log in to your organsiation's Buildkite account.
 
 ## Setting up SSO
-- sso setup ocurrs on both sides, in the OneLogin and buildkite organisations
-- an organisation admin sets up OneLogin with the buildkite app
-- the buildkite team enables sso for your organisation, with the details you provide
+
+Setting up SSO with OneLogin requires organisation administrator privileges in both OneLogin and Buildkite. OneLogin provides support for 'groups', which can be set up inside your OneLogin account.
 
 ### Setup on the OneLogin website
-- in this setup you'll add the Buildkite app to your OneLogin account, and email the OneLogin-specific account details to Buildkite.
+The instructions below guide you through adding the Buildkite app to your OneLogin account, and emailing the OneLogin-specific account details to Buildkite.
 
-1. in the 'apps' tab, select the 'add app' button to search the OneLogin directory
-1. search for Buildkite
-1. add the Buildkite app to your OneLogin account
-1. email support@buildkite with your SSO information:
-- your domain name
-- your Buildkite organisation slug
-- SAML 2.0 Endpoint (HTTP)
-	- click on the Buildkite app in the Company Apps page of OneLogin
-    - click on the SSO tab at the top of the page
-	- copy the URL labeled `SAML 2.0 Endpoint (HTTP)`
-    - paste this URL into the email
-- x.509 certificate
-	- also on the SSO tab, click the 'view details' link under the `x.509 certificate`
-	- under the X.509 Certificate section, select `X.509 PEM` from the dropdown list 
-    - click the download button
-    - attach the downloaded certificate to the email
+1. In the 'Apps' tab of your OneLogin organisation, select the 'Add App' button to search the OneLogin directory
+1. Search for 'Buildkite'
+1. Add the Buildkite app to your OneLogin account
+1. Email support@buildkite.com with the following SSO and OneLogin information:
+    + Your domain name
+    + Your Buildkite organisation slug
+    + SAML 2.0 Endpoint (HTTP):
+        + In the 'Company Apps' page of OneLogin, click on the Buildkite app 
+        + Click on the 'SSO' tab at the top of the page
+        + Copy the URL labeled `SAML 2.0 Endpoint (HTTP)`
+        + Paste this URL into your email to Buildkite
+    + x.509 certificate:
+        + Also on the SSO tab of the OneLogin Buildkite app, click the 'View Details' link under the 'X.509 certificate'
+        + Under the section 'X.509 Certificate', select `X.509 PEM` from the dropdown list of file types
+        + Click the 'Download' button
+        + Attach the downloaded certificate to your email to Buildkite
 
+When we receive your email, the Buildkite team will:
 
-### What the Buildkite team will do
-1. enable sso for the specified organisation
-1. get you to test that it's all working
-1. force a logout for all the users in the organisation, so that everyone will log in via OneLogin next time they access Buildkite.com
+1. Enable SSO for the specified organisation
+1. Reply to your email and get you to test that it's all working
+1. Force a logout for all the users in the organisation, so that everyone will log in via OneLogin next time they attempt to access that organisation on Buildkite.com

--- a/pages/tutorials/onelogin.md.erb
+++ b/pages/tutorials/onelogin.md.erb
@@ -1,0 +1,38 @@
+OneLogin
+========
+- add an app
+- search for buildkite
+- go to the SSO tab
+- send the info to BK support (cert and saml 2.0 endpoint http)
+
+
+# SSO with OneLogin
+
+- Teams using OneLogin can use it to log into Buildkite
+
+## Setting up SSO
+- sso setup ocurrs on both sides, in the OneLogin and buildkite organisations
+- an organisation admin sets up OneLogin with the buildkite app
+- the buildkite team enables sso for your organisation, with the details you provide
+
+### Setup on the OneLogin website
+1. in the 'apps' tab, select the 'add app' button to search the OneLogin directory
+1. search for Buildkite
+1. add the Buildkite app to your OneLogin account
+
+
+1. email support@buildkite with your SSO information:
+- your domain name
+- your Buildkite organisation slug
+- SAML 2.0 Endpoint (HTTP)
+	- click on the SSO tab of the app
+	- copy the URL from the SAML 2.0 Endpoint (HTTP) field
+- x.509 certificate
+	- on the same page, click the 'view details' button under the x.509 certificate
+	- download the certificate and attach it to the email
+
+
+### What the Buildkite team will do
+1. enable sso for the specified organisation
+1. get you to test that it's all working
+1. force a logout for all the users in the organisation, so that everyone will log in via OneLogin next time they access Buildkite.com

--- a/pages/tutorials/onelogin.md.erb
+++ b/pages/tutorials/onelogin.md.erb
@@ -1,11 +1,3 @@
-OneLogin
-========
-- add an app
-- search for buildkite
-- go to the SSO tab
-- send the info to BK support (cert and saml 2.0 endpoint http)
-
-
 # SSO with OneLogin
 
 - Teams using OneLogin can use it to log into Buildkite
@@ -16,20 +8,24 @@ OneLogin
 - the buildkite team enables sso for your organisation, with the details you provide
 
 ### Setup on the OneLogin website
+- in this setup you'll add the Buildkite app to your OneLogin account, and email the OneLogin-specific account details to Buildkite.
+
 1. in the 'apps' tab, select the 'add app' button to search the OneLogin directory
 1. search for Buildkite
 1. add the Buildkite app to your OneLogin account
-
-
 1. email support@buildkite with your SSO information:
 - your domain name
 - your Buildkite organisation slug
 - SAML 2.0 Endpoint (HTTP)
-	- click on the SSO tab of the app
-	- copy the URL from the SAML 2.0 Endpoint (HTTP) field
+	- click on the Buildkite app in the Company Apps page of OneLogin
+    - click on the SSO tab at the top of the page
+	- copy the URL labeled `SAML 2.0 Endpoint (HTTP)`
+    - paste this URL into the email
 - x.509 certificate
-	- on the same page, click the 'view details' button under the x.509 certificate
-	- download the certificate and attach it to the email
+	- also on the SSO tab, click the 'view details' link under the `x.509 certificate`
+	- under the X.509 Certificate section, select `X.509 PEM` from the dropdown list 
+    - click the download button
+    - attach the downloaded certificate to the email
 
 
 ### What the Buildkite team will do


### PR DESCRIPTION
First cut of the SSO Guides! 

I'm specifically looking for feedback on the content: accuracy and readability, and any missing information. Feedback on layout and styling also welcome, especially the AD FS guide! 

In dev, the guides live under 'tutorials':
- google
- okta
- onelogin
- adfs
- custom-saml

Still to come (in a separate PR): Intro to SSO