### PR TITLE
Add the pull request params to the Builds API docs

### DIFF
--- a/pages/apis/rest_api/builds.md.erb
+++ b/pages/apis/rest_api/builds.md.erb
@@ -96,6 +96,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
     "started_at": "2015-05-09T21:05:59.874Z",
     "finished_at": "2015-05-09T21:05:59.874Z",
     "meta_data": { },
+    "pull_request": { },
     "pipeline": {
       "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
       "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline",
@@ -200,6 +201,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
   "started_at": "2015-05-09T21:05:59.874Z",
   "finished_at": "2015-05-09T21:05:59.874Z",
   "meta_data": { },
+  "pull_request": { },
   "pipeline": {
     "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
     "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline",
@@ -314,6 +316,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
   "started_at": "2015-05-09T21:05:59.874Z",
   "finished_at": "2015-05-09T21:05:59.874Z",
   "meta_data": { },
+  "pull_request": { },
   "pipeline": {
     "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
     "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline",
@@ -355,10 +358,13 @@ Optional [request body properties](/docs/api#request-body-properties):
 <table>
 <tbody>
   <tr><th><code>author</code></th><td>A hash with a <code>"name"</code> and <code>"email"</code> key to show who created this build.<br><em>Default value: the user making the API request</em>.</td></tr>
-  <tr><th><code>env</code></th><td>Environment variables to be made available to the build.<br><em>Default value:</em> <code>{}</code>.</td></tr>
-  <tr><th><code>meta_data</code></th><td>A hash of meta-data to make available to the build.<br><em>Default value:</em> <code>{}</code>.</td></tr>
-  <tr><th><code>ignore_pipeline_branch_filters</code></th><td>Run the build regardless of the pipeline’s branch filtering rules. Step branch filtering rules will still apply.<br><em>Default value:</em> <code>false</code>.</td></tr>
   <tr><th><code>clean_checkout</code></th><td>Force the agent to remove any existing build directory and perform a fresh checkout.<br><em>Default value:</em> <code>false</code>.</td></tr>
+  <tr><th><code>env</code></th><td>Environment variables to be made available to the build.<br><em>Default value:</em> <code>{}</code>.</td></tr>
+  <tr><th><code>ignore_pipeline_branch_filters</code></th><td>Run the build regardless of the pipeline’s branch filtering rules. Step branch filtering rules will still apply.<br><em>Default value:</em> <code>false</code>.</td></tr>
+  <tr><th><code>meta_data</code></th><td>A hash of meta-data to make available to the build.<br><em>Default value:</em> <code>{}</code>.</td></tr>
+  <tr><th><code>pull_request_base_branch</code></th><td>For a pull request build, the base branch of the pull request.<br><em>Example:</em> <code>"master"</code></td></tr>
+  <tr><th><code>pull_request_id</code></th><td>For a pull request build, the pull request number.<br><em>Example:</em> <code>42</code></td></tr>
+  <tr><th><code>pull_request_repository</code></th><td>For a pull request build, the git repository of the pull request.<br><em>Example:</em> <code>"git://github.com/my-org/my-repo.git"</code></td></tr>
   </tbody>
 </table>
 
@@ -445,6 +451,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
   "started_at": "2015-05-09T21:05:59.874Z",
   "finished_at": "2015-05-09T21:05:59.874Z",
   "meta_data": { },
+  "pull_request": { },
   "pipeline": {
     "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
     "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline",
@@ -553,6 +560,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
   "started_at": "2015-05-09T21:05:59.874Z",
   "finished_at": "2015-05-09T21:05:59.874Z",
   "meta_data": { },
+  "pull_request": { },
   "pipeline": {
     "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
     "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline",


### PR DESCRIPTION
Adds the pull request params to the [Create a Build](https://buildkite.com/docs/apis/rest-api/builds#create-a-build) documentation:

<img width="883" alt="image" src="https://user-images.githubusercontent.com/153/49418577-047b0300-f7d7-11e8-9a0c-e7e6180d5f98.png">