### PR TITLE
Update old link

### DIFF
--- a/pages/agent/v3/docker.md.erb
+++ b/pages/agent/v3/docker.md.erb
@@ -25,7 +25,7 @@ docker run -d -t buildkite-agent buildkite/agent:3-ubuntu start --token "<your-a
 
 <section class="Docs__troubleshooting-note">
   <h1>Caveats for builds that need Docker access.</h1>
-  <p>If your build jobs require Docker access, and you’re passing through the Docker socket, you must ensure the build path is consistent between the Docker host and the agent container. See <a href="#invoking-docker-from-within-a-build">Invoking Docker from within a build</a> for more details.</a>.
+  <p>If your build jobs require Docker access, and you’re passing through the Docker socket, you must ensure the build path is consistent between the Docker host and the agent container. See <a href="#allowing-builds-to-use-docker">Allowing builds to use Docker</a> for more details.</a>.
 </section>
 
 ## Version tagging


### PR DESCRIPTION
One of the links in the Docker docs referred to a section that had been renamed in #402, this PR updates the text and URL of the link. Ran the tests locally and they're passing 👍🏻 