### PR TITLE
Fix MY_ENV typo

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -524,7 +524,7 @@ For example, if had configured the following environment variables:
   </tbody>
 </table>
 
-In the final job environment, the value of `MY_ENV` would be `"c"`.
+In the final job environment, the value of `MY_ENV1` would be `"c"`.
 
 #### Setting variables in a pipeline.yml
 


### PR DESCRIPTION
In the sentence edited, var name changes to `MY_ENV`, rather than `MY_ENV1` used above.