### PR TITLE
access token api returns uuid instead of id

### DIFF
--- a/pages/apis/rest_api/access_token.md.erb
+++ b/pages/apis/rest_api/access_token.md.erb
@@ -18,7 +18,7 @@ curl "https://api.buildkite.com/v2/access-token"
 
 ```json
 {
-  "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
+  "uuid": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
   "scopes": ["read_build"]
 }
 ```


### PR DESCRIPTION
Access Token API `https://api.buildkite.com/v2/access-token` is returning `uuid`. 