### PR TITLE
HTML available in annotations

### DIFF
--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -1,6 +1,6 @@
 # buildkite-agent annotate
 
-The Buildkite Agent’s `annotate` command allows you to add additional information to Buildkite build pages using Markdown or simple HTML tags. 
+The Buildkite Agent’s `annotate` command allows you to add additional information to Buildkite build pages using CommonMark Markdown. 
 
 <%= image "overview.png", alt: "Screenshot of annotations with test reports" %>
 
@@ -82,7 +82,9 @@ We use CommonMark with GitHub Flavored Markdown extensions to provide consistent
 
 GitHub [kindly provide a guide](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) to this syntax.
 
-Note that we do not support GitHub-style syntax highlighting, task lists, user mentions, or automatic links for references to issues, pull requests or commits.
+Annotations do not support GitHub-style syntax highlighting, task lists, user mentions, or automatic links for references to issues, pull requests or commits.
+
+CommonMark supports HTML inside Markdown blocks, but will revert to Markdown parsing on newlines. For more information about how HTML is parsed and which tags CommonMark supports please refer to the [CommonMark spec](https://spec.commonmark.org).
 
 ## Supported CSS Classes
 

--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -1,6 +1,6 @@
 # buildkite-agent annotate
 
-The Buildkite Agent’s `annotate` command allows you to add additional information to Buildkite build pages using Markdown.
+The Buildkite Agent’s `annotate` command allows you to add additional information to Buildkite build pages using Markdown or simple HTML tags. 
 
 <%= image "overview.png", alt: "Screenshot of annotations with test reports" %>
 


### PR DESCRIPTION
Hey! 

The docs page says that markdown is supported, but most of the examples in the page show HTML. I suspect that the reason HTML is supported is because you can put basic tags into markdown, but maybe it would be good to highlight this to readers? 

Should the supported tags be listed? 