### PR TITLE
Clarify only agent name config supports templates

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -120,7 +120,7 @@ _Optional attributes:_
     <tr>
       <th><code>name</code></th>
       <td>
-        The name of the agent
+        The name of the agent. Supports the template variables <code>%homename</code> (the agent machine's host name) and <code>%n</code> (a unique number for the agent).
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"%hostname-%n"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NAME</code></p>
       </td>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -120,7 +120,7 @@ _Optional attributes:_
     <tr>
       <th><code>name</code></th>
       <td>
-        The name of the agent. Supports the template variables <code>%homename</code> (the agent machine's host name) and <code>%n</code> (a unique number for the agent).
+        The name of the agent. Supports the template variables <code>%hostname</code> (the agent machine’s hostname) and <code>%n</code> (a unique number for the agent).
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"%hostname-%n"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NAME</code></p>
       </td>


### PR DESCRIPTION
Someone wanted to know where the documentation was for which agent configuration options support templates. Only `name` does, but it wasn't entirely clear, so this tries to help make that a little more clear.

I struggled a bit with `%n` because the way it works is complicated, so just stuck with "a unique number".