### PR TITLE
Correct the default branch for Trigger steps

### DIFF
--- a/pages/pipelines/trigger_step.md.erb
+++ b/pages/pipelines/trigger_step.md.erb
@@ -84,7 +84,8 @@ _Optional_ `build` _attributes:_
   <tr>
     <td><code>branch</code></td>
     <td>
-      The branch for the build. Default: <code>"master"</code><br>
+      The branch for the build.<br>
+      Default: The triggered pipeline's default branch.<br>
       <em>Example:</em> <code>"production"</code><br>
     </td>
   </tr>


### PR DESCRIPTION
The docs claimed it was "master" but this was only the case if it was unspecified, which is very uncommon, as that in turn defaults to "master"