### PR TITLE
Add header_times to job log API

### DIFF
--- a/pages/apis/rest_api/jobs.md.erb
+++ b/pages/apis/rest_api/jobs.md.erb
@@ -122,7 +122,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
   "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline/builds/1/jobs/b63254c0-3271-4a98-8270-7cfbd6c2f14e/log",
   "content": "This is the job's log output",
   "size": 28,
-  "header_times": [1433172431123456789, 2433172431123456789]
+  "header_times": [1563337899810051000,1563337899811015000,1563337905336878000,1563337906589603000,156333791038291900]
 }
 ```
 

--- a/pages/apis/rest_api/jobs.md.erb
+++ b/pages/apis/rest_api/jobs.md.erb
@@ -121,7 +121,8 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
 {
   "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline/builds/1/jobs/b63254c0-3271-4a98-8270-7cfbd6c2f14e/log",
   "content": "This is the job's log output",
-  "size": 28
+  "size": 28,
+  "header_times": [1433172431123456789, 2433172431123456789]
 }
 ```
 


### PR DESCRIPTION
A new field called `header_times` was added to the job log payload  in https://github.com/buildkite/buildkite/pull/3968. 

This PR adds the field to the example output in the job REST API doc.