### PR TITLE
Add health-check-addr agent config option and env var

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -175,6 +175,15 @@ _Optional attributes:_
     </tr>
 
     <tr>
+      <th><code>health-check-addr</code></th>
+      <td>
+        Start an HTTP server on the specified address:port that returns whether the agent is healthy.
+        <p class="Docs__api-param-eg"><em>Default:</em> disabled</p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_AGENT_HEALTH_CHECK_ADDR</code></p>
+      </td>
+    </tr>
+
+    <tr>
       <th><code>hooks-path</code></th>
       <td>
         Directory where the global hook scripts are found.

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -228,7 +228,7 @@ Example: `"production"`
 
 The value of the `health-check-addr` [agent configuration option](/docs/agent/v3/configuration). The value cannot be modified as an environment variable.
 
-Example: ``
+Example: `"localhost:8080"`
 
 <h3 class="h3-caps">BUILDKITE_HOOKS_PATH</h3>
 

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -224,6 +224,12 @@ The GitHub deployment payload data as serialized JSON. Only available on builds 
 
 Example: `"production"`
 
+<h3 class="h3-caps">BUILDKITE_AGENT_HEALTH_CHECK_ADDR</h3>
+
+The value of the `health-check-addr` [agent configuration option](/docs/agent/v3/configuration). The value cannot be modified as an environment variable.
+
+Example: ``
+
 <h3 class="h3-caps">BUILDKITE_HOOKS_PATH</h3>
 
 The value of the `hooks-path` [agent configuration option](/docs/agent/v3/configuration). The value cannot be modified as an environment variable.


### PR DESCRIPTION
There was a new Agent config option added in https://github.com/buildkite/agent/pull/1066 - `health-check-addr`. 

This PR adds the config option and the associated env var. @lox what would be an appropriate example to use for the 'address:port'? 