### PR TITLE
Add docs for tags-from-host

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -94,6 +94,15 @@ debug=true
     <tr>
       <th><code>tags-from-host</code></th>
       <td>
+        Include the host's meta-data as tags (hostname, machine-id, and os)
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_HOST</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>tags-from-host</code></th>
+      <td>
         Include the host's meta-data as tags (`hostname`, `machine-id`, and `os`)
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_HOST</code></p>


### PR DESCRIPTION
Done in #791, released inside `v3.3.0`, but PR mentions flag in prose that doesn't match flag in code.