### PR TITLE
Fix wrong link

### DIFF
--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -2,7 +2,7 @@
 
 A *block* step is used to pause the execution of a build and wait on a team member to unblock it via the web or the [API](/docs/apis/rest-api/jobs#unblock-a-job).
 
-A block step is functionally identical to an [input step](/docs/pipelines/block-step), however a block step creates [implicit dependencies](/docs/pipelines/dependencies) to the steps before and after it. 
+A block step is functionally identical to an [input step](/docs/pipelines/input-step), however a block step creates [implicit dependencies](/docs/pipelines/dependencies) to the steps before and after it. 
 
 <%= toc %>
 


### PR DESCRIPTION
Link named "input step" was linking "block step" (that is, this same page)