### PR TITLE
dashboard_path in ApplicationHelper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def dashboard_path
+    "/dashboard"
+  end
+
   def sidebar_link_to(name, path, options = {})
     url = "/docs/#{path}"
 


### PR DESCRIPTION
`/docs` in production was calling this `#dashboard_path` method which only existed in the buildkite/buildkite app that it was a submodule of.

Adding it here allows buildkite/docs to be run in isolation.

The error when this is missing only manifests when `bk_logged_in=true` cookie is set (i.e. `#probably_authenticated?` is true)