### PR TITLE
Remove SSOProviderGitHubOAuth

### DIFF
--- a/pages/tutorials/sso_setup_with_graphql.md.erb
+++ b/pages/tutorials/sso_setup_with_graphql.md.erb
@@ -231,9 +231,6 @@ query FindProviders {
             googleHostedDomain
             discloseGoogleHostedDomain
           }
-          ... on SSOProviderGitHubOAuth {
-            githubOrganizationName
-          }
         }
       }
     }


### PR DESCRIPTION
This was meant to be removed in #302 — and it's now broken, because the type name has changed