### PR TITLE
fix: key value

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -114,6 +114,7 @@ _Optional attributes:_
     <td><code>key</code></td>
     <td>
       A unique string to identify the step. The value is available in the <code>BUILDKITE_STEP_KEY</code> <a href="/docs/pipelines/environment-variables">environment variable</a>.<br>
+      Keys can not have the same pattern as a UUID (<code>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</code>).<br>
       <em>Example:</em> <code>"linter"</code>
       <em>Alias:</em> <code>identifier</code>
     </td>


### PR DESCRIPTION
Got this in a pipeline upload:
```
422 One of the steps you provided was invalid: Step keys can't have the same pattern as a UUID (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
```