### PR TITLE
Small word updates to the meta-data doc

### DIFF
--- a/pages/agent/v2/cli_meta_data.md.erb
+++ b/pages/agent/v2/cli_meta_data.md.erb
@@ -7,7 +7,7 @@
 
 The Buildkite Agent’s `meta-data` command provides your build pipeline with a powerful key/value data-store that works across build steps and build agents, no matter the machine or network.
 
-For practical examples, check out the [Using Build Meta-data](/docs/pipelines/build-meta-data) page.
+See the [Using Build Meta-data](/docs/pipelines/build-meta-data) guide for a step-by-step example.
 
 <%= toc %>
 

--- a/pages/agent/v3/cli_meta_data.md.erb
+++ b/pages/agent/v3/cli_meta_data.md.erb
@@ -2,7 +2,7 @@
 
 The Buildkite Agent’s `meta-data` command provides your build pipeline with a powerful key/value data-store that works across build steps and build agents, no matter the machine or network.
 
-For practical examples, check out the [Using Build Meta-data](/docs/pipelines/build-meta-data) page.
+See the [Using Build Meta-data](/docs/pipelines/build-meta-data) guide for a step-by-step example.
 
 <%= toc %>
 


### PR DESCRIPTION
I found this small fixup in my git stash, from I-can't-remember-when, and it still seemed like an okay change? It just rewords the "practical examples" because there are still some practical examples on these docs pages.

I'm happy for you to decide if the change is right or wrong @harrietgrace! But thought I'd push it up here before I `rm` it.