### PR TITLE
Minor updates to the graphql sso guide

### DIFF
--- a/pages/tutorials/sso_setup_with_graphql.md.erb
+++ b/pages/tutorials/sso_setup_with_graphql.md.erb
@@ -45,6 +45,8 @@ mutation CreateProvider {
 }
 ```
 
+You'll need the provider's `id` from the output of this mutation in step three. 
+
 ### Step 2
 
 The second step is to use the `url` that was returned above to perform a test login. Open the `url` in a browser, and perform a test login via G Suite.
@@ -78,7 +80,9 @@ You should now see that the provider’s state is enabled.
 
 ### Step 1
 
-The first step in setting up a SAML-based provider is to use the `ssoProviderCreate` mutation to create a new provider in Buildkite and retrieve the details you’ll need for your SSO provider’s system.
+The first step in setting up a SAML-based provider is to use the `ssoProviderCreate` mutation to create a new provider in Buildkite. This mutation will return the details you’ll need for your SSO provider’s system.
+
+The `emailDomainVerificationAddress` requires the same domain as `emailDomain`, and must be one of `admin@`, `administrator@`, `postmaster@`, or `webmaster@`.
 
 ```graphql
 mutation CreateProvider {
@@ -89,6 +93,7 @@ mutation CreateProvider {
     emailDomainVerificationAddress: "admin@myorg.com"
   }) {
     ssoProvider {
+      id
       state
       ... on SSOProviderSAML {
         serviceProvider {
@@ -103,6 +108,8 @@ mutation CreateProvider {
   }
 }
 ```
+
+You'll need the provider's `id` from the output of this mutation in steps three and four. 
 
 ### Step 2
 


### PR DESCRIPTION
@eleanorakh mentioned a few things that could be clarified in our GraphQL SSO guide:

- We don't explain that the provider id is different to the organization id, we just sneakily start using it instead
- We don't explain the constraints we have on the emailDomainVerificationAddress param, and they're pretty strict!

This PR adds:
- Some very basic info about retaining your provider id in step 1 for later use (drawing attention to the different types of ids used in each step)
- The provider ID to the output of the saml provider create mutation (otherwise people don't get this value without running an additional org providers query)
- Info about the verification address, and how it has to match the domain in the previous param, and it must be one of four options for the start of the address