### PR TITLE
Update desc for plugin validation

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -304,9 +304,9 @@ Example: `"/etc/buildkite-agent/plugins/"`
 
 <h3 class="h3-caps">BUILDKITE_PLUGIN_VALIDATION</h3>
 
-Whether to enable plugin validation (currently experimental). This variable is read by the bootstrap during the `checkout` phase. The value can be set as an environment variable in a `pipeline.yml` file, or in `environment` and `pre-checkout` hooks. It can also be enabled using the `plugin-validation` [agent configuration option](/docs/agent/v3/configuration). 
+Whether to validate plugin configuration and requirements. The value can be modified by exporting the environment variable in the `environment` or `pre-checkout` hooks, or in a `pipeline.yml` file. It can also be enabled using the `no-plugin-validation` [agent configuration option](/docs/agent/v3/configuration). 
 
-Values: `"true"` and `"false"`
+Default: `"false"`
 
 <h3 class="h3-caps">BUILDKITE_PULL_REQUEST</h3>
 


### PR DESCRIPTION
This has been around for almost a year and a half now (https://github.com/buildkite/agent/pull/748), so I'm removing the 'currently experimental' note from the description. 

Other things:
- Updating the bit about exporting to hooks so that it's in line with the format of the rest of the vars. 
- Changing the agent config option to be `no-plugin-validation` instead of `plugin-validation`, as we only have one with the `no` prefix in the config docs.  
- Changing from 'values' to 'default' in the example bit so that it's clearer that it's off by default.  