### PR TITLE
Update agent config options

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -100,6 +100,24 @@ _Optional attributes:_
     </tr>
 
     <tr>
+      <th><code>endpoint</code></th>
+      <td>
+        The Agent endpoint.
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>"https://agent.buildkite.com/v3"</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_ENDPOINT</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>experiment</code></th>
+      <td>
+        A list of the experimental agent features to enable.
+        <p class="Docs__api-param-eg"><em>Example:</em> <code>"experiment1,experiment2"</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_EXPERIMENT</code></p>
+      </td>
+    </tr>
+
+    <tr>
       <th><code>git-clean-flags</code></th>
       <td>
         Flags to pass to the <code>git clean</code> command. Prior to 3.0 this defaulted to <code>"-fdq"</code>
@@ -118,11 +136,74 @@ _Optional attributes:_
     </tr>
 
     <tr>
+      <th><code>git-clone-mirror-flags</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>git-fetch-flags</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>git-mirrors-lock-timeout</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>git-mirrors-path</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+      </td>
+    </tr>
+
+    <tr>
       <th><code>hooks-path</code></th>
       <td>
         Directory where the global hook scripts are found
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_HOOKS_PATH</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>log-format</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>metrics-datadog</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>metrics-datadog-host</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
       </td>
     </tr>
 
@@ -154,6 +235,24 @@ _Optional attributes:_
     </tr>
 
     <tr>
+      <th><code>no-git-submodules</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>no-http2</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+      </td>
+    </tr>
+
+    <tr>
       <th><code>no-local-hooks</code></th>
       <td>
         Do not execute any local hooks
@@ -168,6 +267,15 @@ _Optional attributes:_
         Do not load any plugins
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PLUGINS</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>no-plugin-validation</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
       </td>
     </tr>
 
@@ -217,6 +325,15 @@ _Optional attributes:_
     </tr>
 
     <tr>
+      <th><code>spawn</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+      </td>
+    </tr>
+
+    <tr>
       <th><code>tags</code></th>
       <td>
         Tags for the agent
@@ -262,6 +379,15 @@ _Optional attributes:_
     </tr>
 
     <tr>
+      <th><code>tags-from-gcp-labels</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+      </td>
+    </tr>
+
+    <tr>
       <th><code>tags-from-host</code></th>
       <td>
         Include the host's meta-data as tags (hostname, machine-id, and os)
@@ -276,6 +402,15 @@ _Optional attributes:_
         Prepend timestamps on each line of output
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_TIMESTAMP_LINES</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>wait-for-gcp-labels-timeout</code></th>
+      <td>
+        
+        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
       </td>
     </tr>
   </tbody>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -25,7 +25,7 @@ _Required attributes:_
    <tr>
       <th><code>token</code></th>
       <td>
-        The agent registration token from your organization’s Agents page, used only to register new agents
+        The agent registration token from your organization’s Agents page, used only to register new agents.
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TOKEN</code></p>
       </td>
     </tr>
@@ -39,7 +39,7 @@ _Optional attributes:_
     <tr>
       <th><code>bootstrap-script</code></th>
       <td>
-        Command to invoke the bootstrap process
+        Command to invoke the bootstrap process.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"buildkite-agent bootstrap"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BOOTSTRAP_SCRIPT_PATH</code></p>
       </td>
@@ -48,7 +48,7 @@ _Optional attributes:_
     <tr>
       <th><code>build-path</code></th>
       <td>
-        Path to where the builds will run from
+        Path to where the builds will run from.
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BUILD_PATH</code></p>
       </td>
@@ -57,7 +57,7 @@ _Optional attributes:_
     <tr>
       <th><code>cancel-grace-period</code></th>
       <td>
-        The number of seconds a canceled or timed out job is given to gracefully terminate and upload its artifacts
+        The number of seconds a canceled or timed out job is given to gracefully terminate and upload its artifacts.
         <p class="Docs__api-param-eg"><em>Default:</em> 10</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_CANCEL_GRACE_PERIOD</code></p>
       </td>
@@ -66,7 +66,7 @@ _Optional attributes:_
     <tr>
       <th><code>cancel-signal</code></th>
       <td>
