### PR TITLE
Update environment_variables.md.erb

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -136,7 +136,9 @@ Default: `10`
 
 <h3 class="h3-caps">BUILDKITE_CANCEL_SIGNAL</h3>
 
-The value of the `cancel-grace-period` [agent configuration option](/docs/agent/v3/configuration). The value can be modified by exporting the environment variable in the `environment` or `pre-checkout` hooks.
+Interpreted through the `buildkite-agent.cfg` as `cancel-signal` which accepts signals in the form of `SIGTERM`, `SIGHUP`, etc.
+
+The default is `SIGTERM` through agent version 3.x.x and below, then `SIGINT` 4.x.x and above
 
 Default: `SIGTERM`
 

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -136,9 +136,7 @@ Default: `10`
 
 <h3 class="h3-caps">BUILDKITE_CANCEL_SIGNAL</h3>
 
-Interpreted through the `buildkite-agent.cfg` as `cancel-signal` which accepts signals in the form of `SIGTERM`, `SIGHUP`, etc.
-
-The default is `SIGTERM` through agent version 3.x.x and below, then `SIGINT` 4.x.x and above
+The value of the `cancel-signal` [agent configuration option](/docs/agent/v3/configuration). The value can be modified by exporting the environment variable in the `environment` or `pre-checkout` hooks.
 
 Default: `SIGTERM`
 


### PR DESCRIPTION
https://github.com/buildkite/agent/pull/1041

noted that there was a duplicate of `BUILDKITE_CANCEL_GRACE_PERIOD` -- putting a proper definition for `BUILDKITE_CANCEL_SIGNAL`