### PR TITLE
Mention that step ids now need to be unique

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -92,7 +92,7 @@ _Optional attributes:_
   <tr>
     <td><code>id</code></td>
     <td>
-      A string to identify the step. The value is available in the <code>BUILDKITE_STEP_IDENTIFIER</code> <a href="/docs/pipelines/environment-variables">environment variable</a>.<br>
+      A unique string to identify the step. The value is available in the <code>BUILDKITE_STEP_IDENTIFIER</code> <a href="/docs/pipelines/environment-variables">environment variable</a>.<br>
       <em>Example:</em> <code>"linter"</code>
       <em>Alias:</em> <code>identifier</code>
     </td>


### PR DESCRIPTION
The following pipeline definition now returns a validation error, because the same step id is used twice:

```yml
steps:
  - command: "tests-1.sh"
    id: "tests"
  - command: "tests-2.sh"
    id: "tests"
```

This updates the docs to mention that the `id` must be unique.