### PR TITLE
Fix agent tag command step link

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -49,7 +49,7 @@ _Optional attributes:_
   <tr>
     <td><code>agents</code></td>
     <td>
-      A map of <a href="/docs/agent/v3/cli-meta-data">meta-data</a> keys to values to <a href="/docs/agent/v3/cli-start#agent-targeting">target specific agents</a> for this step. <br>
+      A map of <a href="/docs/agent/v3/cli-start#setting-tags">agent tag</a> keys to values to <a href="/docs/agent/v3/cli-start#agent-targeting">target specific agents</a> for this step. <br>
       <em>Example:</em> <code>npm: "true"</code>
     </td>
   </tr>


### PR DESCRIPTION
The [command step attributes](https://buildkite.com/docs/pipelines/command-step#command-step-attributes) incorrectly reference the build meta-data docs, instead of the agent tags docs (probably from when agent meta-data was renamed to agent tags). This updates the link and words to point to the new [setting tags](https://buildkite.com/docs/agent/v3/cli-start#setting-tags) doc, and keeps the link to the targeting section as well.