### PR TITLE
Add cancel-grace-period and cancel-signal env vars

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -66,7 +66,7 @@ _Optional attributes:_
     <tr>
       <th><code>cancel-signal</code></th>
       <td>
-        The signal that the agent sends to the bootstrap to signal cancellation, by default SIGTERM.
+        The signal that the agent sends to the bootstrap to signal cancellation.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>SIGTERM</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_CANCEL_SIGNAL</code></p>
       </td>

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -130,7 +130,7 @@ Example: `"https://buildkite.com/acme-inc/my-project/builds/1514"`
 
 <h3 class="h3-caps">BUILDKITE_CANCEL_GRACE_PERIOD</h3>
 
-The value of the `cancel-grace-period` [agent configuration option](/docs/agent/v3/configuration). The value cannot be modified as an environment variable.
+The value of the `cancel-grace-period` [agent configuration option](/docs/agent/v3/configuration). The value can be modified by exporting the environment variable in the `environment` or `pre-checkout` hooks.
 
 Default: `10`
 

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -128,6 +128,12 @@ The url for this build on Buildkite. The value cannot be modified.
 
 Example: `"https://buildkite.com/acme-inc/my-project/builds/1514"`
 
+<h3 class="h3-caps">BUILDKITE_CANCEL_GRACE_PERIOD</h3>
+
+The value of the `cancel-grace-period` [agent configuration option](/docs/agent/v3/configuration). The value cannot be modified as an environment variable.
+
+Default: `10`
+
 <h3 class="h3-caps">BUILDKITE_CLEAN_CHECKOUT</h3>
 
 Whether the build should perform a clean checkout. The variable is read during the default checkout phase of the bootstrap and can be overridden in `environment` or `pre-checkout` hooks.

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -134,6 +134,12 @@ The value of the `cancel-grace-period` [agent configuration option](/docs/agent/
 
 Default: `10`
 
+<h3 class="h3-caps">BUILDKITE_CANCEL_SIGNAL</h3>
+
+The value of the `cancel-grace-period` [agent configuration option](/docs/agent/v3/configuration). The value can be modified by exporting the environment variable in the `environment` or `pre-checkout` hooks.
+
+Default: `SIGTERM`
+
 <h3 class="h3-caps">BUILDKITE_CLEAN_CHECKOUT</h3>
 
 Whether the build should perform a clean checkout. The variable is read during the default checkout phase of the bootstrap and can be overridden in `environment` or `pre-checkout` hooks.


### PR DESCRIPTION
Adds the env var for the `cancel-grace-period` agent config option. 

@lox can it be edited as an env var? Or just as a config option?