### PR TITLE
Update the Artifactory security recommendations

### DIFF
--- a/pages/integrations/artifactory.md.erb
+++ b/pages/integrations/artifactory.md.erb
@@ -37,7 +37,7 @@ _Required environment vars:_
   <tr>
     <td><code>BUILDKITE_ARTIFACTORY_PASSWORD</code></td>
     <td>
-      The password for your Artifactory user<br>
+      The <a href="https://www.jfrog.com/confluence/display/RTF/Updating+Your+Profile#UpdatingYourProfile-APIKey">API Key</a>, <a href="https://www.jfrog.com/confluence/display/ACC/Access+Tokens#AccessTokens-UsingTokens">Access Token</a>, or password for your Artifactory user<br>
       <em>Example:</em> <code>some-password</code><br>
     </td>
   </tr>

--- a/pages/integrations/artifactory.md.erb
+++ b/pages/integrations/artifactory.md.erb
@@ -66,7 +66,7 @@ To help cache and secure your build dependencies, you can use [Artifactory's pac
 For example, to use an [Artifactory NPM registry](https://www.jfrog.com/confluence/display/RTF/npm+Registry?src=sidebar) in your build steps, you can configure the following [Agent environment hook](/docs/agent/v3/hooks) to instruct the [npm command](https://docs.npmjs.com/cli/npm) to use Artifactory instead of npmjs.com:
 
 ```bash
-export NPM_CONFIG_REGISTRY="http://my-artifactory-server/artifactory/api/npm/npm-local/"
+export NPM_CONFIG_REGISTRY="https://${BUILDKITE_ARTIFACTORY_USER}:${BUILDKITE_ARTIFACTORY_PASSWORD}@my-artifactory-server/artifactory/api/npm/npm-local/"
 ```
 
 You can use this same approach for [Ruby gem repositories](https://www.jfrog.com/confluence/display/RTF/RubyGems+Repositories), [Docker registries](https://www.jfrog.com/confluence/display/RTF/Docker+Registry), and any other Artifactory supported package managers.

--- a/pages/integrations/artifactory.md.erb
+++ b/pages/integrations/artifactory.md.erb
@@ -38,7 +38,7 @@ _Required environment vars:_
     <td><code>BUILDKITE_ARTIFACTORY_PASSWORD</code></td>
     <td>
       The <a href="https://www.jfrog.com/confluence/display/RTF/Updating+Your+Profile#UpdatingYourProfile-APIKey">API Key</a>, <a href="https://www.jfrog.com/confluence/display/ACC/Access+Tokens#AccessTokens-UsingTokens">Access Token</a>, or password for your Artifactory user<br>
-      <em>Example:</em> <code>some-password</code><br>
+      <em>Example:</em> <code>AKCp5dKiQ9syTzu9GFhpF3iTzDcFhYAa4...</code><br>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
This updates the Artifactory guide to recommend API keys and access tokens instead of a password. It also fixes the example `NPM_CONFIG_REGISTRY` environment variable to actually work (by using the credentials set up in the previous section)