### PR TITLE
Add note about Bitbucket server to Ignoring Commits

### DIFF
--- a/pages/pipelines/ignoring_a_commit.md.erb
+++ b/pages/pipelines/ignoring_a_commit.md.erb
@@ -18,3 +18,8 @@ Fix readme typos
 
 [skip ci]
 ```
+
+<div class="Docs__troubleshooting-note">
+<h1>Skipping Commits with Bitbucket Server</h1>
+<p>Not all webhooks from Bitbucket Server contain the commit's message. When a commit message is not included in a webhook, the build will run.</p>
+</div>

--- a/pages/pipelines/ignoring_a_commit.md.erb
+++ b/pages/pipelines/ignoring_a_commit.md.erb
@@ -21,5 +21,5 @@ Fix readme typos
 
 <div class="Docs__troubleshooting-note">
 <h1>Skipping Commits with Bitbucket Server</h1>
-<p>Not all webhooks from Bitbucket Server contain the commit's message. When a commit message is not included in a webhook, the build will run.</p>
+<p>Not all webhooks from Bitbucket Server contain the commit message. When a commit message is not included in a webhook, the build will run.</p>
 </div>


### PR DESCRIPTION
As mentioned by @lox in #317, Bitbucket Server doesn't send the commit message with every type of webhook. From the Bitbucket Server docs, it looks like it's just the `refs_changed` webhook that doesn't include the commit message. 

This PR adds a troubleshooting note to the end of the Ignoring Commits doc:

![image](https://user-images.githubusercontent.com/2074469/60068387-e284a600-9751-11e9-9da4-9e90a73fe05a.png)

Closes #317 