### PR TITLE
Update keyservers for Debian and Ubuntu again

### DIFF
--- a/pages/agent/v2/debian.md.erb
+++ b/pages/agent/v2/debian.md.erb
@@ -30,8 +30,8 @@ sudo apt-get install -y apt-transport-https dirmngr
 Now you can add our signed apt repository:
 
 ```shell
-sudo apt-key adv --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
-sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
+sudo apt-key adv --keyserver ipv4.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+echo "echo deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
 ```
 
 Then install the agent:

--- a/pages/agent/v2/ubuntu.md.erb
+++ b/pages/agent/v2/ubuntu.md.erb
@@ -14,8 +14,8 @@ The Buildkite Agent can be installed on on Ubuntu versions 14.04 and above using
 First, add our signed apt repository:
 
 ```shell
-sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
-sudo apt-key adv --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+echo "echo deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
+sudo apt-key adv --keyserver ipv4.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 ```
 
 Then install the agent:

--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -25,8 +25,8 @@ sudo apt-get install -y apt-transport-https dirmngr
 Now you can add our signed apt repository:
 
 ```shell
-sudo apt-key adv --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
-sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
+sudo apt-key adv --keyserver ipv4.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+echo "echo deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
 ```
 
 Then install the agent:

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -9,8 +9,8 @@ The Buildkite Agent can be installed on Ubuntu versions 14.04 and above using ou
 First, add our signed apt repository:
 
 ```shell
-sudo sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list'
-sudo apt-key adv --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+echo "echo deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
+sudo apt-key adv --keyserver ipv4.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 ```
 
 Then install the agent:


### PR DESCRIPTION
People using Docker were having issues with the ipv6 keyserver we were recommending. This updates to use the ipv4 sks-keyservers. Also updates the echo line with @lox's suggested replacement. 