### PR TITLE
Fix ADFS layout issues

### DIFF
--- a/pages/integrations/sso/adfs.md.erb
+++ b/pages/integrations/sso/adfs.md.erb
@@ -15,10 +15,10 @@ ADFS can be used as an SSO provider for your Buildkite organization. To complete
 
 The instructions below will guide you through using a series of wizards to:
 
-1.1 Add a 'relying party trust'
-1.2 Add an 'issuance transform rule', a type of 'claim rule'
-1.3 Export the token-signing certificate
-1.4 Update the authentication policy
+* Add a 'Relying Party Trust'
+* Add an 'Issuance Transform Rule', a type of 'Claim Rule'
+* Export the Token-signing Certificate
+* Update the Authentication Policy
 
 With these wizards, you'll set up your domain for SSO and retreive the information the Buildkite team requires to complete the setup process.
 
@@ -29,7 +29,7 @@ With these wizards, you'll set up your domain for SSO and retreive the informati
 <p>For a guide written for Windows Server 2012, the <a href="https://www.pagerduty.com/docs/guides/adfs-sso-guide/">Pagerduty SSO integration guide</a> is very similar to Buildkite. Follow the Pagerduty instructions, and subsitute in the Buildkite values from the instructions below.</p>
 </div>
 
-#### Step 1.1 Add a Relying Party Trust
+#### **Step 1.1 Add a Relying Party Trust**
 
 From the `Actions` sidebar, click `Add relying party trust...` to start the wizard
 
@@ -54,7 +54,7 @@ From the `Actions` sidebar, click `Add relying party trust...` to start the wiza
 
 In the `Actions` sidebar, you should now have a subheading `Buildkite`. 
 
-#### Step 1.2 Add an issuance transform rule
+#### **Step 1.2 Add an issuance transform rule**
 
 From the `Buildkite` section of the `Actions` sidebar, click `Edit claim issuance policy...`
 
@@ -100,7 +100,7 @@ Rule 3
 
 For more information on what other attributes Buildkite accepts, see the [SAML User Attributes](/docs/integrations/sso/custom-saml#saml-user-attributes) table in the Custom SAML Guide.
 
-#### Step 1.3 Export the token signing certificate
+#### **Step 1.3 Export the token signing certificate**
 
 From the `Service` section of the `ADFS` console tree, select the `Certificates` subsection
 
@@ -114,7 +114,7 @@ From the `Service` section of the `ADFS` console tree, select the `Certificates`
 8.  Completing the Certificate Export Wizard: check the settings are correct, and click `Finish`
 9.  Exit the `Certificate` dialog
 
-#### Step 1.4 Update the authentication policy
+#### **Step 1.4 Update the authentication policy**
 
 From the `Service` section of the `ADFS` console tree, select the `Authentication Methods` subsection
 


### PR DESCRIPTION
@toolmantim pointed out that the ADFS guide is having some layout issues in https://github.com/buildkite/docs/issues/403.

This PR swaps out the sublist items for regular bullet points:
![image](https://user-images.githubusercontent.com/2074469/52573755-1b635480-2e1b-11e9-8977-a6060cca16f9.png)

It also bolded the subheadings inside Step 1. They're not as bold or large as the H3's, and I've left the H4 #s in there incase we ever do have CSS for those:
![image](https://user-images.githubusercontent.com/2074469/52573842-477ed580-2e1b-11e9-9a6c-74c4ee51e1a2.png)
