### PR TITLE
Add agent version note to command hooks description

### DIFF
--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -21,16 +21,46 @@ The following is a complete list of hooks that can be implemented, and the order
     <tr><th>Hook</th><th>Order</th></th><th>Description</th></tr>
   </thead>
   <tbody>
-    <tr><td style="white-space: nowrap"><code>environment</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before all other hooks. Useful for <a href="/docs/pipelines/secrets#storing-secrets-in-environment-hooks">exposing secret keys</a> and <a href="/docs/agent/v3/securing#strict-checks-using-agent-hooks">adding strict checks</a>.</td></tr>
-    <tr><td style="white-space: nowrap"><code>pre-checkout</code></td><td style="white-space: nowrap">Agent, Plugin</td><td>Runs before checkout.</td></tr>
-    <tr><td style="white-space: nowrap"><code>checkout</code></td><td style="white-space: nowrap">Plugin, Agent</td><td>Overrides the default <code>git checkout</code> behavior. <em>Note:</em> If multiple checkout hooks are found, only the first will be run.</td></tr>
-    <tr><td style="white-space: nowrap"><code>post-checkout</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs after checkout.</td></tr>
-    <tr><td style="white-space: nowrap"><code>pre-command</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs before the build command.</td></tr>
-    <tr><td style="white-space: nowrap"><code>command</code></td><td style="white-space: nowrap">Plugin, Repository, Agent</td><td>Overrides the default command running behavior. <em>Note:</em> If multiple command hooks are found, only the first will be run.</td></tr>
-    <tr><td style="white-space: nowrap"><code>post-command</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs after the command.</td></tr>
-    <tr><td style="white-space: nowrap"><code>pre-artifact</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs before artifacts are uploaded, if an artifact upload pattern was defined for the job.</td></tr>
-    <tr><td style="white-space: nowrap"><code>post-artifact</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job.</td></tr>
-    <tr><td style="white-space: nowrap"><code>pre-exit</code></td><td style="white-space: nowrap">Agent, Repository, Plugin</td><td>Runs before the job finishes. Useful for performing cleanup tasks.</td></tr>
+    <tr>
+      <td style="white-space: nowrap"><code>environment</code></td>
+      <td style="white-space: nowrap">Agent, Plugin</td>
+      <td>Runs before all other hooks. Useful for <a href="/docs/pipelines/secrets#storing-secrets-in-environment-hooks">exposing secret keys</a> and <a href="/docs/agent/v3/securing#strict-checks-using-agent-hooks">adding strict checks</a>.</td></tr>
+    <tr>
+      <td style="white-space: nowrap"><code>pre-checkout</code></td>
+      <td style="white-space: nowrap">Agent, Plugin</td>
+      <td>Runs before checkout.</td></tr>
+    <tr>
+      <td style="white-space: nowrap"><code>checkout</code></td>
+      <td style="white-space: nowrap">Plugin, Agent</td>
+      <td>Overrides the default <code>git checkout</code> behavior.<br><em>Note:</em> As of Agent v3.15.0, if multiple checkout hooks are found, only the first will be run.</td></tr>
+    <tr>
+      <td style="white-space: nowrap"><code>post-checkout</code></td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td>Runs after checkout.</td></tr>
+    <tr>
+      <td style="white-space: nowrap"><code>pre-command</code></td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td>Runs before the build command.</td></tr>
+    <tr>
+      <td style="white-space: nowrap"><code>command</code></td>
+      <td style="white-space: nowrap">Plugin, Repository, Agent</td>
+      <td>Overrides the default command running behavior. <em>Note:</em> If multiple command hooks are found, only the first will be run.</td></tr>
+    <tr>
+      <td style="white-space: nowrap"><code>post-command</code></td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td>Runs after the command.</td></tr>
+    <tr>
+      <td style="white-space: nowrap"><code>pre-artifact</code></td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td>Runs before artifacts are uploaded, if an artifact upload pattern was defined for the job.</td></tr>
+    <tr>
+      <td style="white-space: nowrap"><code>post-artifact</code></td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td>Runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job.</td></tr>
+    <tr>
+      <td style="white-space: nowrap"><code>pre-exit</code></td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td>Runs before the job finishes. Useful for performing cleanup tasks.</td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
We recently (agent v3.15.0) changed the behaviour of the command hooks; it used to run all the command hooks present, now it just runs one. Also noted in https://github.com/buildkite/docs/issues/438.

This PR adds Agent version info to the existing note about command hook behaviour. Also includes some purely visual formatting of the table for easier editing 😊