### PR TITLE
Configure CSP nonce correctly for inline scripts

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,8 +16,8 @@ Rails.application.config.content_security_policy do |policy|
   # policy.report_uri "/csp-violation-report-endpoint"
 end
 
-# If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+# We use nonce for inline scripts
+Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:


### PR DESCRIPTION
We use inline scripts for Matomo tracking, and for the agent selector, but they're currently broken because we don't configure any CSP nonce:

<img width="539" alt="image" src="https://user-images.githubusercontent.com/153/58008503-e0ff0700-7b2f-11e9-9ffc-8fae1cd4dfe3.png">

This fixes the inline scripts by configuring the CSP nonce correctly.

Fixes #473