-        The signal to use for cancellation
+        The signal to use for cancellation.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>SIGTERM</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_CANCEL_SIGNAL</code></p>
       </td>
@@ -75,7 +75,7 @@ _Optional attributes:_
     <tr>
       <th><code>debug</code></th>
       <td>
-        Enable debug mode
+        Enable debug mode.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DEBUG</code></p>
       </td>
@@ -84,7 +84,7 @@ _Optional attributes:_
     <tr>
       <th><code>debug-http</code></th>
       <td>
-        Log all HTTP request and response bodies
+        Log all HTTP request and response bodies.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DEBUG_HTTP</code></p>
       </td>
@@ -93,7 +93,7 @@ _Optional attributes:_
     <tr>
       <th><code>disconnect-after-job</code></th>
       <td>
-        Disconnect after processing a single job
+        Disconnect after processing a single job.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB</code></p>
       </td>
@@ -120,7 +120,7 @@ _Optional attributes:_
     <tr>
       <th><code>git-clean-flags</code></th>
       <td>
-        Flags to pass to the <code>git clean</code> command. Prior to 3.0 this defaulted to <code>"-fdq"</code>
+        Flags to pass to the <code>git clean</code> command. Prior to 3.0 this defaulted to <code>"-fdq"</code>.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"-fxdq"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_CLEAN_FLAGS</code></p>
       </td>
@@ -129,7 +129,7 @@ _Optional attributes:_
     <tr>
       <th><code>git-clone-flags</code></th>
       <td>
-        Flags to pass to the <code>git clone</code> command
+        Flags to pass to the <code>git clone</code> command.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"-v"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_CLONE_FLAGS</code></p>
       </td>
@@ -148,7 +148,7 @@ _Optional attributes:_
     <tr>
       <th><code>git-fetch-flags</code></th>
       <td>
-        Flags to pass to the <code>git fetch</code> command
+        Flags to pass to the <code>git fetch</code> command.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"-v --prune"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_FETCH_FLAGS</code></p>
       </td>
@@ -177,7 +177,7 @@ _Optional attributes:_
     <tr>
       <th><code>hooks-path</code></th>
       <td>
-        Directory where the global hook scripts are found
+        Directory where the global hook scripts are found.
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_HOOKS_PATH</code></p>
       </td>
@@ -186,7 +186,7 @@ _Optional attributes:_
     <tr>
       <th><code>log-format</code></th>
       <td>
-        The format to use for the logger output
+        The format to use for the logger output.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>text</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_LOG_FORMAT</code></p>
       </td>
@@ -195,7 +195,7 @@ _Optional attributes:_
     <tr>
       <th><code>metrics-datadog</code></th>
       <td>
-        Send metrics to DogStatsD for Datadog
+        Send metrics to DogStatsD for Datadog.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_METRICS_DATADOG</code></p>
       </td>
@@ -204,7 +204,7 @@ _Optional attributes:_
     <tr>
       <th><code>metrics-datadog-host</code></th>
       <td>
-        The DogStatsD instance to send metrics to via udp
+        The DogStatsD instance to send metrics to via udp.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>127.0.0.1:8125</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_METRICS_DATADOG_HOST</code></p>
       </td>
@@ -222,7 +222,7 @@ _Optional attributes:_
     <tr>
       <th><code>no-color</code></th>
       <td>
-        Do not show colors in logging
+        Do not show colors in logging.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NO_COLOR</code></p>
       </td>
@@ -231,7 +231,7 @@ _Optional attributes:_
     <tr>
       <th><code>no-command-eval</code></th>
       <td>
-        Do not allow this agent to run arbitrary console commands
+        Do not allow this agent to run arbitrary console commands.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_COMMAND_EVAL</code></p>
       </td>
@@ -240,7 +240,7 @@ _Optional attributes:_
     <tr>
       <th><code>no-git-submodules</code></th>
       <td>
-        Do not automatically checkout git submodules
+        Do not automatically checkout git submodules.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_GIT_SUBMODULES, BUILDKITE_DISABLE_GIT_SUBMODULES</code></p>
       </td>
