### PR TITLE
Add info about where to add webhooks

### DIFF
--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -2,7 +2,7 @@
 
 Webhooks allow you to monitor and respond to events within your Buildkite organization, providing a real time view of activity and allowing you to extend and integrate Buildkite into your systems.
 
-Webhooks can be added and configured on your organization's Notification Services settings page.
+Webhooks can be added and configured on your [organization's Notification Services settings](https://buildkite.com/organizations/-/services) page.
 
 <%= toc %>
 

--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -2,6 +2,8 @@
 
 Webhooks allow you to monitor and respond to events within your Buildkite organization, providing a real time view of activity and allowing you to extend and integrate Buildkite into your systems.
 
+Webhooks can be added and configured on your organization's Notification Services settings page.
+
 <%= toc %>
 
 ## Events


### PR DESCRIPTION
As mentioned in #292, we currently don't say where to set up your webhooks. This PR adds a note about where to find the webhooks in the org settings. 

@toolmantim do you think it needs more than this? I would have liked to mention the provider-specific guides we have too, but they don't seem to be linked from within the app after you've set up your pipeline? Do they only appear on the initial blank pipeline setup page?

Closes #292 