### PR TITLE
Remove unmaintained NodeJS library

### DIFF
--- a/pages/apis/rest_api.md.erb
+++ b/pages/apis/rest_api.md.erb
@@ -124,5 +124,4 @@ To make getting started easier, check out these clients available from our contr
 
  * [Buildkit](https://github.com/Shopify/buildkit) for [Ruby](https://www.ruby-lang.org)
  * [go-buildkite](https://github.com/buildkite/go-buildkite) for [Go](https://golang.org)
- * [buildkite-node](https://github.com/fraserxu/buildkite-node) for [Node.js](https://nodejs.org)
  * [PSBuildkite](https://github.com/felixfbecker/PSBuildkite) for [PowerShell](https://microsoft.com/powershell)


### PR DESCRIPTION
The most recent commit to the buildkite-node library was [2 years ago](https://github.com/fraserxu/buildkite-node/commits/master) and the package is [not available in NPM](https://www.npmjs.com/search?q=buildkite-node).