@@ -258,7 +258,7 @@ _Optional attributes:_
     <tr>
       <th><code>no-local-hooks</code></th>
       <td>
-        Do not execute any local hooks
+        Do not execute any local hooks.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_NO_LOCAL_HOOKS</code></p>
       </td>
@@ -267,7 +267,7 @@ _Optional attributes:_
     <tr>
       <th><code>no-plugins</code></th>
       <td>
-        Do not load any plugins
+        Do not load any plugins.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PLUGINS</code></p>
       </td>
@@ -276,7 +276,7 @@ _Optional attributes:_
     <tr>
       <th><code>no-plugin-validation</code></th>
       <td>
-        Do not validate plugin configuration and requirements
+        Do not validate plugin configuration and requirements.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PLUGIN_VALIDATION</code></p>
       </td>
@@ -285,7 +285,7 @@ _Optional attributes:_
     <tr>
       <th><code>no-pty</code></th>
       <td>
-        Do not run jobs within a pseudo terminal
+        Do not run jobs within a pseudo terminal.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PTY</code></p>
       </td>
@@ -294,7 +294,7 @@ _Optional attributes:_
     <tr>
       <th><code>no-ssh-keyscan</code></th>
       <td>
-        Do not automatically run ssh-keyscan before checkout
+        Do not automatically run ssh-keyscan before checkout.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_SSH_KEYSCAN</code></p>
       </td>
@@ -303,7 +303,7 @@ _Optional attributes:_
     <tr>
       <th><code>plugins-path</code></th>
       <td>
-        Directory where the plugins are saved
+        Directory where the plugins are saved.
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_PLUGINS_PATH</code></p>
       </td>
@@ -312,7 +312,7 @@ _Optional attributes:_
     <tr>
       <th><code>priority</code></th>
       <td>
-        The priority of the agent (higher priorities are assigned work first, null is assigned last)
+        The priority of the agent. Higher priorities are assigned work first, null is assigned last.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>null</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_PRIORITY</code></p>
       </td>
@@ -321,7 +321,7 @@ _Optional attributes:_
     <tr>
       <th><code>shell</code></th>
       <td>
-        The shell command used to interpret build commands, e.g <code>/bin/bash -e -c</code>
+        The shell command used to interpret build commands. E.g <code>/bin/bash -e -c</code>.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"C:\Windows\System32\CMD.exe"</code> on Windows, <code>"/bin/bash"</code> on *nix systems</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_SHELL</code></p>
       </td>
@@ -330,7 +330,7 @@ _Optional attributes:_
     <tr>
       <th><code>spawn</code></th>
       <td>
-        The number of agents to spawn in parallel
+        The number of agents to spawn in parallel.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>1</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_SPAWN</code></p>
       </td>
@@ -339,7 +339,7 @@ _Optional attributes:_
     <tr>
       <th><code>tags</code></th>
       <td>
-        Tags for the agent
+        Tags for the agent.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"queue=default"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS</code></p>
       </td>
@@ -348,7 +348,7 @@ _Optional attributes:_
     <tr>
       <th><code>tags-from-ec2</code></th>
       <td>
-        Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as tags
+        Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as tags.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_EC2</code></p>
       </td>
@@ -357,7 +357,7 @@ _Optional attributes:_
     <tr>
       <th><code>tags-from-ec2-tags</code></th>
       <td>
-        Include the host's EC2 tags as agent tags
+        Include the host's EC2 tags as agent tags.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS</code></p>
       </td>
@@ -366,7 +366,7 @@ _Optional attributes:_
     <tr>
       <th><code>tags-from-gcp</code></th>
       <td>
-        Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+        Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone).
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_GCP</code></p>
       </td>
@@ -375,7 +375,7 @@ _Optional attributes:_
     <tr>
       <th><code>tags-from-gcp-labels</code></th>
       <td>
-        Include the host's Google Cloud instance labels as tags
+        Include the host's Google Cloud instance labels as tags.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_GCP_LABELS</code></p>
       </td>
@@ -384,7 +384,7 @@ _Optional attributes:_
     <tr>
       <th><code>tags-from-host</code></th>
       <td>
