### PR TITLE
Fix the pipeline notification documentation

### DIFF
--- a/pages/pipelines/notifications.md.erb
+++ b/pages/pipelines/notifications.md.erb
@@ -103,11 +103,11 @@ You can also specify multiple teams and channels with the `channels` attribute:
 ```yaml
 notify:
   - slack:
-    channels:
-      - buildkite-community#sre
-      - buildkite-community#announcements
-      - buildkite-team#monitoring
-      - "#general"
+      channels:
+        - buildkite-community#sre
+        - buildkite-community#announcements
+        - buildkite-team#monitoring
+        - "#general"
 ```
 
 In the example above, the notification will be sent to the 'sre' and 'announcements' channels in the 'buildkite-community' workspace, the 'monitoring' channel in the 'buildkite-team' workspace, as well as to the 'general' channel of all configured workspaces.


### PR DESCRIPTION
The syntax listed here will currently result in an unhandled 500 error. The "channels" options must in fact live within the "slack" object.