### PR TITLE
Fix reference to parallel builds tutorial

### DIFF
--- a/pages/tutorials/docker_containerized_builds.md.erb
+++ b/pages/tutorials/docker_containerized_builds.md.erb
@@ -1,6 +1,6 @@
 # Containerized Builds with Docker
 
-The Buildkite Agent ships with built-in support for running your builds in Docker containers. Running your builds with Docker allows each pipeline to define and document its testing environment, greatly simplifying your build servers, and provides build isolation when [parallelizing your build](parallelizing-builds).
+The Buildkite Agent ships with built-in support for running your builds in Docker containers. Running your builds with Docker allows each pipeline to define and document its testing environment, greatly simplifying your build servers, and provides build isolation when [parallelizing your build](parallel-builds).
 
 <%= toc %>
 
@@ -8,9 +8,9 @@ The Buildkite Agent ships with built-in support for running your builds in Docke
 
 To run your steps using Docker, we have two [plugins](/docs/pipelines/plugins): the [Docker Compose plugin](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin), and the [Docker plugin](https://github.com/buildkite-plugins/docker-buildkite-plugin).
 
-The [Docker Compose plugin](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin) supports repositories with `docker-compose.yml` files, projects that use multiple containers or have dependent services, and building docker images inside pipeline steps. 
+The [Docker Compose plugin](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin) supports repositories with `docker-compose.yml` files, projects that use multiple containers or have dependent services, and building docker images inside pipeline steps.
 
-The [Docker plugin](https://github.com/buildkite-plugins/docker-buildkite-plugin) supports single container applications, and involves less setup than the Docker Compose plugin. It doesn't allow the use of `docker-compose.yml` files, and doesn't support advanced operations like building images. 
+The [Docker plugin](https://github.com/buildkite-plugins/docker-buildkite-plugin) supports single container applications, and involves less setup than the Docker Compose plugin. It doesn't allow the use of `docker-compose.yml` files, and doesn't support advanced operations like building images.
 
 ## Creating a Docker Compose configuration file
 
@@ -65,7 +65,7 @@ docker-compose run app test.sh
 
 For more examples and information on using this plugin, have a look at the [Docker Compose Plugin on GitHub](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin).
 
-The Buildkite Agent also has support for running build steps in an existing Docker image. To use the Docker plugin, add the `plugins` attribute to your command step. 
+The Buildkite Agent also has support for running build steps in an existing Docker image. To use the Docker plugin, add the `plugins` attribute to your command step.
 
 In this example, the `yarn` commands will be run inside a Docker container using the `node:8` Docker image:
 


### PR DESCRIPTION
Fix link to parallel builds tutorial page and remove extraneous spaces