-        Include the host's meta-data as tags (hostname, machine-id, and os)
+        Include the host's meta-data as tags (hostname, machine-id, and os).
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_HOST</code></p>
       </td>
@@ -393,7 +393,7 @@ _Optional attributes:_
     <tr>
       <th><code>timestamp-lines</code></th>
       <td>
-        Prepend timestamps on each line of output
+        Prepend timestamps on each line of output.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_TIMESTAMP_LINES</code></p>
       </td>
@@ -402,7 +402,7 @@ _Optional attributes:_
     <tr>
       <th><code>wait-for-ec2-tags-timeout</code></th>
       <td>
-        The amount of time to wait for tags from EC2 before proceeding
+        The amount of time to wait for tags from EC2 before proceeding.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>10s</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_WAIT_FOR_EC2_TAGS_TIMEOUT</code></p>
       </td>
@@ -411,7 +411,7 @@ _Optional attributes:_
     <tr>
       <th><code>wait-for-gcp-labels-timeout</code></th>
       <td>
-        The amount of time to wait for labels from GCP before proceeding
+        The amount of time to wait for labels from GCP before proceeding.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>10s</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_WAIT_FOR_GCP_LABELS_TIMEOUT</code></p>
       </td>
@@ -426,7 +426,7 @@ _Optional attributes:_
     <tr>
       <th><code>disconnect-after-job-timeout</code></th>
       <td>
-        When <code>disconnect-after-job</code> is specified, the number of seconds to wait for a job before shutting down
+        When <code>disconnect-after-job</code> is specified, the number of seconds to wait for a job before shutting down.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>120</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB_TIMEOUT</code></p>
       </td>
@@ -435,7 +435,7 @@ _Optional attributes:_
     <tr>
       <th><code>meta-data</code></th>
       <td>
-        Meta data for the agent
+        Meta data for the agent.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"queue=default"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_META_DATA</code></p>
         <p class="Docs__api-param-eg"><em>Use instead:</em> <code>tags</code></p>
@@ -445,7 +445,7 @@ _Optional attributes:_
     <tr>
       <th><code>meta-data-ec2</code></th>
       <td>
-        Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data
+        Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_META_DATA_EC2</code></p>
         <p class="Docs__api-param-eg"><em>Use instead:</em> <code>tags-from-ec2</code></p>
@@ -455,7 +455,7 @@ _Optional attributes:_
     <tr>
       <th><code>meta-data-ec2-tags</code></th>
       <td>
-        Include the host's EC2 tags as meta-data
+        Include the host's EC2 tags as meta-data.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_META_DATA_EC2_TAGS</code></p>
         <p class="Docs__api-param-eg"><em>Use instead:</em> <code>tags-from-ec2-tags</code></p>
@@ -465,7 +465,7 @@ _Optional attributes:_
     <tr>
       <th><code>meta-data-gcp</code></th>
       <td>
-        Include the host's GCP meta-data as meta-data
+        Include the host's GCP meta-data as meta-data.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_META_DATA_EC2_TAGS</code></p>
         <p class="Docs__api-param-eg"><em>Use instead:</em> <code>tags-from-ec2-tags</code></p>
@@ -475,7 +475,7 @@ _Optional attributes:_
     <tr>
       <th><code>no-automatic-ssh-fingerprint-verification</code></th>
       <td>
-        Do not automatically verify SSH fingerprints for first-time checkouts
+        Do not automatically verify SSH fingerprints for first-time checkouts.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_AUTOMATIC_SSH_FINGERPRINT_VERIFICATION</code></p>
         <p class="Docs__api-param-eg"><em>Use instead:</em> <code>no-ssh-keyscan</code></p>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -62,6 +62,15 @@ _Optional attributes:_
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_CANCEL_GRACE_PERIOD</code></p>
       </td>
     </tr>
+
+    <tr>
+      <th><code>cancel-signal</code></th>
+      <td>
+        The signal to use for cancellation
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>SIGTERM</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_CANCEL_SIGNAL</code></p>
+      </td>
+    </tr>
     
     <tr>
       <th><code>debug</code></th>
