### PR TITLE
Update job event descriptions

### DIFF
--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -13,19 +13,19 @@ You can subscribe to one or more of the following events:
   <tr><th>Event</th><th>Description</th></tr>
 </thead>
 <tbody>
-  <tr><th>ping</th><td>Webhook notification settings have changed</td></tr>
-  <tr><th>build.scheduled</th><td>A build has been scheduled</td></tr>
-  <tr><th>build.running</th><td>A build has started running</td></tr>
-  <tr><th>build.finished</th><td>A build has finished</td></tr>
-  <tr><th>job.scheduled</th><td>A job has been scheduled</td></tr>
-  <tr><th>job.started</th><td>A job has started</td></tr>
-  <tr><th>job.finished</th><td>A job has finished</td></tr>
-  <tr><th>job.activated</th><td>A job has been activated</td></tr>
-  <tr><th>agent.connected</th><td>An agent has connected</td></tr>
-  <tr><th>agent.lost</th><td>An agent has been marked as lost</td></tr>
-  <tr><th>agent.disconnected</th><td>An agent has disconnected</td></tr>
-  <tr><th>agent.stopping</th><td>An agent is stopping</td></tr>
-  <tr><th>agent.stopped</th><td>An agent has stopped</td></tr>
+  <tr><th>ping</th><td><%= webhook_description "ping" %></td></tr>
+  <tr><th>build.scheduled</th><td><%= webhook_description "build.scheduled" %></td></tr>
+  <tr><th>build.running</th><td><%= webhook_description "build.running" %></td></tr>
+  <tr><th>build.finished</th><td><%= webhook_description "build.finished" %></td></tr>
+  <tr><th>job.scheduled</th><td><%= webhook_description "job.scheduled" %></td></tr>
+  <tr><th>job.started</th><td><%= webhook_description "job.started" %></td></tr>
+  <tr><th>job.finished</th><td><%= webhook_description "job.finished" %></td></tr>
+  <tr><th>job.activated</th><td><%= webhook_description "job.activated" %></td></tr>
+  <tr><th>agent.connected</th><td><%= webhook_description "agent.connected" %></td></tr>
+  <tr><th>agent.lost</th><td><%= webhook_description "agent.lost" %></td></tr>
+  <tr><th>agent.disconnected</th><td><%= webhook_description "agent.disconnected" %></td></tr>
+  <tr><th>agent.stopping</th><td><%= webhook_description "agent.stopping" %></td></tr>
+  <tr><th>agent.stopped</th><td><%= webhook_description "agent.stopped" %></td></tr>
 </tbody>
 </table>
 

--- a/pages/apis/webhooks/job_events.md.erb
+++ b/pages/apis/webhooks/job_events.md.erb
@@ -8,15 +8,15 @@
 <tbody>
   <tr>
     <th><code>job.started</code></th>
-    <td><%= webhook_description "job.started" %></td>
+    <td>A command step has been started</td>
   </tr>
   <tr>
     <th><code>job.finished</code></th>
-    <td><%= webhook_description "job.finished" %></td>
+    <td>A job has been finished</td>
   </tr>
   <tr>
     <th><code>job.activated</code></th>
-    <td><%= webhook_description "job.activated" %></td>
+    <td>A block step has been unblocked</td>
   </tr>
 </tbody>
 </table>

--- a/pages/apis/webhooks/job_events.md.erb
+++ b/pages/apis/webhooks/job_events.md.erb
@@ -8,15 +8,15 @@
 <tbody>
   <tr>
     <th><code>job.started</code></th>
-    <td>A command step has been started</td>
+    <td><%= webhook_description "job.started" %></td>
   </tr>
   <tr>
     <th><code>job.finished</code></th>
-    <td>A job has been finished</td>
+    <td><%= webhook_description "job.finished" %></td>
   </tr>
   <tr>
     <th><code>job.activated</code></th>
-    <td>A block step has been unblocked</td>
+    <td><%= webhook_description "job.activated" %></td>
   </tr>
 </tbody>
 </table>


### PR DESCRIPTION
We've been using the descriptions from the main bk app's config yml in here for a while. They don't really describe what's actually going on, and we've had a few people now ask about what the difference is between started and activated. 

I couldn't find if those snippets are used elsewhere in the app, so I decided to just change them in the docs 👍🏻