### PR TITLE
Add a CLI reference page for `buildkite-agent step`

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -175,6 +175,7 @@
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "meta-data", 'agent/v3/cli-meta-data' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "pipeline", 'agent/v3/cli-pipeline' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "bootstrap", 'agent/v3/cli-bootstrap' %></li>
+                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "step", 'agent/v3/cli-step' %></li>
                   </ul>
                 <% end %>
               <% else %>

--- a/pages/agent/v3/cli_step.md.erb
+++ b/pages/agent/v3/cli_step.md.erb
@@ -1,0 +1,21 @@
+# buildkite-agent step
+
+The Buildkite Agent’s `step` command provides the ability to retrieve and  update the attributes of steps in your `pipeline.yml` files.  
+
+<%= toc %>
+
+## Updating a step
+
+Use this command in your build scripts to update an attribute of a step. 
+
+```
+<%= render 'agent/v3/help/step_update.txt' %>
+```
+
+## Getting a step
+
+Use this command in your build scripts to get the value of a particular attribute from a step. 
+
+```
+<%= render 'agent/v3/help/step_get.txt' %>
+```

--- a/pages/agent/v3/help/_step_get.txt
+++ b/pages/agent/v3/help/_step_get.txt
@@ -1,0 +1,32 @@
+Usage:
+
+   buildkite-agent step get <attribute> [arguments...]
+
+Description:
+
+   Retrieve the value of an attribute in a step. If no attribute is passed, the
+   entire step will be returned.
+
+   In the event a complex object is returned (i.e. an object or an array),
+   you'll need to supply the --format option to tell the agent how it should
+   output the data (currently only JSON is supported).
+
+Example:
+
+   $ buildkite-agent step get "label"
+   $ buildkite-agent step get --format json
+   $ buildkite-agent step get "retry" --format json
+   $ buildkite-agent step get "state" --step "my-other-step"
+
+Options:
+
+   --step value                The step to get. Can be either it's ID (BUILDKITE_STEP_ID) or key (BUILDKITE_STEP_KEY) [$BUILDKITE_STEP_ID]
+   --build value               The build to look for the step in. Only required when targeting a step using it's key (BUILDKITE_STEP_KEY) [$BUILDKITE_BUILD_ID]
+   --format value              The format to output the attribute value in (currently only JSON is supported) [$BUILDKITE_STEP_GET_FORMAT]
+   --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
+   --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
+   --no-http2                  Disable HTTP2 when communicating with the Agent API. [$BUILDKITE_NO_HTTP2]
+   --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
+   --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
+   --profile value             Enable a profiling mode, either cpu, memory, mutex or block [$BUILDKITE_AGENT_PROFILE]

--- a/pages/agent/v3/help/_step_update.txt
+++ b/pages/agent/v3/help/_step_update.txt
@@ -1,0 +1,27 @@
+Usage:
+
+   buildkite-agent step update <attribute> <value> [arguments...]
+
+Description:
+
+   Update an attribute of a step in the build
+
+Example:
+
+   $ buildkite-agent step update "label" "New Label"
+   $ buildkite-agent step update "label" " (add to end of label)" --append
+   $ buildkite-agent step update "label" < ./tmp/some-new-label
+   $ ./script/label-generator | buildkite-agent step update "label"
+
+Options:
+
+   --step value                The step to update. Can be either it's ID (BUILDKITE_STEP_ID) or key (BUILDKITE_STEP_KEY) [$BUILDKITE_STEP_ID]
+   --build value               The build to look for the step in. Only required when targeting a step using it's key (BUILDKITE_STEP_KEY) [$BUILDKITE_BUILD_ID]
+   --append                    Append to current attribute instead of replacing it [$BUILDKITE_STEP_UPDATE_APPEND]
+   --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
+   --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
+   --no-http2                  Disable HTTP2 when communicating with the Agent API. [$BUILDKITE_NO_HTTP2]
+   --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
+   --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
+   --profile value             Enable a profiling mode, either cpu, memory, mutex or block [$BUILDKITE_AGENT_PROFILE]


### PR DESCRIPTION
Docs for https://github.com/buildkite/agent/pull/833 and https://github.com/buildkite/agent/pull/1083. 

@keithpitt I wasn't really sure how to describe this in the little intro paragraph. Is what I've got accurate? Do we need to add anything else?