### PR TITLE
add in started_at finished_at

### DIFF
--- a/pages/integrations/amazon_eventbridge.md.erb
+++ b/pages/integrations/amazon_eventbridge.md.erb
@@ -132,6 +132,8 @@ exports.handler = (event, context, callback) => {
       "message": "Merge pull request #456 from my-org/chore/update-deps",
       "branch": "master",
       "state": "scheduled",
+      "started_at": null,
+      "finished_at": null,
       "source": "webhook"
     },
     "pipeline": {
@@ -163,6 +165,8 @@ exports.handler = (event, context, callback) => {
       "message": "Merge pull request #456 from my-org/chore/update-deps",
       "branch": "master",
       "state": "started",
+      "started_at": "2019-08-11 06:01:16 UTC",
+      "finished_at": null,
       "source": "webhook"
     },
     "pipeline": {
@@ -194,6 +198,8 @@ exports.handler = (event, context, callback) => {
       "message": "Merge pull request #456 from my-org/chore/update-deps",
       "branch": "master",
       "state": "passed",
+      "started_at": "2019-08-11 06:01:16 UTC",
+      "finished_at": "2019-08-11 06:01:35 UTC",
       "source": "webhook"
     },
     "pipeline": {


### PR DESCRIPTION
Adds in the started_at and finished_at values to eventbridge events.

<img width="906" alt="Screen Shot 2020-01-28 at 6 48 58 pm" src="https://user-images.githubusercontent.com/585588/73246632-02f07380-41ff-11ea-899b-6785695cc425.png">

<img width="906" alt="Screen Shot 2020-01-28 at 6 49 07 pm" src="https://user-images.githubusercontent.com/585588/73246642-08e65480-41ff-11ea-99aa-6323dd444f90.png">

<img width="903" alt="Screen Shot 2020-01-28 at 6 49 13 pm" src="https://user-images.githubusercontent.com/585588/73246655-126fbc80-41ff-11ea-8c4d-ef70280ce124.png">

