### PR TITLE
Alpha-sort agent configuration setting table + add 'required?' column

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -18,14 +18,23 @@ debug=true
 
 ## Configuration Settings
 
+_Required attributes:_
+
 <table>
-  <thead>
-    <tr>
-      <th>setting</th>
-      <th>purpose</th>
-      <th>required?</th>
+  <tbody>
+   <tr>
+      <th><code>token</code></th>
+      <td>
+        The agent registration token from your organization’s Agents page, used only to register new agents
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TOKEN</code></p>
+      </td>
     </tr>
-  </thead>
+  </tbody>
+</table>
+
+_Optional attributes:_
+
+<table>
   <tbody>
     <tr>
       <th><code>bootstrap-script</code></th>
@@ -34,7 +43,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"buildkite-agent bootstrap"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BOOTSTRAP_SCRIPT_PATH</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -44,7 +52,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BUILD_PATH</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -54,7 +61,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DEBUG</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -64,7 +70,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DEBUG_HTTP</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -74,7 +79,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -84,7 +88,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>120</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB_TIMEOUT</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -94,7 +97,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"-fxdq"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_CLEAN_FLAGS</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -104,7 +106,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"-v"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_CLONE_FLAGS</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -114,7 +115,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_HOOKS_PATH</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -124,7 +124,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"%hostname-%n"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NAME</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -134,7 +133,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NO_COLOR</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -144,7 +142,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_COMMAND_EVAL</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -154,7 +151,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NO_LOCAL_HOOKS</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -164,7 +160,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PLUGINS</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -174,7 +169,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PTY</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -184,7 +178,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_SSH_KEYSCAN</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -194,7 +187,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_PLUGINS_PATH</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -204,7 +196,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>null</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_PRIORITY</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -214,7 +205,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"C:\Windows\System32\CMD.exe"</code> on Windows, <code>"/bin/bash"</code> on *nix systems</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_SHELL</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -224,7 +214,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"queue=default"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -234,7 +223,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_EC2</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -244,7 +232,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -254,7 +241,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>10s</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_WAIT_FOR_EC2_TAGS_TIMEOUT</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -264,7 +250,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_GCP</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -274,7 +259,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_HOST</code></p>
       </td>
-      <td>no</td>
     </tr>
 
     <tr>
@@ -284,16 +268,6 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_TIMESTAMP_LINES</code></p>
       </td>
-      <td>no</td>
-    </tr>
-
-    <tr>
-      <th><code>token</code></th>
-      <td>
-        The agent registration token from your organization’s Agents page, used only to register new agents
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TOKEN</code></p>
-      </td>
-      <td>yes</td>
     </tr>
   </tbody>
 </table>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -19,6 +19,13 @@ debug=true
 ## Configuration Settings
 
 <table>
+  <thead>
+    <tr>
+      <th>setting</th>
+      <th>purpose</th>
+      <th>required?</th>
+    </tr>
+  </thead>
   <tbody>
     <tr>
       <th><code>bootstrap-script</code></th>
@@ -27,6 +34,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"buildkite-agent bootstrap"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BOOTSTRAP_SCRIPT_PATH</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -36,6 +44,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BUILD_PATH</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -45,6 +54,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DEBUG</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -54,6 +64,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DEBUG_HTTP</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -63,6 +74,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -72,6 +84,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>120</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB_TIMEOUT</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -81,6 +94,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"-fxdq"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_CLEAN_FLAGS</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -90,6 +104,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"-v"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_CLONE_FLAGS</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -99,6 +114,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_HOOKS_PATH</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -108,6 +124,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"%hostname-%n"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NAME</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -117,6 +134,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NO_COLOR</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -126,6 +144,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_COMMAND_EVAL</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -135,6 +154,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NO_LOCAL_HOOKS</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -144,6 +164,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PLUGINS</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -153,6 +174,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PTY</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -162,6 +184,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_SSH_KEYSCAN</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -171,6 +194,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_PLUGINS_PATH</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -180,6 +204,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>null</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_PRIORITY</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -189,6 +214,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"C:\Windows\System32\CMD.exe"</code> on Windows, <code>"/bin/bash"</code> on *nix systems</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_SHELL</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -198,6 +224,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"queue=default"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -207,6 +234,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_EC2</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -216,6 +244,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -225,6 +254,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>10s</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_WAIT_FOR_EC2_TAGS_TIMEOUT</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -234,6 +264,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_GCP</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -243,6 +274,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_HOST</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -252,6 +284,7 @@ debug=true
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_TIMESTAMP_LINES</code></p>
       </td>
+      <td>no</td>
     </tr>
 
     <tr>
@@ -260,6 +293,7 @@ debug=true
         The agent registration token from your organization’s Agents page, used only to register new agents
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TOKEN</code></p>
       </td>
+      <td>yes</td>
     </tr>
   </tbody>
 </table>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -21,10 +21,83 @@ debug=true
 <table>
   <tbody>
     <tr>
-      <th><code>token</code></th>
+      <th><code>bootstrap-script</code></th>
       <td>
