### PR TITLE
Bump OS versions in agent instructions

### DIFF
--- a/pages/agent/v2/ubuntu.md.erb
+++ b/pages/agent/v2/ubuntu.md.erb
@@ -5,7 +5,7 @@
   <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/ubuntu">see the latest version of this document</a>.
 </section>
 
-The Buildkite Agent can be installed on on Ubuntu versions 12.04 and above using our signed apt repository.
+The Buildkite Agent can be installed on on Ubuntu versions 14.04 and above using our signed apt repository.
 
 <%= toc %>
 
@@ -32,7 +32,7 @@ See the [Agent SSH Keys](/docs/agent/v2/ssh-keys) documentation for more details
 You can run as many parallel agents on the one machine as you wish by duplicating the upstart service configuration file, for example:
 
 ```shell
-# For Ubuntu 15.04+ (using systemd)
+# For Ubuntu 15.04 and above (using systemd)
 
 # Disable the default unit
 sudo systemctl stop buildkite-agent && sudo systemctl disable buildkite-agent
@@ -41,8 +41,8 @@ sudo systemctl stop buildkite-agent && sudo systemctl disable buildkite-agent
 sudo cp /lib/systemd/system/buildkite-agent.service /etc/systemd/system/buildkite-agent@.service
 
 # Now, as many times as you like
-sudo systemctl enable buildkite-agent@1 && sudo systemctl start buildkite-agent@1
-sudo systemctl enable buildkite-agent@2 && sudo systemctl start buildkite-agent@2
+sudo systemctl enable --now buildkite-agent@1
+sudo systemctl enable --now buildkite-agent@2
 
 # Follow them all
 sudo journalctl -f -u "buildkite-agent@*"

--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -1,6 +1,6 @@
 # Installing Buildkite Agent on Debian
 
-The Buildkite Agent can be installed on on Debian versions 7.x and 8.x using our signed apt repository.
+The Buildkite Agent can be installed on on Debian versions 7.x and above using our signed apt repository.
 
 <%= toc %>
 
@@ -26,7 +26,7 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 
 You can run as many parallel agents on the one machine as you wish by duplicating the systemd/upstart service configuration file, for example:
 
-### For Debian 8.x (systemd)
+### For Debian 8.x and above (systemd)
 
 ```shell
 # Disable the default unit

--- a/pages/agent/v3/install/_debian.md.erb
+++ b/pages/agent/v3/install/_debian.md.erb
@@ -32,7 +32,7 @@ sudo sed -i "s/xxx/<%= token %>/g" /etc/buildkite-agent/buildkite-agent.cfg
 And then start the agent:
 
 ```shell
-# For Debian 8.x (systemd)
+# For Debian 8.x and above (systemd)
 sudo systemctl enable buildkite-agent && systemctl start buildkite-agent
 
 # For Debian 7.x (using upstart)
@@ -45,7 +45,7 @@ sudo /etc/init.d/buildkite-agent start
 You can view the logs at:
 
 ```shell
-# For Debian 8.x (systemd)
+# For Debian 8.x and above (systemd)
 sudo journalctl -f -u buildkite-agent
 
 # For Debian 7.x (using upstart)

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -1,6 +1,6 @@
 # Installing Buildkite Agent on Ubuntu
 
-The Buildkite Agent can be installed on on Ubuntu versions 12.04 and above using our signed apt repository.
+The Buildkite Agent can be installed on on Ubuntu versions 14.04 and above using our signed apt repository.
 
 <%= toc %>
 
@@ -27,7 +27,7 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 You can run as many parallel agents on the one machine as you wish by duplicating the upstart service configuration file, for example:
 
 ```shell
-# For Ubuntu 15.04+ (using systemd)
+# For Ubuntu 15.04 and above (using systemd)
 
 # Disable the default unit
 sudo systemctl stop buildkite-agent && sudo systemctl disable buildkite-agent
@@ -36,8 +36,8 @@ sudo systemctl stop buildkite-agent && sudo systemctl disable buildkite-agent
 sudo cp /lib/systemd/system/buildkite-agent.service /etc/systemd/system/buildkite-agent@.service
 
 # Now, as many times as you like
-sudo systemctl enable buildkite-agent@1 && sudo systemctl start buildkite-agent@1
-sudo systemctl enable buildkite-agent@2 && sudo systemctl start buildkite-agent@2
+sudo systemctl enable --now buildkite-agent@1
+sudo systemctl enable --now buildkite-agent@2
 
 # Follow them all
 sudo journalctl -f -u "buildkite-agent@*"


### PR DESCRIPTION
Ubuntu 14.04 is LTS and still supported until April 2019, but 12.04 is long gone.

Debian 9.x came out mid last year, so let's say 7.x+