### PR TITLE
Fix incorrect BUILDKITE_BUILD_ID docs

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -44,7 +44,7 @@ The following environment variables are automatically provided to every job, and
   </tr>
   <tr>
     <th><code>BUILDKITE_BUILD_ID</code></th>
-    <td>The UUID of the build. <p class="Docs__api-param-eg"><em>Example:</em> <code>"4735ba57-80d0-46e2-8fa0-b28223a86586"</code>, or <code>""</code> if not a rebuild.</p></td>
+    <td>The UUID of the build. <p class="Docs__api-param-eg"><em>Example:</em> <code>"4735ba57-80d0-46e2-8fa0-b28223a86586"</code></td>
   </tr>
   <tr>
     <th><code>BUILDKITE_BUILD_NUMBER</code></th>


### PR DESCRIPTION
The docs currently suggest that `BUILDKITE_BUILD_ID` can be blank on rebuilds, surely not?