### PR TITLE
Add SIGQUIT behavior to docs

### DIFF
--- a/pages/agent/v3.md.erb
+++ b/pages/agent/v3.md.erb
@@ -54,3 +54,5 @@ The agent’s behavior can be customized using hooks, which are just shell scrip
 When a build job is cancelled the agent will send the build job process a `SIGTERM` signal to allow it to gracefully exit. If the process does not exit within 10 seconds it will be forcefully terminated with a `SIGKILL` signal.
 
 The agent will also accept `SIGTERM` directly, and will gracefully exit. After it has processed the current job, it will disconnect and stop accepting jobs. 
+
+Lastly, the agent accepts `SIGQUIT` directly, and will immediately terminate. The agent will immediately report its loss to Buildkite and will fail jobs. 


### PR DESCRIPTION
We found out about the `SIGQUIT` behavior from source code, which we are using to immediately fail and retry jobs when we spin down AWS instances. 

Feel free to make any changes to the wording. 