### PR TITLE
Correct the order of `<pre />` and `<code />` tags in annotation docs

### DIFF
--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -73,7 +73,7 @@ We accept the following parts of version 8.0 of Basscss within annotations:
 
 ### Colored console output
 
-Console output in annotations can be displayed with ANSI colors when processed through [our Terminal tool](http://buildkite.github.io/terminal-to-html/) and wrapped in `<code><pre class="term"></pre></code>` tags before uploading.
+Console output in annotations can be displayed with ANSI colors when processed through [our Terminal tool](http://buildkite.github.io/terminal-to-html/) and wrapped in `<pre class="term"><code></code></pre>` tags before uploading.
 
 <%= image "annotations-terminal-output.png", alt: "Screenshot of colored terminal output in an annotation" %>
 


### PR DESCRIPTION
Turns out our docs had been misleading people somewhat the whole time!

When writing an HTML block in markdown, the wrapping element needs to be a recognised starting html element. `<pre />` qualifies, but `<code />` does not. This means that if someone used our example, the code would come through as processed markdown, causing strange rendering errors.

Fixes buildkite/terminal-to-html#64