### PR TITLE
Fix the SSO heading

### DIFF
--- a/pages/integrations/sso.md.erb
+++ b/pages/integrations/sso.md.erb
@@ -37,9 +37,9 @@ Google and Github both use OAuth rather than SAML. See the [Google G Suite setup
 
 You can also set up OAuth providers with GraphQL, see our [GraphQL SSO guide](/docs/integrations/sso/sso-setup-with-graphql) for steps and code samples.
 
- ### Using Okta, OneLogin, ADFS, or a custom SAML Provider
+### Using Okta, OneLogin, ADFS, or a custom SAML Provider
 
- There are guides available for setting up Buildkite with the following SAML identity providers: [Okta](/docs/integrations/sso/okta), [OneLogin](/docs/integrations/sso/onelogin), [Google Cloud Identity](/docs/integrations/sso/g-cloud-identity), [ADFS](/docs/integrations/sso/adfs), and a general guide for [custom identity providers](/docs/integrations/sso/custom-saml).
+There are guides available for setting up Buildkite with the following SAML identity providers: [Okta](/docs/integrations/sso/okta), [OneLogin](/docs/integrations/sso/onelogin), [Google Cloud Identity](/docs/integrations/sso/g-cloud-identity), [ADFS](/docs/integrations/sso/adfs), and a general guide for [custom identity providers](/docs/integrations/sso/custom-saml).
 
 For more information on the SAML user attributes Buildkite supports, see the [user attributes](/docs/integrations/sso/custom-saml#saml-user-attributes) section of the Custom SAML Guide.
 


### PR DESCRIPTION
Fixes the following bug on https://buildkite.com/docs/integrations/sso:
<img width="664" alt="image" src="https://user-images.githubusercontent.com/153/61347833-bfa56780-a8a1-11e9-9c13-9187ff7111d3.png">