### PR TITLE
Fix old reference to a step "id"

### DIFF
--- a/pages/pipelines/secrets.md.erb
+++ b/pages/pipelines/secrets.md.erb
@@ -19,7 +19,7 @@ For example, say you had the following deploy [command step](/docs/pipelines/com
 ```yml
 steps:
   - command: scripts/trigger-github-deploy
-    id: trigger-github-deploy
+    key: trigger-github-deploy
 ```
 
 This step runs the `scripts/trigger-github-deploy` script from the repository, and creates a GitHub Deployment using a [GitHub personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line). The script has the following source code:


### PR DESCRIPTION
A quick update to #519 which catches a missing step `id` property