### PR TITLE
Add launchctl gui troubleshooting note

### DIFF
--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -72,6 +72,11 @@ launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist
 tail -f ~/.buildkite-agent/log/buildkite-agent.log
 ```
 
+<section class="Docs__troubleshooting-note">
+  <p>launchctl fails with "Could not find domain for"</p>
+  <p>Ensure that you're logged in to the GUI, then rerun `launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist`.</p>
+</section>
+
 ## Upgrading
 
 If you installed the agent using Homebrew you can use the standard brew upgrade command to update the agent:

--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -73,8 +73,8 @@ tail -f ~/.buildkite-agent/log/buildkite-agent.log
 ```
 
 <section class="Docs__troubleshooting-note">
-  <p>launchctl fails with "Could not find domain for"</p>
-  <p>Ensure that you're logged in to the GUI, then rerun `launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist`.</p>
+  <h1>Troubleshooting: <code>launchctl</code> fails with "Could not find domain for"</h1>
+  <p>Ensure that you're logged in to the <code>launchctl</code> GUI, then re-run:<br><code>launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist`</code></p>
 </section>
 
 ## Upgrading

--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -74,7 +74,7 @@ tail -f ~/.buildkite-agent/log/buildkite-agent.log
 
 <section class="Docs__troubleshooting-note">
   <h1>Troubleshooting: <code>launchctl</code> fails with "Could not find domain for"</h1>
-  <p>Ensure that you're logged in to the <code>launchctl</code> GUI, then re-run:<br><code>launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist</code></p>
+  <p>Ensure that you have a user logged in to the macOS host, then re-run:<br><code>launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist</code></p>
 </section>
 
 ## Upgrading

--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -74,7 +74,7 @@ tail -f ~/.buildkite-agent/log/buildkite-agent.log
 
 <section class="Docs__troubleshooting-note">
   <h1>Troubleshooting: <code>launchctl</code> fails with "Could not find domain for"</h1>
-  <p>Ensure that you're logged in to the <code>launchctl</code> GUI, then re-run:<br><code>launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist`</code></p>
+  <p>Ensure that you're logged in to the <code>launchctl</code> GUI, then re-run:<br><code>launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist</code></p>
 </section>
 
 ## Upgrading


### PR DESCRIPTION
As discovered in https://github.com/buildkite/docs/issues/353, when you're using launchctl to start your Agents on macos, you can run into issues if you're not logged in to the launchctl GUI. 

This PR adds a troubleshooting note to the 'Starting on Login' section of the macos Agent page, including the text of the resulting error:

![image](https://user-images.githubusercontent.com/2074469/65164166-49091f80-da34-11e9-89b1-1d5b8cd9a611.png)

@lox does the content of the note make sense? Do we need any further steps other than just being logged in and restarting?

Closes #353 