### PR TITLE
Add note about alternate pipeline.yaml paths

### DIFF
--- a/pages/pipelines/defining_steps.md.erb
+++ b/pages/pipelines/defining_steps.md.erb
@@ -44,7 +44,9 @@ Your pipeline will now show a new step labeled :pipeline: that runs a `buildkite
 
 When you run a build, this step will add any steps defined in the `pipeline.yml` file to your Buildkite pipeline.
 
-Create a file called `pipeline.yml` in a directory called `.buildkite` in your repository. This file will describe your pipeline steps in YAML, and will be versioned alongside your code.  
+Create a file called `pipeline.yml` in a directory called `.buildkite` in your repository. This file will describe your pipeline steps in YAML, and will be versioned alongside your code.
+
+If you're using any tools that ignore hidden directories, you can store your `pipeline.yml` file either in the top level of your repository, or in a non-hidden directory called `buildkite`. 
 
 The following example YAML defines a pipeline with one command step that will echo 'Hello' into your build log:
 


### PR DESCRIPTION
You can store your `pipeline.yml` in other places than just the `.buildkite` directory that we mention in the docs. Added in https://github.com/buildkite/agent/pull/1051.

This PR adds a note that you can also use the top level of your repo, or a non-hidden `buildkite` folder. 