### PR TITLE
Document the `cancel-grace-period` agent config option

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -53,7 +53,16 @@ _Optional attributes:_
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BUILD_PATH</code></p>
       </td>
     </tr>
-
+    
+    <tr>
+      <th><code>cancel-grace-period</code></th>
+      <td>
+        The number of seconds a canceled or timed out job is given to gracefully terminate and upload its artifacts
+        <p class="Docs__api-param-eg"><em>Default:</em> 10</p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_CANCEL_GRACE_PERIOD</code></p>
+      </td>
+    </tr>
+    
     <tr>
       <th><code>debug</code></th>
       <td>


### PR DESCRIPTION
Adds the agent config option `cancel-grace-period` to the agent configuration docs.

Related: https://github.com/buildkite/agent/pull/1071