### PR TITLE
Add meta-data keys --help text

### DIFF
--- a/pages/agent/v3/cli_meta_data.md.erb
+++ b/pages/agent/v3/cli_meta_data.md.erb
@@ -27,3 +27,9 @@ Use this command in your build scripts to get a previously saved value from the 
 ```
 <%= render 'agent/v3/help/meta_data_exists.txt' %>
 ```
+
+## Listing keys
+
+```
+<%= render 'agent/v3/help/meta_data_keys.txt' %>
+```

--- a/pages/agent/v3/help/_meta_data_keys.txt
+++ b/pages/agent/v3/help/_meta_data_keys.txt
@@ -1,0 +1,23 @@
+Usage:
+
+   buildkite-agent meta-data keys [arguments...]
+
+Description:
+
+   Lists all meta-data keys that have been previously set, delimited by a newline
+   and terminated with a trailing newline.
+
+Example:
+
+   $ buildkite-agent meta-data keys
+
+Options:
+
+   --job value                 Which job should the meta-data be checked for [$BUILDKITE_JOB_ID]
+   --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
+   --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
+   --no-http2                  Disable HTTP2 when communicating with the Agent API. [$BUILDKITE_NO_HTTP2]
+   --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
+   --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
+   --profile value             Enable a profiling mode, either cpu, memory, mutex or block [$BUILDKITE_AGENT_PROFILE]


### PR DESCRIPTION
Adding the `buildkite-agent meta-data keys` command to the meta-data CLI page. Added in https://github.com/buildkite/agent/pull/1039.

