### PR TITLE
Ensure any bare Slack channel names in the `notify` docs are quoted

### DIFF
--- a/pages/pipelines/notifications.md.erb
+++ b/pages/pipelines/notifications.md.erb
@@ -82,8 +82,12 @@ Add a Slack notification to your pipeline using the `slack` attribute of the `no
 
 ```yaml
 notify:
-  - slack: #general
+  - slack: "#general"
 ```
+
+<section class="Docs__troubleshooting-note">
+  <p>When using just a channel name, you must specify it in quotes, as otherwise the <code>#</code> will cause the channel name to be treated as a comment.</p>
+</section>
 
 The above example will deliver the notification to all configured workspaces that have a channel named 'general'.
 
@@ -103,7 +107,7 @@ notify:
       - buildkite-community#sre
       - buildkite-community#announcements
       - buildkite-team#monitoring
-      - #general
+      - "#general"
 ```
 
 In the example above, the notification will be sent to the 'sre' and 'announcements' channels in the 'buildkite-community' workspace, the 'monitoring' channel in the 'buildkite-team' workspace, as well as to the 'general' channel of all configured workspaces.


### PR DESCRIPTION
Due to how YAML handles this, channel names not in quotes, or not directly following a workspace name, are treated as comments and their values discarded!