### PR TITLE
Update the SNS/Lambda webhooks info

### DIFF
--- a/pages/apis/webhooks/integrations.md.erb
+++ b/pages/apis/webhooks/integrations.md.erb
@@ -6,7 +6,7 @@ There are a number of third party services you can use with Buildkite webhooks. 
 
 ## AWS Lambda
 
-[AWS Lambda](https://aws.amazon.com/lambda/) is an AWS service for running code functions in response to events. [AWS API Gateway](https://aws.amazon.com/api-gateway/) is a service for creating HTTP endpoints for your Lambda functions, and [AWS SNS](https://aws.amazon.com/sns/) is a messaging service which can be used to trigger many Lambda functions from webhook events. These three services can be combined in a variety of ways to integrate webhooks.
+[AWS Lambda](https://aws.amazon.com/lambda/) is an AWS service for running code functions in response to events. [AWS API Gateway](https://aws.amazon.com/api-gateway/) is a service for creating HTTP endpoints for your Lambda functions, and [AWS SNS](https://aws.amazon.com/sns/) is a messaging service which can be used to trigger many Lambda functions from webhook events. These three services can be combined in a variety of ways to consume webhooks.
 
 There are many ways to integrate webhooks with Lambda. The following example repos show two of ways to use Lambda to process SNS messages:
 

--- a/pages/apis/webhooks/integrations.md.erb
+++ b/pages/apis/webhooks/integrations.md.erb
@@ -10,7 +10,7 @@ There are a number of third party services you can use with Buildkite webhooks. 
 
 There are many ways to integrate webhooks with AWS Lambda. The following repositories demonstrate two ways to process Buildkite webhooks using AWS Lambda:
 
-* Rivet's [buildkite-webhook-aws-terraform](https://github.com/rivethealth/buildkite-webhook-aws-terraform) uses API Gateway to publish Buildkite webhook events to SNS
+ * Rivet's [buildkite-webhook-aws-terraform](https://github.com/rivethealth/buildkite-webhook-aws-terraform) uses [AWS Lambda](https://aws.amazon.com/lambda/) and [AWS API Gateway](https://aws.amazon.com/api-gateway/) to publish Buildkite webhook events to an [AWS SNS](https://aws.amazon.com/sns/) topic.
 * Rivet's [buildkite-bitbucket-aws-terraform](https://github.com/rivethealth/buildkite-bitbucket-aws-terraform) demonstrates a more complex setup, using SNS and webhooks to send build statuses to Atlassian Bitbucket Server
 
 ## Google Cloud Functions

--- a/pages/apis/webhooks/integrations.md.erb
+++ b/pages/apis/webhooks/integrations.md.erb
@@ -11,7 +11,7 @@ There are a number of third party services you can use with Buildkite webhooks. 
 There are many ways to integrate webhooks with AWS Lambda. The following repositories demonstrate two ways to process Buildkite webhooks using AWS Lambda:
 
  * Rivet's [buildkite-webhook-aws-terraform](https://github.com/rivethealth/buildkite-webhook-aws-terraform) uses [AWS Lambda](https://aws.amazon.com/lambda/) and [AWS API Gateway](https://aws.amazon.com/api-gateway/) to publish Buildkite webhook events to an [AWS SNS](https://aws.amazon.com/sns/) topic.
-* Rivet's [buildkite-bitbucket-aws-terraform](https://github.com/rivethealth/buildkite-bitbucket-aws-terraform) demonstrates a more complex setup, using SNS and webhooks to send build statuses to Atlassian Bitbucket Server
+ * Rivet's [buildkite-bitbucket-aws-terraform](https://github.com/rivethealth/buildkite-bitbucket-aws-terraform) demonstrates using [AWS Lambda](https://aws.amazon.com/lambda/), [AWS API Gateway](https://aws.amazon.com/api-gateway/) and [AWS SNS](https://aws.amazon.com/sns/) to send build statuses to an Atlassian Bitbucket Server.
 
 ## Google Cloud Functions
 

--- a/pages/apis/webhooks/integrations.md.erb
+++ b/pages/apis/webhooks/integrations.md.erb
@@ -6,7 +6,7 @@ There are a number of third party services you can use with Buildkite webhooks. 
 
 ## AWS Lambda
 
-[AWS Lambda](https://aws.amazon.com/lambda/) is an AWS service for running code functions in response to events. [AWS API Gateway](https://aws.amazon.com/api-gateway/) is a service for creating HTTP endpoints for your Lambda functions, and [AWS SNS](https://aws.amazon.com/sns/) is a messaging service which can be used to trigger many Lambda functions from webhook events. These three services can be combined in a variety of ways to consume webhooks.
+[AWS Lambda](https://aws.amazon.com/lambda/) is a service for running functions, and when combined with [AWS API Gateway](https://aws.amazon.com/api-gateway/), can be used to process your Buildkite webhooks.
 
 There are many ways to integrate webhooks with Lambda. The following example repos show two of ways to use Lambda to process SNS messages:
 

--- a/pages/apis/webhooks/integrations.md.erb
+++ b/pages/apis/webhooks/integrations.md.erb
@@ -4,13 +4,12 @@ There are a number of third party services you can use with Buildkite webhooks. 
 
 <%= toc %>
 
-## AWS SNS with AWS Lambda
+## AWS Lambda
 
-[AWS SNS](https://aws.amazon.com/sns/) is an Amazon pub-sub service providing messaging and mobile notifications. [AWS Lambda](https://aws.amazon.com/lambda/) is an Amazon service for running code functions in response to events like SNS messages or HTTP requests.
+[AWS Lambda](https://aws.amazon.com/lambda/) is an AWS service for running code functions in response to events. [AWS API Gateway](https://aws.amazon.com/api-gateway/) is a service for creating HTTP endpoints for your Lambda functions, and [AWS SNS](https://aws.amazon.com/sns/) is a messaging service which can be used to trigger many Lambda functions from webhook events. These three services can be combined in a variety of ways to integrate webhooks.
 
-There are many ways to integrate webhooks with SNS. The following examples show a variety of ways to use Lambda to process SNS messages:
+There are many ways to integrate webhooks with Lambda. The following example repos show two of ways to use Lambda to process SNS messages:
 
-* AWS's [GitHub webhook guide](https://aws.amazon.com/blogs/compute/dynamic-github-actions-with-aws-lambda/) provides an example of publishing webhook events as SNS topics and then processing them using AWS Lambda
 * Rivet's [buildkite-webhook-aws-terraform](https://github.com/rivethealth/buildkite-webhook-aws-terraform) uses API Gateway to publish Buildkite webhook events to SNS
 * Rivet's [buildkite-bitbucket-aws-terraform](https://github.com/rivethealth/buildkite-bitbucket-aws-terraform) demonstrates a more complex setup, using SNS and webhooks to send build statuses to Atlassian Bitbucket Server
 

--- a/pages/apis/webhooks/integrations.md.erb
+++ b/pages/apis/webhooks/integrations.md.erb
@@ -8,7 +8,7 @@ There are a number of third party services you can use with Buildkite webhooks. 
 
 [AWS Lambda](https://aws.amazon.com/lambda/) is a service for running functions, and when combined with [AWS API Gateway](https://aws.amazon.com/api-gateway/), can be used to process your Buildkite webhooks.
 
-There are many ways to integrate webhooks with Lambda. The following example repos show two of ways to use Lambda to process SNS messages:
+There are many ways to integrate webhooks with AWS Lambda. The following repositories demonstrate two ways to process Buildkite webhooks using AWS Lambda:
 
 * Rivet's [buildkite-webhook-aws-terraform](https://github.com/rivethealth/buildkite-webhook-aws-terraform) uses API Gateway to publish Buildkite webhook events to SNS
 * Rivet's [buildkite-bitbucket-aws-terraform](https://github.com/rivethealth/buildkite-bitbucket-aws-terraform) demonstrates a more complex setup, using SNS and webhooks to send build statuses to Atlassian Bitbucket Server


### PR DESCRIPTION
Removed the outdated link that @ticky reported in #98. Gave it a new title to take the focus off SNS, added in a new intro that @toolmantim came up with that includes a mention of API gateway. 

The updated section looks like this:
![image](https://user-images.githubusercontent.com/2074469/53095412-15592c00-351d-11e9-9a14-b708a56c94c8.png)

Closes #98 