### PR TITLE
Document the recently-added `term` blocks in annotations

### DIFF
--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -110,9 +110,20 @@ p4 pt4 pr4 pb4 pl4 py4 px4
 
 ### Colored console output
 
-Console output in annotations can be displayed with ANSI colors when processed through [our Terminal tool](http://buildkite.github.io/terminal-to-html/) and wrapped in `<pre class="term"><code></code></pre>` tags before uploading.
+Console output in annotations can be displayed with ANSI colors when wrapped in a Markdown block with either the `term` or `terminal` syntax.
+
+    ```term
+    \x1b[31mFailure/Error:\x1b[0m \x1b[32mexpect\x1b[0m(new_item.created_at).to eql(now)
+
+    \x1b[31m  expected: 2018-06-20 19:42:26.290538462 +0000\x1b[0m
+    \x1b[31m       got: 2018-06-20 19:42:26.290538000 +0000\x1b[0m
+
+    \x1b[31m  (compared using eql?)\x1b[0m
+    ```
 
 <%= image "annotations-terminal-output.png", alt: "Screenshot of colored terminal output in an annotation" %>
+
+Additionally, terminal output processed through [our Terminal tool](http://buildkite.github.io/terminal-to-html/) can be wrapped in `<pre class="term"><code></code></pre>` tags, which will accept the terminal colour styles but not attempt to process it again.
 
 ## Embedding & linking artifacts in annotations
 


### PR DESCRIPTION
This documents the coloured console output behaviour added in buildkite/buildkite#3479

<img width="699" alt="image" src="https://user-images.githubusercontent.com/282113/68095017-222a7e00-fefa-11e9-8ce3-24df65e1c519.png">

Note: the four-character Markdown indent was used in this because of vmg/redcarpet#208