### PR TITLE
Add missing "API" to Builds REST API doc

### DIFF
--- a/pages/apis/rest_api/builds.md.erb
+++ b/pages/apis/rest_api/builds.md.erb
@@ -1,4 +1,4 @@
-# Builds
+# Builds API
 
 <%= toc %>
 


### PR DESCRIPTION
Looks like the oldest REST API doc is inconsistent with the rest. This updates the header, so it matches all the other rest docs.