### PR TITLE
Add new 'running agents' page

### DIFF
--- a/pages/agent/v3/running.md.erb
+++ b/pages/agent/v3/running.md.erb
@@ -1,0 +1,25 @@
+# Running Buildkite Agent
+
+- intro
+
+<%= toc %>
+
+## where to run
+	your machine or other physical hardware, cloud services
+	docker or other containers
+
+## running one
+	need an agent token, link to token docs
+	use the buildkite-agent start command, link to start docs
+	choose which config options you'd like, and if you want to do a config file or inline config, if you need env vars etc. link to config docs
+
+## running multiple
+	see each installer guide's example code for running multiple agents 
+	kubernetes (scheduling)
+	elastic stack
+
+## running multiple with different config
+	systemd service templates
+	
+## autoscaling
+	automatically starting and stopping your agents


### PR DESCRIPTION
An outline of an idea for a new page under the Agent/v3 menu item, to possibly go after the Configuration page. 

It will pull together a bunch of info that's presently scattered over several docs - starting, configuring, running multiple, doing scaling etc. It won't be a deep dive on anything that we have docs on already like config, it will have an overview and then link out to those existing sections. It'll also include the info from #141.

Thoughts @toolmantim? Anything else you'd like to see included?