### PR TITLE
Add STEP_* env vars

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -90,9 +90,9 @@ _Optional attributes:_
     </td>
   </tr>
   <tr>
-    <td><code>id</code></td>
+    <td><code>key</code></td>
     <td>
-      A unique string to identify the step. The value is available in the <code>BUILDKITE_STEP_IDENTIFIER</code> <a href="/docs/pipelines/environment-variables">environment variable</a>.<br>
+      A unique string to identify the step. The value is available in the <code>BUILDKITE_STEP_KEY</code> <a href="/docs/pipelines/environment-variables">environment variable</a>.<br>
       <em>Example:</em> <code>"linter"</code>
       <em>Alias:</em> <code>identifier</code>
     </td>

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -344,24 +344,6 @@ How many times this job has been retried. The value cannot be modified.
 
 Example: `"0"`
 
-<h3 class="h3-caps">BUILDKITE_SHELL</h3>
-
-The value of the `shell` [agent configuration option](/docs/agent/v3/configuration). The value cannot be modified as an environment variable.
-
-Example: `"/bin/bash -e -c"`
-
-<h3 class="h3-caps">BUILDKITE_SOURCE</h3>
-
-The source of the event that created the build. The value cannot be modified.
-
-Values: `"webhook"`, `"api"`, `"ui"`, `"trigger_job"`, or `"schedule"`
-
-<h3 class="h3-caps">BUILDKITE_SSH_KEYSCAN</h3>
-
-The opposite of the value of the `no-ssh-keyscan` [agent configuration option](/docs/agent/v3/configuration). The value cannot be modified as an environment variable.
-
-Values: `"true"` and `"false"`
-
 <h3 class="h3-caps">BUILDKITE_S3_ACCESS_KEY_ID</h3>
 
 The access key ID for your S3 IAM user, for use with [private S3 buckets](/docs/agent/v3/cli-artifact#using-your-private-aws-s3-bucket). The variable is read by the `buildkite-agent artifact upload` command, and during the artifact upload phase of [command steps](/docs/pipelines/command-step#command-step-attributes). The value can only be set by exporting the environment variable in the `environment`, `pre-checkout` or `pre-command` hooks.
@@ -391,6 +373,24 @@ Default: `"us-east-1"`
 The secret access key for your S3 IAM user, for use with [private S3 buckets](/docs/agent/v3/cli-artifact#using-your-private-aws-s3-bucket). The variable is read by the `buildkite-agent artifact upload` command, as well as during the artifact upload phase of [command steps](/docs/pipelines/command-step#command-step-attributes). The value can only be set by exporting the environment variable in the `environment`, `pre-checkout` or `pre-command` hooks. Do not print or export this variable anywhere except your agent hooks. 
 
 Example: `"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"`
+
+<h3 class="h3-caps">BUILDKITE_SHELL</h3>
+
+The value of the `shell` [agent configuration option](/docs/agent/v3/configuration). The value cannot be modified as an environment variable.
+
+Example: `"/bin/bash -e -c"`
+
+<h3 class="h3-caps">BUILDKITE_SOURCE</h3>
+
+The source of the event that created the build. The value cannot be modified.
+
+Values: `"webhook"`, `"api"`, `"ui"`, `"trigger_job"`, or `"schedule"`
+
+<h3 class="h3-caps">BUILDKITE_SSH_KEYSCAN</h3>
+
+The opposite of the value of the `no-ssh-keyscan` [agent configuration option](/docs/agent/v3/configuration). The value cannot be modified as an environment variable.
+
+Values: `"true"` and `"false"`
 
 <h3 class="h3-caps">BUILDKITE_TAG</h3>
 

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -400,7 +400,7 @@ Example: "080b7d73-986d-4a39-a510-b34f9faf4710"
 
 <h3 class="h3-caps">BUILDKITE_STEP_KEY</h3>
 
-A unique string set by the user to identify a step. This value cannot be modified as an environment variable. 
+The value of the `key` [command step option](/docs/pipelines/command-step#command-step-attributes), a unique string set by you to identify a step. This value cannot be modified as an environment variable. 
 
 Example: "tests-06"
 

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -392,6 +392,18 @@ The opposite of the value of the `no-ssh-keyscan` [agent configuration option](/
 
 Values: `"true"` and `"false"`
 
+<h3 class="h3-caps">BUILDKITE_STEP_ID</h3>
+
+A unique string that identifies a step. This value cannot be modified.
+
+Example: "080b7d73-986d-4a39-a510-b34f9faf4710"
+
+<h3 class="h3-caps">BUILDKITE_STEP_KEY</h3>
+
+A unique string set by the user to identify a step. This value cannot be modified as an environment variable. 
+
+Example: "tests-06"
+
 <h3 class="h3-caps">BUILDKITE_TAG</h3>
 
 The name of the tag being built, if this build was triggered from a tag. The value cannot be modified.
@@ -461,6 +473,10 @@ The following environment variables have been deprecated.
   <tr>
     <th><code>BUILDKITE_SCRIPT_PATH</code></th>
     <td>This has been renamed to `BUILDKITE_COMMAND`</td>
+  </tr>
+  <tr>
+    <th><code>BUILDKITE_STEP_IDENTIFIER</code></th>
+    <td>This has been renamed to `BUILDKITE_STEP_KEY`</td>
   </tr>
 </tbody>
 </table>

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -400,7 +400,7 @@ Example: "080b7d73-986d-4a39-a510-b34f9faf4710"
 
 <h3 class="h3-caps">BUILDKITE_STEP_KEY</h3>
 
-The value of the `key` [command step option](/docs/pipelines/command-step#command-step-attributes), a unique string set by you to identify a step. This value cannot be modified as an environment variable. 
+The value of the `key` [command step attribute](/docs/pipelines/command-step#command-step-attributes), a unique string set by you to identify a step. This value cannot be modified as an environment variable. 
 
 Example: "tests-06"
 

--- a/pages/pipelines/secrets.md.erb
+++ b/pages/pipelines/secrets.md.erb
@@ -42,7 +42,7 @@ To set up the `GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN` secret for the step, you w
 set -euo pipefail
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "my-app" ]]; then
-  if [[ "$BUILDKITE_STEP_IDENTIFIER" == "trigger-github-deploy" ]]; then
+  if [[ "$BUILDKITE_STEP_KEY" == "trigger-github-deploy" ]]; then
     export GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN="bd0fa963610b..."
   fi
 fi
@@ -62,7 +62,7 @@ For example, to expose a `GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN` environment var
 #!/bin/bash
 set -euo pipefail
 
-if [[ "$BUILDKITE_STEP_IDENTIFIER" == "trigger-github-deploy" ]]; then
+if [[ "$BUILDKITE_STEP_KEY" == "trigger-github-deploy" ]]; then
   export GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN="bd0fa963610b..."
 fi
 ```


### PR DESCRIPTION
Env vars page update for https://github.com/buildkite/buildkite/pull/4063:

- deprecates the `BUILDKITE_STEP_IDENTIFIER` var
- adds the `BUILDKITE_STEP_ID` and `BUILDKITE_STEP_KEY` vars to the main list

Also snuck in a little alphabetise of the vars list - the S3 vars were at the end of the S's when they should have been at the start. 

@toolmantim do those descriptions of the new STEP_* vars look legit?