### PR TITLE
Remove mention of annotation display limit

### DIFF
--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -10,7 +10,7 @@ The Buildkite Agent’s `annotate` command allows you to add additional informat
 
 The `buildkite-agent annotate` command creates an annotation associated with the current build.
 
-The first five annotations created will be displayed on the build page, however there is no limit to the amount of annotations you can create. All annotations can be retreived using the [GraphQL API](/docs/apis/graphql-api).
+There is no limit to the amount of annotations you can create. All annotations can be retreived using the [GraphQL API](/docs/apis/graphql-api).
 
 Options for the `annotate` command can be found in the `buildkite-agent` cli help:
 


### PR DESCRIPTION
Now that we've got a "show more" button for annotations on the build pages, we don't need to mention the 5 annotation limit. See https://github.com/buildkite/buildkite/pull/3468 for more context.