### PR TITLE
Use a consistent filename for the k8s manifest template

### DIFF
--- a/pages/deployments/deploying_to_kubernetes.md.erb
+++ b/pages/deployments/deploying_to_kubernetes.md.erb
@@ -122,7 +122,7 @@ manifest="$(mktemp)"
 
 echo '--- \:kubernetes\: Shipping'
 
-envsubst < k8s/app.yml > "${manifest}"
+envsubst < k8s/deployment.yml > "${manifest}"
 kubectl apply -f "${manifest}"
 
 echo '--- \:zzz\: Waiting for deployment'


### PR DESCRIPTION
Earlier in the tutorial, we created the template at `k8s/deployment.yml` rather than `k8s/app.yml`.

Thanks to Madhuri Yechuri for noticing this.