### PR TITLE
Fix the meta data doc

### DIFF
--- a/pages/builds/build_meta_data.md.erb
+++ b/pages/builds/build_meta_data.md.erb
@@ -6,7 +6,7 @@ In this guide we’ll walk through using the Buildkite Agent’s [meta-data comm
 
 ## Setting data
 
-You can set meta-data via the command line or in a script. Both of these methods use the `buildkite-agent` cli with the `meta-data` command. Meta-data can only be set prior to starting an agent, it cannot be added once an agent is running.
+You can set meta-data via the command line or in a script. Both of these methods use the `buildkite-agent` cli with the `meta-data` command.
 
 To set meta-data in the meta-data store, use the `set` command with a key/value pair:
 


### PR DESCRIPTION
Removing the bit about not being able to add metadata to running agents. 

Do you think anything needs to be added in its place @toolmantim, or is it enough to just not have this misleading bit?