### PR TITLE
Add annotation limit info

### DIFF
--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -70,14 +70,14 @@ Annotations are intended to group messages of the same type. You can add more da
 For example, a 'test-failures' annotation can be created to track failed tests:
 
 ```
-buildkite-agent annotate "Failed tests:" --context test-failures
+buildkite-agent annotate --context test-failures --style "error" "# Failed tests:\n\n"
 ```
 
-Using the `--append` option, the 'test-failures' annotation is updated with each failure as they occur: 
+Using the `--append` option, the 'test-failures' annotation is updated with a failure when it occurs: 
 
 ```
 if test-fails
-  buildkite-agent annotate "Test 6 failed with exit code 1: <error>" --context test-failures --append
+  buildkite-agent annotate --context test-failures --append "* Test 1 failed :sad_face:\n"
 ```
 
 ## Annotation styles

--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -1,6 +1,6 @@
 # buildkite-agent annotate
 
-The Buildkite Agent’s `annotate` command allows you to add additional information to Buildkite build pages using CommonMark Markdown. 
+The Buildkite Agent’s `annotate` command allows you to add additional information to Buildkite build pages using CommonMark Markdown. Up to five annotations can be displayed on each step in your pipeline.
 
 <%= image "overview.png", alt: "Screenshot of annotations with test reports" %>
 

--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -1,12 +1,18 @@
 # buildkite-agent annotate
 
-The Buildkite Agent’s `annotate` command allows you to add additional information to Buildkite build pages using CommonMark Markdown. Up to five annotations can be displayed on each step in your pipeline.
+The Buildkite Agent’s `annotate` command allows you to add additional information to Buildkite build pages using CommonMark Markdown.
 
 <%= image "overview.png", alt: "Screenshot of annotations with test reports" %>
 
 <%= toc %>
 
 ## Creating an annotation
+
+The `buildkite-agent` cli's `annotate` command creates an annotation associated with the current build.
+
+The first five annotations created will be displayed on the build page, however there is no limit to the amount of annotations you can create. All annotations can be retreived using the [GraphQL API](/docs/apis/graphql-api).
+
+Options for the `annotate` command can be found in the `buildkite-agent` cli help: 
 
 ```
 $ buildkite-agent annotate --help
@@ -55,6 +61,23 @@ Options:
    --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
    --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
    --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
+```
+
+## Grouping annotations
+
+Annotations are intended to group messages of the same type. You can add more data to existing annotations by using the `--append` option. 
+
+For example, a 'test-failures' annotation can be created to track failed tests:
+
+```
+buildkite-agent annotate "Failed tests:" --context test-failures
+```
+
+Using the `--append` option, the 'test-failures' annotation is updated with each failure as they occur: 
+
+```
+if test-fails
+  buildkite-agent annotate "Test 6 failed with exit code 1: <error>" --context test-failures --append
 ```
 
 ## Annotation styles

--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -8,7 +8,7 @@ The Buildkite Agent’s `annotate` command allows you to add additional informat
 
 ## Creating an annotation
 
-The `buildkite-agent` cli's `annotate` command creates an annotation associated with the current build.
+The `buildkite-agent annotate` command creates an annotation associated with the current build.
 
 The first five annotations created will be displayed on the build page, however there is no limit to the amount of annotations you can create. All annotations can be retreived using the [GraphQL API](/docs/apis/graphql-api).
 

--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -63,23 +63,6 @@ Options:
    --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
 ```
 
-## Grouping annotations
-
-Annotations are intended to group messages of the same type. You can add more data to existing annotations by using the `--append` option. 
-
-For example, a 'test-failures' annotation can be created to track failed tests:
-
-```
-buildkite-agent annotate --context test-failures --style "error" "# Failed tests:\n\n"
-```
-
-Using the `--append` option, the 'test-failures' annotation is updated with a failure when it occurs: 
-
-```
-if test-fails
-  buildkite-agent annotate --context test-failures --append "* Test 1 failed :sad_face:\n"
-```
-
 ## Annotation styles
 
 You can change the visual style of annotations using the `--style` option.


### PR DESCRIPTION
Adding a note about how many annotations will display in the build for each step. Closes #337.

@eleanorakh I got this info from your support ticket, just wanted you to have a squiz before I merge 😄