### PR TITLE
Update the location of buildkite-agent.cfg for GKE clusters

### DIFF
--- a/pages/agent/v3/gcloud.md.erb
+++ b/pages/agent/v3/gcloud.md.erb
@@ -211,7 +211,7 @@ volumes:
 
 ### Further configuration
 
-To [configure](/docs/agent/v3/configuration) the agent further you can create a [config map](https://kubernetes.io/docs/user-guide/configmap/) and volume mount it over the default agent configuration file in `/buildkite/buildkite-agent.cfg`.
+To [configure](/docs/agent/v3/configuration) the agent further you can create a [config map](https://kubernetes.io/docs/user-guide/configmap/) and volume mount it over the default agent configuration file in `/etc/buildkite-agent/buildkite-agent.cfg`.
 
 To add [agent hooks](/docs/agent/v3/hooks) add another config map and volume mount them into `/buildkite/hooks/`.
 


### PR DESCRIPTION
`buildkite-agent.cfg` is actually located at `/etc/buildkite-agent/buildkite-agent.cfg`, not `/buildkite/buildkite-agent.cfg`.

This took me a pretty fun half-hour of scratching my head to figure out why it wasn't working.