### PR TITLE
Add new conditionals vars

### DIFF
--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -48,7 +48,7 @@ _Optional attributes:_
   <tr>
     <td><code>if</code></td>
     <td>
-      A boolean expression to restrict the running of the step. See <a href="/docs/pipelines/conditionals">Using conditionals</a> for supported expressions.<br>
+      A boolean expression that omits the step when false. See <a href="/docs/pipelines/conditionals">Using conditionals</a> for supported expressions.<br>
       <em>Example:</em> <code>build.message != "skip me"</code>
     </td>
   </tr>

--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -92,7 +92,7 @@ _Optional attributes:_
   <tr>
     <td><code>if</code></td>
     <td>
-      A boolean expression to restrict the running of the step. See <a href="/docs/pipelines/conditionals">Using conditionals</a> for supported expressions.<br>
+      A boolean expression that omits the step when false. See <a href="/docs/pipelines/conditionals">Using conditionals</a> for supported expressions.<br>
       <em>Example:</em> <code>build.message != "skip me"</code>
     </td>
   </tr>

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -93,6 +93,26 @@ The below variables are supported by the `if` attribute:
 <table>
 <tbody>
 	<tr>
+		<td><code>build.author.email</code></td>
+		<td><code>String</code></td>
+		<td>The email address of the user who authored the build's commit</td>
+	</tr>
+	<tr>
+		<td><code>build.author.id</code></td>
+		<td><code>String</code></td>
+		<td>The ID of the user who authored the build's commit</td>
+	</tr>
+	<tr>
+		<td><code>build.author.name</code></td>
+		<td><code>String</code></td>
+		<td>The name of the user who authored the build's commit</td>
+	</tr>
+	<tr>
+		<td><code>build.author.teams</code></td>
+		<td><code>Array</code></td>
+		<td>An array of the team/s which the user who authored the build's commit is a member of</td>
+	</tr>
+	<tr>
 		<td><code>build.branch</code></td>
 		<td><code>String</code></td>
 		<td>The branch on which this build is created from</td>
@@ -103,9 +123,29 @@ The below variables are supported by the `if` attribute:
 		<td>The commit number of the commit the current build is based on</td>
 	</tr>
 	<tr>
-		<td><code>build.env()</code></td>
+		<td><code>build.creator.email</code></td>
 		<td><code>String</code></td>
-		<td>The value of the environment variable specified inside the parentheses</td>
+		<td>The email of the user who created the build</td>
+	</tr>
+	<tr>
+		<td><code>build.creator.id</code></td>
+		<td><code>String</code></td>
+		<td>The ID of the user who created the build</td>
+	</tr>
+	<tr>
+		<td><code>build.creator.name</code></td>
+		<td><code>String</code></td>
+		<td>The name of the user who created the build</td>
+	</tr>
+	<tr>
+		<td><code>build.creator.teams</code></td>
+		<td><code>Array</code></td>
+		<td>An array of the team/s which the user who created the build is a member of</td>
+	</tr>
+	<tr>
+		<td><code>build.env()</code></td>
+		<td><code>String</code>, <code>null</code></td>
+		<td>This function returns the value of the environment passed as the first argument, otherwise <code>null</code> if the environment variable has not been set</td>
 	</tr>
 	<tr>
 		<td><code>build.id</code></td>

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -103,6 +103,11 @@ The below variables are supported by the `if` attribute:
 		<td>The commit number of the commit the current build is based on</td>
 	</tr>
 	<tr>
+		<td><code>build.env()</code></td>
+		<td><code>String</code></td>
+		<td>The value of the environment variable specified inside the parentheses</td>
+	</tr>
+	<tr>
 		<td><code>build.id</code></td>
 		<td width="20%"><code>String</code></td>
 		<td>The ID of the current build</td>

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -93,29 +93,9 @@ The below variables are supported by the `if` attribute:
 <table>
 <tbody>
 	<tr>
-		<td><code>build.id</code></td>
-		<td width="20%"><code>String</code></td>
-		<td>The ID of the current build</td>
-	</tr>
-	<tr>
-		<td><code>build.source</code></td>
-		<td><code>String</code></td>
-		<td>The source of the event that created the build<br><em>Available sources:</em> <code>ui</code>, <code>api</code>, <code>webhook</code>, <code>trigger_job</code>, <code>schedule</code></td>
-	</tr>
-	<tr>
 		<td><code>build.branch</code></td>
 		<td><code>String</code></td>
 		<td>The branch on which this build is created from</td>
-	</tr>
-	<tr>
-		<td><code>build.tag</code></td>
-		<td><code>String</code>, <code>null</code></td>
-		<td>The tag associated with the commit the current build is based on</td>
-	</tr>
-	<tr>
-		<td><code>build.message</code></td>
-		<td><code>String</code>, <code>null</code></td>
-		<td>The current build's message</td>
 	</tr>
 	<tr>
 		<td><code>build.commit</code></td>
@@ -123,20 +103,29 @@ The below variables are supported by the `if` attribute:
 		<td>The commit number of the commit the current build is based on</td>
 	</tr>
 	<tr>
+		<td><code>build.id</code></td>
+		<td width="20%"><code>String</code></td>
+		<td>The ID of the current build</td>
+	</tr>
+	<tr>
+		<td><code>build.message</code></td>
+		<td><code>String</code>, <code>null</code></td>
+		<td>The current build's message</td>
+	</tr>
+	<tr>
 		<td><code>build.number</code></td>
 		<td><code>Integer</code></td>
 		<td>The number of the current build</td>