@@ -87,15 +96,6 @@ _Optional attributes:_
         Disconnect after processing a single job
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB</code></p>
-      </td>
-    </tr>
-
-    <tr>
-      <th><code>disconnect-after-job-timeout</code></th>
-      <td>
-        When `disconnect-after-job` is specified, the number of seconds to wait for a job before shutting down
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>120</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB_TIMEOUT</code></p>
       </td>
     </tr>
 
@@ -138,36 +138,39 @@ _Optional attributes:_
     <tr>
       <th><code>git-clone-mirror-flags</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        Flags to pass to the <code>git clone</code> command when used for mirroring. This is an experimental flag. <br>
+        Must set the <code>experiment</code> option with the <code>git-mirror</code> value, and the <code>git-mirrors-path</code> option.
+        <p class="Docs__api-param-eg"><em>Example:</em> <code>"-v --mirror"</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_CLONE_MIRROR_FLAGS</code></p>
       </td>
     </tr>
 
     <tr>
       <th><code>git-fetch-flags</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        Flags to pass to the <code>git fetch</code> command
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>"-v --prune"</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_FETCH_FLAGS</code></p>
       </td>
     </tr>
 
     <tr>
       <th><code>git-mirrors-lock-timeout</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        Seconds to lock a git mirror during clone, should exceed your longest checkout. This is an experimental flag. <br>
+        Must set the <code>experiment</code> option with the <code>git-mirror</code> value, and the <code>git-mirrors-path</code> option.
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>300</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT</code></p>
       </td>
     </tr>
 
     <tr>
       <th><code>git-mirrors-path</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        Path to where mirrors of git repositories are stored. This is an experimental flag. <br>
+        Must set the <code>experiment</code> option with the <code>git-mirror</code> value.
+        <p class="Docs__api-param-eg"><em>Example:</em> <code>???</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_MIRRORS_PATH</code></p>
       </td>
     </tr>
 
@@ -183,27 +186,27 @@ _Optional attributes:_
     <tr>
       <th><code>log-format</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        The format to use for the logger output
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>text</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_LOG_FORMAT</code></p>
       </td>
     </tr>
 
     <tr>
       <th><code>metrics-datadog</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        Send metrics to DogStatsD for Datadog
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_METRICS_DATADOG</code></p>
       </td>
     </tr>
 
     <tr>
       <th><code>metrics-datadog-host</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        The DogStatsD instance to send metrics to via udp
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>127.0.0.1:8125</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_METRICS_DATADOG_HOST</code></p>
       </td>
     </tr>
 
@@ -237,18 +240,18 @@ _Optional attributes:_
     <tr>
       <th><code>no-git-submodules</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        Do not automatically checkout git submodules
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_GIT_SUBMODULES, BUILDKITE_DISABLE_GIT_SUBMODULES</code></p>
       </td>
     </tr>
 
     <tr>
       <th><code>no-http2</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        Disable HTTP2 when communicating with the Agent API.
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_HTTP2</code></p>
       </td>
     </tr>
 
@@ -273,9 +276,9 @@ _Optional attributes:_
     <tr>
       <th><code>no-plugin-validation</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        Do not validate plugin configuration and requirements
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PLUGIN_VALIDATION</code></p>
       </td>
     </tr>
 
@@ -291,7 +294,7 @@ _Optional attributes:_
     <tr>
       <th><code>no-ssh-keyscan</code></th>
       <td>
-        Don't automatically run ssh-keyscan before checkout
+        Do not automatically run ssh-keyscan before checkout
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_SSH_KEYSCAN</code></p>
       </td>
@@ -327,9 +330,9 @@ _Optional attributes:_
     <tr>
       <th><code>spawn</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        The number of agents to spawn in parallel
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>1</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_SPAWN</code></p>
       </td>
     </tr>
 
@@ -361,15 +364,6 @@ _Optional attributes:_
     </tr>
 
     <tr>
-      <th><code>wait-for-ec2-tags-timeout</code></th>
-      <td>
-        The amount of time to wait for tags from EC2 before proceeding
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>10s</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_WAIT_FOR_EC2_TAGS_TIMEOUT</code></p>
-      </td>
-    </tr>
-
-    <tr>
       <th><code>tags-from-gcp</code></th>
       <td>
         Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
