### PR TITLE
Clarify empty string is the same as false when skipping

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -126,7 +126,7 @@ _Optional attributes:_
       Note: Skipped steps will be hidden in the pipeline view by default, but can be made visible by toggling the 'Skipped jobs' icon.<br>
       <em>Example:</em> <code>true</code><br>
       <em>Example:</em> <code>false</code><br>
-      <em>Example:</em> <code>"My reason"</code><br>
+      <em>Example:</em> <code>"My reason"</code>
     </td>
   </tr>
   <tr>

--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -122,11 +122,11 @@ _Optional attributes:_
   <tr>
     <td><code>skip</code></td>
     <td>
-      Whether to skip this step or not.<br>
+      Whether to skip this step or not. Passing a string provides a reason for skipping this command. Passing an empty string is equivalent to <code>false</code>.
       Note: Skipped steps will be hidden in the pipeline view by default, but can be made visible by toggling the 'Skipped jobs' icon.<br>
       <em>Example:</em> <code>true</code><br>
       <em>Example:</em> <code>false</code><br>
-      <em>Example:</em> <code>"My reason"</code>
+      <em>Example:</em> <code>"My reason"</code><br>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
Clarifying the use of `""` within the skip command section. Wasn't sure whether to add this as a sentence or as an example case, but I decided it wasn't clear what the example case results in.