### PR TITLE
Remove incorrect info about reconnecting

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -203,7 +203,7 @@ _Optional Attributes_
 
 <div class="Docs__note">
 <p class="Docs__note__heading">-1 Exit Status</p>
-<p>A job will show an exit status of -1 if the connection to the agent is lost. When using <code>automatic: true</code>, Buildkite will try to reconnect to an agent twice before marking the job as failed.</p>
+<p>A job will fail with an exit status of -1 if communication with the agent has been lost (e.g. the agent has been forcefully terminated, or the agent machine was shut down without allowing the agent to disconnect).</p>
 </div>
 
 ```yml


### PR DESCRIPTION
Adding in @toolmantim's suggestion for the exit status note, removing the incorrect info about attempting to reconnect to the agent. 