### PR TITLE
Add S3 encryption env var

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -386,6 +386,12 @@ The secret access key for your S3 IAM user, for use with [private S3 buckets](/d
 
 Example: `"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"`
 
+<h3 class="h3-caps">BUILDKITE_S3_SSE_ENABLED</h3>
+
+Whether to enable encryption for the artifacts in your [private S3 bucket](/docs/agent/v3/cli-artifact#using-your-private-aws-s3-bucket). The variable is read by the `buildkite-agent artifact upload` command, as well as during the artifact upload phase of [command steps](/docs/pipelines/command-step#command-step-attributes). The value can only be set by exporting the environment variable in the `environment`, `pre-checkout` or `pre-command` hooks.
+
+Default: `false`
+
 <h3 class="h3-caps">BUILDKITE_SHELL</h3>
 
 The value of the `shell` [agent configuration option](/docs/agent/v3/configuration). The value cannot be modified as an environment variable.


### PR DESCRIPTION
A new env var was added in https://github.com/buildkite/agent/pull/1072 to enable encryption for S3 artifacts. 

This PR adds the new env var using the same format as the other private S3 bucket vars. @lox is the hooks info the same as the other S3 vars for this one?