### PR TITLE
Update pipelines.md.erb tabbing

### DIFF
--- a/pages/apis/rest_api/pipelines.md.erb
+++ b/pages/apis/rest_api/pipelines.md.erb
@@ -48,19 +48,19 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines"
     "waiting_jobs_count": 0,
     "visibility": "private",
     "steps": [
-        {
-          "type": "script",
-          "name": "Test :white_check_mark:",
-          "command": "script/test.sh",
-          "artifact_paths": "results/*",
-          "branch_configuration": "master feature/*",
-          "env": { },
-          "timeout_in_minutes": null,
-          "agent_query_rules": [ ]
-        }
-      ],
-      "env": {
+      {
+        "type": "script",
+        "name": "Test :white_check_mark:",
+        "command": "script/test.sh",
+        "artifact_paths": "results/*",
+        "branch_configuration": "master feature/*",
+        "env": { },
+        "timeout_in_minutes": null,
+        "agent_query_rules": [ ]
       }
+    ],
+    "env": {
+    }
   }
 ]
 ```


### PR DESCRIPTION
I was reading the docs on https://buildkite.com/docs/apis/rest-api/pipelines, and I noticed that the tabbing was off, seeming to me that it `env` was part of `steps`. 

This fixes the tabbing. 