### PR TITLE
Use hkps with the ubuntu keyserver

### DIFF
--- a/pages/agent/v2/debian.md.erb
+++ b/pages/agent/v2/debian.md.erb
@@ -30,7 +30,7 @@ sudo apt-get install -y apt-transport-https dirmngr
 Now you can add our signed apt repository:
 
 ```shell
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
 ```
 

--- a/pages/agent/v2/debian.md.erb
+++ b/pages/agent/v2/debian.md.erb
@@ -30,7 +30,7 @@ sudo apt-get install -y apt-transport-https dirmngr
 Now you can add our signed apt repository:
 
 ```shell
-sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+sudo apt-key adv --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
 ```
 

--- a/pages/agent/v2/ubuntu.md.erb
+++ b/pages/agent/v2/ubuntu.md.erb
@@ -15,7 +15,7 @@ First, add our signed apt repository:
 
 ```shell
 sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
-sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+sudo apt-key adv --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 ```
 
 Then install the agent:

--- a/pages/agent/v2/ubuntu.md.erb
+++ b/pages/agent/v2/ubuntu.md.erb
@@ -15,7 +15,7 @@ First, add our signed apt repository:
 
 ```shell
 sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 ```
 
 Then install the agent:

--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -25,7 +25,7 @@ sudo apt-get install -y apt-transport-https dirmngr
 Now you can add our signed apt repository:
 
 ```shell
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
 ```
 

--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -25,7 +25,7 @@ sudo apt-get install -y apt-transport-https dirmngr
 Now you can add our signed apt repository:
 
 ```shell
-sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+sudo apt-key adv --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
 ```
 

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -10,7 +10,7 @@ First, add our signed apt repository:
 
 ```shell
 sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
-sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+sudo apt-key adv --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 ```
 
 Then install the agent:

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -10,7 +10,7 @@ First, add our signed apt repository:
 
 ```shell
 sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 ```
 
 Then install the agent:


### PR DESCRIPTION
Updating the Ubuntu and Debian instructions for both v2 and v3 to use `hkps://` instead of `hkp://`. 

Closes #328. 
