### PR TITLE
Mention command step options that can be lists of maps

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -106,7 +106,7 @@ _Optional attributes:_
   <tr>
     <td><code>plugins</code></td>
     <td>
-      A map of <a href="/docs/pipelines/plugins">plugins</a> for this step.<br>
+      A map, or array of maps, <a href="/docs/pipelines/plugins">plugins</a> for this step.<br>
       <em>Example:</em><br>
       <code>docker-compose#v1.0.0:<br>
 &nbsp;&nbsp;run: app</code>


### PR DESCRIPTION
This updates the command step docs to mention the options that take arrays of maps.

Some of the command step map options can be specified as arrays (e.g. plugins). This is especially important if people are digging deep into the syntax to create tools that output JSON.

- [x] Update `plugins`
- [ ] Investigate `env`
- [ ] Investigate `agents`
- [ ] Final updates