@@ -381,9 +375,9 @@ _Optional attributes:_
     <tr>
       <th><code>tags-from-gcp-labels</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        Include the host's Google Cloud instance labels as tags
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_TAGS_FROM_GCP_LABELS</code></p>
       </td>
     </tr>
 
@@ -406,11 +400,20 @@ _Optional attributes:_
     </tr>
 
     <tr>
+      <th><code>wait-for-ec2-tags-timeout</code></th>
+      <td>
+        The amount of time to wait for tags from EC2 before proceeding
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>10s</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_WAIT_FOR_EC2_TAGS_TIMEOUT</code></p>
+      </td>
+    </tr>
+
+    <tr>
       <th><code>wait-for-gcp-labels-timeout</code></th>
       <td>
-        
-        <p class="Docs__api-param-eg"><em>Default:</em> <code></code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_</code></p>
+        The amount of time to wait for labels from GCP before proceeding
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>10s</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_WAIT_FOR_GCP_LABELS_TIMEOUT</code></p>
       </td>
     </tr>
   </tbody>
@@ -420,6 +423,15 @@ _Optional attributes:_
 
 <table>
   <tbody>
+    <tr>
+      <th><code>disconnect-after-job-timeout</code></th>
+      <td>
+        When <code>disconnect-after-job</code> is specified, the number of seconds to wait for a job before shutting down
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>120</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_DISCONNECT_AFTER_JOB_TIMEOUT</code></p>
+      </td>
+    </tr>
+
     <tr>
       <th><code>meta-data</code></th>
       <td>
@@ -444,6 +456,16 @@ _Optional attributes:_
       <th><code>meta-data-ec2-tags</code></th>
       <td>
         Include the host's EC2 tags as meta-data
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_META_DATA_EC2_TAGS</code></p>
+        <p class="Docs__api-param-eg"><em>Use instead:</em> <code>tags-from-ec2-tags</code></p>
+      </td>
+    </tr>
+
+    <tr>
+      <th><code>meta-data-gcp</code></th>
+      <td>
+        Include the host's GCP meta-data as meta-data
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_META_DATA_EC2_TAGS</code></p>
         <p class="Docs__api-param-eg"><em>Use instead:</em> <code>tags-from-ec2-tags</code></p>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -66,7 +66,7 @@ _Optional attributes:_
     <tr>
       <th><code>cancel-signal</code></th>
       <td>
-        The signal to use for cancellation.
+        The signal that the agent sends to the bootstrap to signal cancellation, by default SIGTERM.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>SIGTERM</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_CANCEL_SIGNAL</code></p>
       </td>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -169,7 +169,7 @@ _Optional attributes:_
       <td>
         Path to where mirrors of git repositories are stored. This is an experimental flag. <br>
         Must set the <code>experiment</code> option with the <code>git-mirror</code> value.
-        <p class="Docs__api-param-eg"><em>Example:</em> <code>???</code></p>
+        <p class="Docs__api-param-eg"><em>Example:</em> <code>/tmp/buildkite-git-mirrors</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_MIRRORS_PATH</code></p>
       </td>
     </tr>


### PR DESCRIPTION
As pointed out in https://github.com/buildkite/docs/issues/501, we're missing a bunch of config options in our Agent Configuration options section.

This PR adds:
--endpoint 
--experiment 
--git-clone-mirror-flags 
--git-fetch-flags 
--git-mirrors-lock-timeout  
--git-mirrors-path 
--log-format 
--metrics-datadog 
--metrics-datadog-host 
--no-git-submodules 
--no-http2 
--no-plugin-validation 
--spawn 
--tags-from-gcp-labels 
--wait-for-gcp-labels-timeout

The descriptions are from the [agent start code](https://github.com/buildkite/agent/blob/22e3b5110a066e5404e1de1780846d3505656a94/clicommand/agent_start.go). I also moved `disconnect-after-job-timeout` to deprecated, as it's listed in the deprecated bit of that agent start file.  

The only thing missing is an example or default for `git-mirrors-path`. 

Closes #501.