### PR TITLE
Add doc for --tags-from-host from v3.3.0

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -92,6 +92,15 @@ debug=true
     </tr>
 
     <tr>
+      <th><code>tags-from-host</code></th>
+      <td>
+        Include the host's meta-data as tags (`hostname`, `machine-id`, and `os`)
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_HOST</code></p>
+      </td>
+    </tr>
+
+    <tr>
       <th><code>shell</code></th>
       <td>
         The shell command used to interpret build commands, e.g <code>/bin/bash -e -c</code>


### PR DESCRIPTION
This was done via #791 and released in v3.3.0. The PR prose refers to a command-line flag that is wrong :(