### PR TITLE
Add JIT provisioning to FAQ

### DIFF
--- a/pages/integrations/sso.md.erb
+++ b/pages/integrations/sso.md.erb
@@ -44,6 +44,9 @@ If you have disabled all your SSO providers, users will be required to log in us
 ### Can some people in the organization use SSO and others not?
 Yes, team maintainers can select whether a user is 'required' to use SSO or whether it is 'optional'. This setting can be found in the team settings.
 
+### Do you support JIT provisioning?
+Yes, we do.
+
 ### What happens if a person leaves our company?
 You will need to manually remove them from your Buildkite organization. This will not affect access to the user's personal account or any other organizations they are a member of.
 


### PR DESCRIPTION
As @toolmantim pointed out in #451, we don't mention JIT provisioning anywhere in our SSO docs, even though it's a thing we have always supported.

This PR adds a (very) brief FAQ containing those keywords:
![image](https://user-images.githubusercontent.com/2074469/64173828-09e1a880-ce50-11e9-906c-90a04b348ef7.png)

Closes #451 