### PR TITLE
Update wait docs

### DIFF
--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -32,3 +32,5 @@ If the previous steps failed, the build will be marked as failed only after the 
 ```
 
 In this example, if `command.sh` succeeds, both of the following command steps will be run. If `command.sh` fails, only the first will be run, and the build will then be marked as failed.
+
+The explicit null `~` syntax used in the above example isn't required, but is reccommended as a best practice. It ensures that nothing else is accidentally added to the `wait` before the `continue_on_failure` attribute.

--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -33,4 +33,4 @@ If the previous steps failed, the build will be marked as failed only after the 
 
 In this example, if `command.sh` succeeds, both of the following command steps will be run. If `command.sh` fails, only the first will be run, and the build will then be marked as failed.
 
-The explicit null `~` syntax used in the above example isn't required, but is reccommended as a best practice. It ensures that nothing else is accidentally added to the `wait` before the `continue_on_failure` attribute.
+The explicit null `~` character used in the above example isn't required, but is reccommended as a best practice. It ensures that nothing else is accidentally added to the `wait` before the `continue_on_failure` attribute.


### PR DESCRIPTION
Adds a quick explainer about the `~` in the continue on failure example. Mentions that it's an explicit null character, that it's not required, and that we recommend its use to prevent other things getting in between the wait and the continue lines. 

I'm a little unsure of the wording I've used, do you have any feels about it @toolmantim?

Closes #222 
