### PR TITLE
Add EventBridge detail-type and fix the payloads

### DIFF
--- a/pages/integrations/amazon_eventbridge.md.erb
+++ b/pages/integrations/amazon_eventbridge.md.erb
@@ -104,6 +104,7 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
+  "detail-type": "Build Created",
   "detail": {
     "version": 1,
     "build": {
@@ -134,6 +135,7 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
+  "detail-type": "Build Started",
   "detail": {
     "version": 1,
     "build": {
@@ -164,6 +166,7 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
+  "detail-type": "Build Finished",
   "detail": {
     "version": 1,
     "build": {
@@ -194,6 +197,7 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
+  "detail-type": "Job Scheduled",
   "detail": {
     "version": 1,
     "job": {
@@ -242,6 +246,7 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
+  "detail-type": "Job Started",
   "detail": {
     "version": 1,
     "job": {
@@ -290,6 +295,7 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
+  "detail-type": "Job Finished",
   "detail": {
     "version": 1,
     "job": {
@@ -338,6 +344,7 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
+  "detail-type": "Job Activated",
   "detail": {
     "version": 1,
     "job": {
@@ -384,6 +391,7 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
+  "detail-type": "Agent Connected",
   "detail": {
     "version": 1,
     "agent": {
@@ -416,28 +424,31 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
-  "version": 1,
-  "agent": {
-    "uuid": "288139c5-728d-4c22-88e3-5a926b6c4a51",
-    "graphql_id": "QWdlbnQtLS0yODgxMzljNS03MjhkLTRjMjItODhlMy01YTkyNmI2YzRhNTE=",
-    "connection_state": "disconnected",
-    "name": "my-agent-1",
-    "version": "3.13.2",
-    "ip_address": "3.80.193.183",
-    "hostname": "ip-10-0-2-73.ec2.internal",
-    "pid": "18534",
-    "priority": 0,
-    "meta_data": [
-      "aws:instance-id=i-0ce2c738afbfc6c83"
-    ],
-    "connected_at": "2019-08-10 09:44:40 UTC",
-    "disconnected_at": "2019-08-10 09:54:40 UTC",
-    "lost_at": null
-  },
-  "organization": {
-    "uuid": "a98961b7-adc1-41aa-8726-cfb2c46e42e0",
-    "graphql_id": "T3JnYW5pemF0aW9uLS0tYTk4OTYxYjctYWRjMS00MWFhLTg3MjYtY2ZiMmM0NmU0MmUw",
-    "slug": "my-org"
+  "detail-type": "Agent Disconnected",
+  "detail": {
+    "version": 1,
+    "agent": {
+      "uuid": "288139c5-728d-4c22-88e3-5a926b6c4a51",
+      "graphql_id": "QWdlbnQtLS0yODgxMzljNS03MjhkLTRjMjItODhlMy01YTkyNmI2YzRhNTE=",
+      "connection_state": "disconnected",
+      "name": "my-agent-1",
+      "version": "3.13.2",
+      "ip_address": "3.80.193.183",
+      "hostname": "ip-10-0-2-73.ec2.internal",
+      "pid": "18534",
+      "priority": 0,
+      "meta_data": [
+        "aws:instance-id=i-0ce2c738afbfc6c83"
+      ],
+      "connected_at": "2019-08-10 09:44:40 UTC",
+      "disconnected_at": "2019-08-10 09:54:40 UTC",
+      "lost_at": null
+    },
+    "organization": {
+      "uuid": "a98961b7-adc1-41aa-8726-cfb2c46e42e0",
+      "graphql_id": "T3JnYW5pemF0aW9uLS0tYTk4OTYxYjctYWRjMS00MWFhLTg3MjYtY2ZiMmM0NmU0MmUw",
+      "slug": "my-org"
+    }
   }
 }
 ```
@@ -446,28 +457,31 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
-  "version": 1,
-  "agent": {
-    "uuid": "288139c5-728d-4c22-88e3-5a926b6c4a51",
-    "graphql_id": "QWdlbnQtLS0yODgxMzljNS03MjhkLTRjMjItODhlMy01YTkyNmI2YzRhNTE=",
-    "connection_state": "lost",
-    "name": "my-agent-1",
-    "version": "3.13.2",
-    "ip_address": "3.80.193.183",
-    "hostname": "ip-10-0-2-73.ec2.internal",
-    "pid": "18534",
-    "priority": 0,
-    "meta_data": [
-      "aws:instance-id=i-0ce2c738afbfc6c83"
-    ],
-    "connected_at": "2019-08-10 09:44:40 UTC",
-    "disconnected_at": "2019-08-10 09:54:40 UTC",
-    "lost_at": "2019-08-10 09:54:40 UTC"
-  },
-  "organization": {
-    "uuid": "a98961b7-adc1-41aa-8726-cfb2c46e42e0",
-    "graphql_id": "T3JnYW5pemF0aW9uLS0tYTk4OTYxYjctYWRjMS00MWFhLTg3MjYtY2ZiMmM0NmU0MmUw",
-    "slug": "my-org"
+  "detail-type": "Agent Lost",
+  "detail": {
+    "version": 1,
+    "agent": {
+      "uuid": "288139c5-728d-4c22-88e3-5a926b6c4a51",
+      "graphql_id": "QWdlbnQtLS0yODgxMzljNS03MjhkLTRjMjItODhlMy01YTkyNmI2YzRhNTE=",
+      "connection_state": "lost",
+      "name": "my-agent-1",
+      "version": "3.13.2",
+      "ip_address": "3.80.193.183",
+      "hostname": "ip-10-0-2-73.ec2.internal",
+      "pid": "18534",
+      "priority": 0,
+      "meta_data": [
+        "aws:instance-id=i-0ce2c738afbfc6c83"
+      ],
+      "connected_at": "2019-08-10 09:44:40 UTC",
+      "disconnected_at": "2019-08-10 09:54:40 UTC",
+      "lost_at": "2019-08-10 09:54:40 UTC"
+    },
+    "organization": {
+      "uuid": "a98961b7-adc1-41aa-8726-cfb2c46e42e0",
+      "graphql_id": "T3JnYW5pemF0aW9uLS0tYTk4OTYxYjctYWRjMS00MWFhLTg3MjYtY2ZiMmM0NmU0MmUw",
+      "slug": "my-org"
+    }
   }
 }
 ```
@@ -476,28 +490,31 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
-  "version": 1,
-  "agent": {
-    "uuid": "288139c5-728d-4c22-88e3-5a926b6c4a51",
-    "graphql_id": "QWdlbnQtLS0yODgxMzljNS03MjhkLTRjMjItODhlMy01YTkyNmI2YzRhNTE=",
-    "connection_state": "stopping",
-    "name": "my-agent-1",
-    "version": "3.13.2",
-    "ip_address": "3.80.193.183",
-    "hostname": "ip-10-0-2-73.ec2.internal",
-    "pid": "18534",
-    "priority": 0,
-    "meta_data": [
-      "aws:instance-id=i-0ce2c738afbfc6c83"
-    ],
-    "connected_at": "2019-08-10 09:44:40 UTC",
-    "disconnected_at": null,
-    "lost_at": null
-  },
-  "organization": {
-    "uuid": "a98961b7-adc1-41aa-8726-cfb2c46e42e0",
-    "graphql_id": "T3JnYW5pemF0aW9uLS0tYTk4OTYxYjctYWRjMS00MWFhLTg3MjYtY2ZiMmM0NmU0MmUw",
-    "slug": "my-org"
+  "detail-type": "Agent Stopping",
+  "detail": {
+    "version": 1,
+    "agent": {
+      "uuid": "288139c5-728d-4c22-88e3-5a926b6c4a51",
+      "graphql_id": "QWdlbnQtLS0yODgxMzljNS03MjhkLTRjMjItODhlMy01YTkyNmI2YzRhNTE=",
+      "connection_state": "stopping",
+      "name": "my-agent-1",
+      "version": "3.13.2",
+      "ip_address": "3.80.193.183",
+      "hostname": "ip-10-0-2-73.ec2.internal",
+      "pid": "18534",
+      "priority": 0,
+      "meta_data": [
+        "aws:instance-id=i-0ce2c738afbfc6c83"
+      ],
+      "connected_at": "2019-08-10 09:44:40 UTC",
+      "disconnected_at": null,
+      "lost_at": null
+    },
+    "organization": {
+      "uuid": "a98961b7-adc1-41aa-8726-cfb2c46e42e0",
+      "graphql_id": "T3JnYW5pemF0aW9uLS0tYTk4OTYxYjctYWRjMS00MWFhLTg3MjYtY2ZiMmM0NmU0MmUw",
+      "slug": "my-org"
+    }
   }
 }
 ```
@@ -506,28 +523,31 @@ exports.handler = (event, context, callback) => {
 
 ```json
 {
-  "version": 1,
-  "agent": {
-    "uuid": "288139c5-728d-4c22-88e3-5a926b6c4a51",
-    "graphql_id": "QWdlbnQtLS0yODgxMzljNS03MjhkLTRjMjItODhlMy01YTkyNmI2YzRhNTE=",
-    "connection_state": "stopped",
-    "name": "my-agent-1",
-    "version": "3.13.2",
-    "ip_address": "3.80.193.183",
-    "hostname": "ip-10-0-2-73.ec2.internal",
-    "pid": "18534",
-    "priority": 0,
-    "meta_data": [
-      "aws:instance-id=i-0ce2c738afbfc6c83"
-    ],
-    "connected_at": "2019-08-10 09:44:40 UTC",
-    "disconnected_at": "2019-08-10 09:54:40 UTC",
-    "lost_at": null
-  },
-  "organization": {
-    "uuid": "a98961b7-adc1-41aa-8726-cfb2c46e42e0",
-    "graphql_id": "T3JnYW5pemF0aW9uLS0tYTk4OTYxYjctYWRjMS00MWFhLTg3MjYtY2ZiMmM0NmU0MmUw",
-    "slug": "my-org"
+  "detail-type": "Agent Stopped",
+  "detail": {
+    "version": 1,
+    "agent": {
+      "uuid": "288139c5-728d-4c22-88e3-5a926b6c4a51",
+      "graphql_id": "QWdlbnQtLS0yODgxMzljNS03MjhkLTRjMjItODhlMy01YTkyNmI2YzRhNTE=",
+      "connection_state": "stopped",
+      "name": "my-agent-1",
+      "version": "3.13.2",
+      "ip_address": "3.80.193.183",
+      "hostname": "ip-10-0-2-73.ec2.internal",
+      "pid": "18534",
+      "priority": 0,
+      "meta_data": [
+        "aws:instance-id=i-0ce2c738afbfc6c83"
+      ],
+      "connected_at": "2019-08-10 09:44:40 UTC",
+      "disconnected_at": "2019-08-10 09:54:40 UTC",
+      "lost_at": null
+    },
+    "organization": {
+      "uuid": "a98961b7-adc1-41aa-8726-cfb2c46e42e0",
+      "graphql_id": "T3JnYW5pemF0aW9uLS0tYTk4OTYxYjctYWRjMS00MWFhLTg3MjYtY2ZiMmM0NmU0MmUw",
+      "slug": "my-org"
+    }
   }
 }
 ```


### PR DESCRIPTION
This adds a `detail-type` to the payload examples, which are often used in the event pattern to filter only certain types of events. It also fixes some incorrect payload examples in the last bunch of agent events.

Thanks to @keithduncan for the report of these!