### PR TITLE
Remove beta section of the graphql api doc

### DIFF
--- a/pages/apis/graphql_api.md.erb
+++ b/pages/apis/graphql_api.md.erb
@@ -67,8 +67,3 @@ Further resources for learning more about GraphQL:
 * [graphql.org/learn](http://graphql.org/learn/) — The Learn section of the official GraphQL website
 * [github.com/buildkite/frontend](https://github.com/buildkite/frontend) — Buildkite’s web interface makes extensive use of the GraphQL API
 
-## Beta caveats
-
-Whilst the GraphQL API is in beta, you should note the following caveats:
-
-* GraphQL API tokens do not currently respect their organization scope settings, so we recommend creating a separate API token or user account for performing API requests in production.


### PR DESCRIPTION
Update docs to remove the beta warning in the graphql api, since the beta label has been removed.