### PR TITLE
Fix broken link on plugins page

### DIFF
--- a/pages/pipelines/plugins.md.erb
+++ b/pages/pipelines/plugins.md.erb
@@ -177,6 +177,6 @@ Agent plugins are still new, and we are evolving them as we learn more. We'd lov
 [JSON Schema]: http://json-schema.org
 [JSON Schema Lint]: https://jsonschemalint.com/
 [Plugin Linter]: https://github.com/buildkite-plugins/buildkite-plugin-linter
-[bksr]: https://github.com/toolmantim/bksr
+[Buildkite CLI]: https://github.com/buildkite/cli
 [Understanding JSON Schema]: https://spacetelescope.github.io/understanding-json-schema/
 [Shellcheck Plugin]: https://github.com/buildkite-plugins/shellcheck-buildkite-plugin


### PR DESCRIPTION
Fixes the broken link that @keithpitt pointed out 🙏🏻

The copy has a link to Buildkite CLI, but in the links at the bottom there was bksr instead. Removed bksr and put in the correct url and link name for Buildkite CLI.   