### PR TITLE
Fix broken reference to parallel builds

### DIFF
--- a/pages/tutorials/docker_containerized_builds.md.erb
+++ b/pages/tutorials/docker_containerized_builds.md.erb
@@ -89,7 +89,7 @@ There are many configuration options available for the Docker plugin. For the co
 
 If your team has significant Docker experience you might find it worthwhile invoking your own runner scripts rather than using the simpler built-in Docker support.
 
-To do this see the [agent hooks](/docs/agent/v3/hooks) and [parallelizing builds](parallelizing-builds) documentation.
+To do this see the [agent hooks](/docs/agent/v3/hooks) and [parallel builds](parallel-builds) documentation.
 
 ## Adding buildkite-agent to the Docker group
 


### PR DESCRIPTION
The referenced document (if I am not mistaken) is parallel builds.