-	</tr>
-
-	<tr>
-		<td><code>build.pull_request.id</code></td>
-		<td><code>String</code>, <code>null</code></td>
- 		<td>The number of the pull request, otherwise <code>null</code> if the branch is not a pull request</td>
 	</tr>
 	<tr>
 		<td><code>build.pull_request.base_branch</code></td>
 		<td><code>String</code>, <code>null</code></td>
 		<td>The base branch that the pull request is targeting, otherwise <code>null</code> if the branch is not a pull request</td>
+	</tr>
+	<tr>
+		<td><code>build.pull_request.id</code></td>
+		<td><code>String</code>, <code>null</code></td>
+ 		<td>The number of the pull request, otherwise <code>null</code> if the branch is not a pull request</td>
 	</tr>
 	<tr>
 		<td><code>build.pull_request.repository</code></td>
@@ -148,16 +137,15 @@ The below variables are supported by the `if` attribute:
 		<td><code>Boolean</code>, <code>null</code></td>
 		<td>If the pull request comes from a forked repository, otherwise <code>null</code> if the branch is not a pull request</td>
 	</tr>
-
 	<tr>
-		<td><code>pipeline.id</code></td>
+		<td><code>build.source</code></td>
 		<td><code>String</code></td>
-		<td>The ID of the pipeline the current build is from</td>
+		<td>The source of the event that created the build<br><em>Available sources:</em> <code>ui</code>, <code>api</code>, <code>webhook</code>, <code>trigger_job</code>, <code>schedule</code></td>
 	</tr>
 	<tr>
-		<td><code>pipeline.slug</code></td>
-		<td><code>String</code></td>
-		<td>The slug of the pipeline the current build is from</td>
+		<td><code>build.tag</code></td>
+		<td><code>String</code>, <code>null</code></td>
+		<td>The tag associated with the commit the current build is based on</td>
 	</tr>
 	<tr>
 		<td><code>pipeline.default_branch</code></td>
@@ -165,9 +153,19 @@ The below variables are supported by the `if` attribute:
 		<td>The default branch of the pipeline the current build is from</td>
 	</tr>
 	<tr>
+		<td><code>pipeline.id</code></td>
+		<td><code>String</code></td>
+		<td>The ID of the pipeline the current build is from</td>
+	</tr>
+	<tr>
 		<td><code>pipeline.repository</code></td>
 		<td><code>String</code>, <code>null</code></td>
 		<td>The repository of the pipeline the current build is from</td>
+	</tr>
+	<tr>
+		<td><code>pipeline.slug</code></td>
+		<td><code>String</code></td>
+		<td>The slug of the pipeline the current build is from</td>
 	</tr>
 	<tr>
 		<td><code>organization.id</code></td>

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -260,7 +260,11 @@ build.tag != null
 To run only when building a tag beginning with a `v` and ends with a `.0`, such as `v1.0`:
 
 ```js
+// Using the tag variable
 build.tag =~ /^v[0-9]+\.0\$/
+
+// Using the env fuction
+build.env("BUILDKITE_TAG") =~ /^v[0-9]+\.0\$/
 ```
 
 To run only if the message doesn't contain `[skip tests]`, case insensitive:

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -275,3 +275,8 @@ To run only if the build was created from a schedule:
 build.source == "schedule"
 ```
 
+To run when the value of `CUSTOM_ENVIRONMENT_VARIABLE` is `value`:
+
+```js
+build.env("CUSTOM_ENVIRONMENT_VARIABLE") == "value"
+```

--- a/pages/pipelines/trigger_step.md.erb
+++ b/pages/pipelines/trigger_step.md.erb
@@ -64,7 +64,7 @@ _Optional attributes:_
   <tr>
     <td><code>if</code></td>
     <td>
-      A boolean expression to restrict the running of the step. See <a href="/docs/pipelines/conditionals">Using conditionals</a> for supported expressions.<br>
+      A boolean expression that omits the step when false. See <a href="/docs/pipelines/conditionals">Using conditionals</a> for supported expressions.<br>
       <em>Example:</em> <code>build.message != "skip me"</code>
     </td>
   </tr>

--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -29,7 +29,7 @@ _Optional attributes:_
   <tr>
     <td><code>if</code></td>
     <td>
-      A boolean expression to restrict the running of the step. See <a href="/docs/pipelines/conditionals">Using conditionals</a> for supported expressions.<br>
+      A boolean expression that omits the step when false. See <a href="/docs/pipelines/conditionals">Using conditionals</a> for supported expressions.<br>
       <em>Example:</em> <code>build.message != "skip me"</code>
     </td>
   </tr>


### PR DESCRIPTION
Adds `build.env()` to the supported variables list on the Conditionals page. I've also alphabetised the table so it's easier to find things. 

@keithpitt could I please get your help with an example? Also, is the description correct? 😄

![image](https://user-images.githubusercontent.com/2074469/67291312-44bf9e80-f4d9-11e9-88a6-1c72f4f6a3c4.png)

Edit: Adds a bunch more new supported vars too! (From https://github.com/buildkite/buildkite/pull/4348)

- [x] Add new vars
- [x] Update description for `if` in the step docs (from #549)
- [x] Fix build.env description
- [ ] Add new examples