### PR TITLE
Remove link that no longer exists

### DIFF
--- a/pages/integrations/sso/custom_saml.md.erb
+++ b/pages/integrations/sso/custom_saml.md.erb
@@ -6,7 +6,7 @@ Any identify provider that supports SAML 2.0 can be used to authorize access to 
 
 ## Set up your provider
 
-There are two ways to set up your custom provider: using the Buildkite meta-data XML to your identity provider, or manually adding your Buildkite data into your identity provider. After setting up your provider, you'll need to send the Buildkite team your [application information](#send-your-application-information-to-buildkite).
+There are two ways to set up your custom provider: using the Buildkite meta-data XML to your identity provider, or manually adding your Buildkite data into your identity provider. After setting up your provider, you'll need to send the Buildkite team your application information.
 
 Self-service SSO provisioning in Buildkite is available via our GraphQL explorer. For further information, see the [GraphQL SSO Setup Guide](/docs/integrations/sso/sso-setup-with-graphql). 
 


### PR DESCRIPTION
This section heading got removed when I updated the Custom SAML doc to use the same formatting/structure as the other guides. 