### PR TITLE
Add section on cloning pipeline steps

### DIFF
--- a/pages/pipelines/defining_steps.md.erb
+++ b/pages/pipelines/defining_steps.md.erb
@@ -202,6 +202,18 @@ Your steps should then look something like this:
 
 <%= image "pipeline-upload-migrate-existing-steps.png", width: 998/2, height: 940/2, alt: "Screenshot of the above described pipeline upload command, before some existing steps" %>
 
+## Cloning a pipeline
+
+When creating a new pipeline, you can take a shortcut if you want to set up the new pipeline with the same steps as an existing pipeline.
+
+Using the `?clone` URL parameter, you can prefill the new pipeline page with the steps from another pipeline. It will not copy any other fields such as environment variables or repository information. 
+
+The below example URL will copy the steps from the 'My Llamas Pipeline' into the New Pipeline page: 
+
+```
+https://buildkite.com/organizations/acme-inc/pipelines/new?clone=my-llamas-pipeline
+```
+
 ## Further documentation
 
 You can also upload pipelines from the command line using the `buildkite-agent` command line tool. See the [buildkite-agent pipeline documentation](/docs/agent/v3/cli-pipeline) for a full list of the available parameters.


### PR DESCRIPTION
Adds a section explaining how to use the `?clone` URL param to copy a pipeline's steps into a new pipeline. 

Does that all sound legit @lox?

Closes #439 