-        The agent registration token from your organization’s Agents page, used only to register new agents
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TOKEN</code></p>
+        Command to invoke the bootstrap process
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>"buildkite-agent bootstrap"</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BOOTSTRAP_SCRIPT_PATH</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>build-path</code></th>
+      <td>
+        Path to where the builds will run from
+        <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BUILD_PATH</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>debug</code></th>
+      <td>
+        Enable debug mode
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DEBUG</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>debug-http</code></th>
+      <td>
+        Log all HTTP request and response bodies
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DEBUG_HTTP</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>disconnect-after-job</code></th>
+      <td>
+        Disconnect after processing a single job
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>disconnect-after-job-timeout</code></th>
+      <td>
+        When `disconnect-after-job` is specified, the number of seconds to wait for a job before shutting down
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>120</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB_TIMEOUT</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>git-clean-flags</code></th>
+      <td>
+        Flags to pass to the <code>git clean</code> command. Prior to 3.0 this defaulted to <code>"-fdq"</code>
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>"-fxdq"</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_CLEAN_FLAGS</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>git-clone-flags</code></th>
+      <td>
+        Flags to pass to the <code>git clone</code> command
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>"-v"</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_CLONE_FLAGS</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>hooks-path</code></th>
+      <td>
+        Directory where the global hook scripts are found
+        <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_HOOKS_PATH</code></p>
       </td>
     </tr>
 
@@ -38,11 +111,83 @@ debug=true
     </tr>
 
     <tr>
+      <th><code>no-color</code></th>
+      <td>
+        Do not show colors in logging
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NO_COLOR</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>no-command-eval</code></th>
+      <td>
+        Do not allow this agent to run arbitrary console commands
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_COMMAND_EVAL</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>no-local-hooks</code></th>
+      <td>
+        Do not execute any local hooks
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NO_LOCAL_HOOKS</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>no-plugins</code></th>
+      <td>
+        Do not load any plugins
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PLUGINS</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>no-pty</code></th>
+      <td>
+        Do not run jobs within a pseudo terminal
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PTY</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>no-ssh-keyscan</code></th>
+      <td>
+        Don't automatically run ssh-keyscan before checkout
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_SSH_KEYSCAN</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>plugins-path</code></th>
+      <td>
+        Directory where the plugins are saved
+        <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_PLUGINS_PATH</code></p>
+      </td>
+    </tr>
+
+    <tr>
       <th><code>priority</code></th>
       <td>
         The priority of the agent (higher priorities are assigned work first, null is assigned last)
         <p class="Docs__api-param-eg"><em>Default:</em> <code>null</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_PRIORITY</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>shell</code></th>
+      <td>
+        The shell command used to interpret build commands, e.g <code>/bin/bash -e -c</code>
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>"C:\Windows\System32\CMD.exe"</code> on Windows, <code>"/bin/bash"</code> on *nix systems</p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_SHELL</code></p>
       </td>
     </tr>
 
@@ -101,141 +246,6 @@ debug=true
     </tr>
 
     <tr>
-      <th><code>shell</code></th>
-      <td>
-        The shell command used to interpret build commands, e.g <code>/bin/bash -e -c</code>
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>"C:\Windows\System32\CMD.exe"</code> on Windows, <code>"/bin/bash"</code> on *nix systems</p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_SHELL</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>git-clean-flags</code></th>
-      <td>
-        Flags to pass to the <code>git clean</code> command. Prior to 3.0 this defaulted to <code>"-fdq"</code>
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>"-fxdq"</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_CLEAN_FLAGS</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>git-clone-flags</code></th>
-      <td>
-        Flags to pass to the <code>git clone</code> command
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>"-v"</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_CLONE_FLAGS</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>bootstrap-script</code></th>
-      <td>
-        Command to invoke the bootstrap process
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>"buildkite-agent bootstrap"</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BOOTSTRAP_SCRIPT_PATH</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>build-path</code></th>
-      <td>
-        Path to where the builds will run from
-        <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BUILD_PATH</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>hooks-path</code></th>
-      <td>
-        Directory where the global hook scripts are found
-        <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_HOOKS_PATH</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>plugins-path</code></th>
-      <td>
-        Directory where the plugins are saved
-        <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_PLUGINS_PATH</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>no-pty</code></th>
-      <td>
-        Do not run jobs within a pseudo terminal
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PTY</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>no-ssh-keyscan</code></th>
-      <td>
-        Don't automatically run ssh-keyscan before checkout
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_SSH_KEYSCAN</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>no-command-eval</code></th>
-      <td>
-        Do not allow this agent to run arbitrary console commands
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_COMMAND_EVAL</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>disconnect-after-job</code></th>
-      <td>
-        Disconnect after processing a single job
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>disconnect-after-job-timeout</code></th>
-      <td>
-        When `disconnect-after-job` is specified, the number of seconds to wait for a job before shutting down
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>120</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB_TIMEOUT</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>debug</code></th>
-      <td>
-        Enable debug mode
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DEBUG</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>debug-http</code></th>
-      <td>
-        Log all HTTP request and response bodies
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DEBUG_HTTP</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>no-color</code></th>
-      <td>
-        Do not show colors in logging
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NO_COLOR</code></p>
-      </td>
-    </tr>
-
-    <tr>
       <th><code>timestamp-lines</code></th>
       <td>
         Prepend timestamps on each line of output
@@ -245,20 +255,10 @@ debug=true
     </tr>
 
     <tr>
-      <th><code>no-plugins</code></th>
+      <th><code>token</code></th>
       <td>
-        Do not load any plugins
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PLUGINS</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>no-local-hooks</code></th>
-      <td>
-        Do not execute any local hooks
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NO_LOCAL_HOOKS</code></p>
+        The agent registration token from your organization’s Agents page, used only to register new agents
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TOKEN</code></p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
I find docs easier to read when sorted. Unfortunately:
* this splits apart the semantic-groupings for things like paths
* this makes token last, but it's required, so I added a column to denote that fact

Suggestion - JS-based table-sorting/filtering thing?