### PR TITLE
Fix spelling error in interdependant

### DIFF
--- a/pages/pipelines/controlling_concurrency.md.erb
+++ b/pages/pipelines/controlling_concurrency.md.erb
@@ -2,7 +2,7 @@
 
 Some tasks need to be run with very strict concurrency rules to ensure they don’t collide with each other. Common examples for needing concurrency control are deployments, app releases and infrastructure tasks.
 
-To help you control concurrency, Buildkite provides two primitives: concurrency limits and concurrency groups. While these two primitives are closely linked and interdependant, they operate at different levels.
+To help you control concurrency, Buildkite provides two primitives: concurrency limits and concurrency groups. While these two primitives are closely linked and interdependent, they operate at different levels.
 
 <%= toc %>
 


### PR DESCRIPTION
I was recently implementing concurrency controls in some of my Buildkite pipelines and saw this spelling error. I thought I would fix it up :smile: 