### PR TITLE
revert BUILDKITE_CANCEL_GRACE_PERIOD changes on pipeline value

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -142,7 +142,7 @@ Example: `"https://buildkite.com/acme-inc/my-project/builds/1514"`
 
 <h3 class="h3-caps">BUILDKITE_CANCEL_GRACE_PERIOD</h3>
 
-The value of the `cancel-grace-period` [agent configuration option](/docs/agent/v3/configuration). The value can be modified by exporting the environment variable in the `environment` or `pre-checkout` hooks.
+The value of the `cancel-grace-period` [agent configuration option](/docs/agent/v3/configuration). The value cannot be modified as an environment variable.
 
 Default: `10`
 


### PR DESCRIPTION
I did some digging with this one today for a user that was trying to set BUILDKITE_CANCEL_GRACE_PERIOD in the pipeline. 

Even though the value is not in the protected list as discussed https://github.com/buildkite/docs/pull/543 It is the config value that is actually used when cancelling here https://github.com/buildkite/agent/blob/master/agent/job_runner.go#L330.

I have just reverted to the text to the previous value.