### PR TITLE
Fix “Disabling an SSO provider” query

### DIFF
--- a/pages/integrations/sso/sso_setup_with_graphql.md.erb
+++ b/pages/integrations/sso/sso_setup_with_graphql.md.erb
@@ -266,6 +266,11 @@ mutation DisableProvider {
   ssoProviderDisable(input:{
     id: "<provider id>",
     disabledReason: "Disabled because..."
-  })
+  }) {
+    ssoProvider {
+      state
+      url
+    }
+  }
 }
 ```


### PR DESCRIPTION
As it stands, the DisableProvider query doesn’t work, because it doesn’t select any of the output of `ssoProviderDisable`.

This was reported by a customer in Slack.