### PR TITLE
Update branch pattern negation and info

### DIFF
--- a/pages/pipelines/branch_configuration.md.erb
+++ b/pages/pipelines/branch_configuration.md.erb
@@ -52,11 +52,14 @@ You can add branch filters to steps created in Buildkite, as well as to steps in
 
 ## Branch pattern examples
 
-The following are examples of patterns, and what branches they would match:
+When you define a value in the `branch` attribute of a step, only builds on the specified branch/es will contain that step. Adding more values to the `branch` attribute will expand the set of branches that will include that step.
+
+The following are examples of patterns, and the branches that they will match:
 
 * `master production` will match master and production only
 * `master features/*` will match master and any branch that starts with `features/`
 * `*/release-123` will match any branch that ends with `/release-123` such as `feature-123/release-123`
 * `v*.0` will match branch that begins with a `v` and ends with a `.0`, such as `v1.0`
 * `v*.*.*` will match branch that begins with a `v` and has two periods, such as `v1.2.3`
-* `!production` will match any branch that's not `production` (this value should be quoted if defined in a YAML file and uploaded via `buildkite-agent pipeline upload`)
+* `!production` will match any branch that's not `production`
+* `staging !production development` will match staging and development only 


### PR DESCRIPTION
There have been two issues this year requesting clarification on how branch patterns work with negation: #241 and #514. Looks like our docs on this were definitely due a little update!

This PR adds a quick intro paragraph to the branch patterns section that describes a bit more about how the attribute works. There's also an extra example including negation that includes it with some non-negative branches. 

Closes #241 and closes #514 