### PR TITLE
Link to the buildkite/cli instead of bksr

### DIFF
--- a/pages/pipelines/plugins.md.erb
+++ b/pages/pipelines/plugins.md.erb
@@ -139,7 +139,7 @@ The following are some helpful tools when developing plugins:
 * [JSON Schema Lint] - A tool that allows for validating your JSON schema with YAML.
 * [JSON Schema] - The JSON Schema spec.
 * [Understanding JSON Schema] - A tutorial to help understand how to write JSON Schema.
-* [Buildkite CLI] - A command line tool that can running Buildkite pipeline steps entirely locally.
+* [Buildkite CLI] - A command line tool that can run Buildkite pipeline steps entirely locally.
 
 ## Security and reliability
 

--- a/pages/pipelines/plugins.md.erb
+++ b/pages/pipelines/plugins.md.erb
@@ -139,7 +139,7 @@ The following are some helpful tools when developing plugins:
 * [JSON Schema Lint] - A tool that allows for validating your JSON schema with YAML.
 * [JSON Schema] - The JSON Schema spec.
 * [Understanding JSON Schema] - A tutorial to help understand how to write JSON Schema.
-* [bksr] - A command line tool for running Buildkite pipeline steps locally.
+* [Buildkite CLI] - A command line tool that can running Buildkite pipeline steps entirely locally.
 
 ## Security and reliability
 


### PR DESCRIPTION
[bksr](https://github.com/toolmantim/bksr) has been deprecated in favour of the [Buildkite CLI](https://github.com/buildkite/cli)