### PR TITLE
Add warning for conditionals with custom build.env values

### DIFF
--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -235,8 +235,8 @@ The below variables are supported by the `if` attribute:
 </table>
 
 <div class="Docs__troubleshooting-note">
-<h1>Using build.env with custom environment variables</h1>
-<p>Custom environment variables can only be used when the <a href="https://buildkite.com/changelog/32-defining-pipeline-build-steps-with-yaml">YAML pipeline steps editor</a> has been enabled.</p>
+<h1>Using <code>build.env()</code> with custom environment variables</h1>
+<p>To access custom environment variables with the <code>build.env()</code> function, ensure that the <a href="https://buildkite.com/changelog/32-defining-pipeline-build-steps-with-yaml">YAML pipeline steps editor</a> has been enabled in the Pipeline Settings menu.</p>
 </div>
 
 ## Example expressions

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -234,6 +234,11 @@ The below variables are supported by the `if` attribute:
 </tbody>
 </table>
 
+<div class="Docs__troubleshooting-note">
+<h1>Using build.env with custom environment variables</h1>
+<p>Custom environment variables can only be used when the <a href="https://buildkite.com/changelog/32-defining-pipeline-build-steps-with-yaml">YAML pipeline steps editor</a> has been enabled.</p>
+</div>
+
 ## Example expressions
 
 To run only when the branch is `master` or `production`:


### PR DESCRIPTION
Adding a warning around custom env vars as I have had two users caught out by this.

A bit of background:
Currently there are two flows when the build is created and they both operate differently in how they handle the processing of env var precedence. The new beta YAML pipeline steps supports this but the original pipeline upload does not (possibly breaking existing pipelines if we changed the precedence).

- Not sure if we want to link to the change log here as I did not see any other documentation around this.
- I did try and initially add this as **Note** to the build.env in the table column but it was pretty large