### PR TITLE
use an in-repo script to push the docs docker image to ECR

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -1,10 +1,12 @@
 steps:
   - name: ":docker::ecr: Push to ECR"
+    command: ".buildkite/push-image.sh"
     depends_on: "rspec"
     if: |
       build.branch == "master"
     agents:
       queue: deploy-production
     plugins:
-      - seek-oss/docker-ecr-publish#v1.2.0:
-          ecr-name: ${ECR_REPO}
+     ecr#v2.0.0:
+       login: true
+       account-ids: ${ECR_ACCOUNT_ID}

--- a/.buildkite/push-image.sh
+++ b/.buildkite/push-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eu
 
 echo "--- :docker: Building docker image"
 


### PR DESCRIPTION
the docker-ecr-publish plugin works well, but it insists on pushing a `latest` tag to the repository.

We're experimenting with an immutable tags on ECR, so pushing latest fails. I've opened [an issue](https://github.com/seek-oss/docker-ecr-publish-buildkite-plugin/issues/12), but in the meantime this should get the docs build working again.