### PR TITLE
Make the detect-clowns plugin example work

### DIFF
--- a/pages/pipelines/plugins.md.erb
+++ b/pages/pipelines/plugins.md.erb
@@ -19,7 +19,7 @@ The simplest plugin is one that accepts no configuration, such as the [Detect Cl
 steps:
   - label: "\:clown_face\:"
     plugins:
-      - detect-clowns#v1.0.0: ~
+      - detect-clowns#v2.0.0: ~
 ```
 
 More commonly, plugins accept various configuration options, as the [Docker plugin] which can be configured to use a Docker image to run your command:


### PR DESCRIPTION
v1 of the detect-clowns plugin required a `command`, so the current example would fail. This updates the example to use v2 of the plugin, which doesn't need the `command`, which makes it work with the example 🤡