### PR TITLE
WIP docs searchable

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,17 @@
+class SearchController < ApplicationController
+
+  skip_before_action :verify_authenticity_token, :only => [:show]
+
+  def show
+    @data = []
+
+    @query = params[:search_query]
+
+    @data = Search.new.find_word(@query)
+
+    respond_to do |format|
+      format.html
+    end
+
+  end
+end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,7 +7,7 @@ class SearchController < ApplicationController
 
     @query = params[:query]
 
-    @data = Search.new.find_word(@query)
+    @data = Search.find_word(@query)
 
     respond_to do |format|
       format.html

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,10 +2,10 @@ class SearchController < ApplicationController
 
   skip_before_action :verify_authenticity_token, :only => [:show]
 
-  def show
+  def index
     @data = []
 
-    @query = params[:search_query]
+    @query = params[:query]
 
     @data = Search.new.find_word(@query)
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,0 +1,24 @@
+class Search
+
+  def all_documents
+    mdfiles = File.join("**", "*.md.erb")
+    Dir.glob(mdfiles)
+  end
+
+  def find_word(query)
+    data = []
+    docs = Search.new.all_documents
+    docs.each do |doc|
+      File.open(doc) do |f|
+        f.any? do |line|
+          if line.include?(query)
+            # link = remove page and md.erb from doc
+            data << [doc, line]
+          end
+        end
+      end
+    end
+    return data
+  end
+
+end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -5,6 +5,13 @@ class Search
       Dir.glob(mdfiles)
     end
 
+    def make_link_pretty(doc)
+      remove_page = "pages/"
+      remove_file_tag = ".md.erb"
+      doc = doc.sub(remove_page, '')
+      doc.chomp(remove_file_tag)
+    end
+
     def find_word(query)
       data = []
       docs = Search.all_documents
@@ -12,8 +19,8 @@ class Search
         File.open(doc) do |f|
           f.any? do |line|
             if line.include?(query)
-              # link = remove page and md.erb from doc
-              data << [doc, line]
+              link = make_link_pretty(doc)
+              data << {:link => link, :content => line}
             end
           end
         end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,24 +1,24 @@
 class Search
+  class << self
+    def all_documents
+      mdfiles = File.join("**", "*.md.erb")
+      Dir.glob(mdfiles)
+    end
 
-  def all_documents
-    mdfiles = File.join("**", "*.md.erb")
-    Dir.glob(mdfiles)
-  end
-
-  def find_word(query)
-    data = []
-    docs = Search.new.all_documents
-    docs.each do |doc|
-      File.open(doc) do |f|
-        f.any? do |line|
-          if line.include?(query)
-            # link = remove page and md.erb from doc
-            data << [doc, line]
+    def find_word(query)
+      data = []
+      docs = Search.all_documents
+      docs.each do |doc|
+        File.open(doc) do |f|
+          f.any? do |line|
+            if line.include?(query)
+              # link = remove page and md.erb from doc
+              data << [doc, line]
+            end
           end
         end
       end
+      return data
     end
-    return data
   end
-
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,6 +70,13 @@
         <div class="Docs__page-container__inner PageContainer">
 
           <nav class="Docs__nav">
+            <form method="post" action="/search/show" class="search_query">
+              <div class="FormField">
+                <input autofocus="autofocus" class="input" type="search_query" name="search_query">
+                <button class="button" type="submit">Search</button>
+              </div>
+            </form>
+            <br/>
             <% if request.url.include?('/docs/tutorials') %>
               <p class="Docs__nav__section-heading">Tutorials</p>
               <ul class="Docs__nav__sub-nav">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,9 +70,9 @@
         <div class="Docs__page-container__inner PageContainer">
 
           <nav class="Docs__nav">
-            <form method="post" action="/search/show" class="search_query">
+            <form method="get" action="/search" class="query">
               <div class="FormField">
-                <input autofocus="autofocus" class="input" type="search_query" name="search_query">
+                <input autofocus="autofocus" class="input" type="query" name="query">
                 <button class="button" type="submit">Search</button>
               </div>
             </form>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,13 +1,11 @@
 <h1> Search Results <h1>
 
-<h2>Returning results for <%=@query%><h2>
-
+<h2>Returning results for <%= @query %><h2>
+<table>
 <% @data.each do |result| %>
   <tr>
     <td><%= link_to result[:link], docs_page_path(result[:link]) %></td>
-    </br>
     <td><%= result[:content] %></td>
-    </br>
-    </br>
   </tr>
 <% end %>
+<table>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -2,4 +2,4 @@
 
 <h2>Returning results for <%=@query%><h2>
 
-  <p><%=@data %><p>
+<p><%=@data %><p>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -2,4 +2,12 @@
 
 <h2>Returning results for <%=@query%><h2>
 
-<p><%=@data %><p>
+<% @data.each do |result| %>
+  <tr>
+    <td><%= link_to result[:link], docs_page_path(result[:link]) %></td>
+    </br>
+    <td><%= result[:content] %></td>
+    </br>
+    </br>
+  </tr>
+<% end %>

--- a/app/views/search/show.html.erb
+++ b/app/views/search/show.html.erb
@@ -1,0 +1,5 @@
+<h1> Search Results <h1>
+
+<h2>Returning results for <%=@query%><h2>
+
+  <p><%=@data %><p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,4 +119,6 @@ Rails.application.routes.draw do
 
   # Take us straight to the docs when running standalone
   root to: redirect("/docs")
+
+  post "/search/show" => "search#show"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,5 +120,5 @@ Rails.application.routes.draw do
   # Take us straight to the docs when running standalone
   root to: redirect("/docs")
 
-  post "/search/show" => "search#show"
+  get '/search' => 'search#index', as: :search
 end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Search, type: :model do
+  context 'returns all documents from pages directory' do
+    it 'expect v2.md.erb to be returned' do
+      expect(Search.all_documents).to include("pages/agent/v2.md.erb")
+    end
+
+    it 'gets all 130 documents in pages directory' do
+      expect(Search.all_documents.count).to eq(130)
+    end
+
+    it 'makes sure there are documents in pages directory' do
+      expect(Search.all_documents.count).to_not eq(0)
+    end
+  end
+end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -14,4 +14,17 @@ RSpec.describe Search, type: :model do
       expect(Search.all_documents.count).to_not eq(0)
     end
   end
+
+  context 'makes url pretty' do
+    let(:doc) { 'pages/example.md.erb' }
+    it 'makes example link pretty' do
+      expect(Search.make_link_pretty(doc)).to eq('example')
+    end
+  end
+
+  context 'return results for query' do
+    it 'returns 6 results for hello' do
+      expect(Search.find_word('hello').count).to eq(6)
+    end
+  end
 end


### PR DESCRIPTION
Currently WIP

This should fix issue #35 and a little of #263.

This PR will add a search bar to the nav.
<img width="791" alt="Screen Shot 2020-02-13 at 9 34 16 pm" src="https://user-images.githubusercontent.com/8427242/74475966-b9fc1880-4ea8-11ea-89a7-7be138b4f45f.png">

Search will return results for queries
<img width="768" alt="Screen Shot 2020-02-13 at 10 41 53 pm" src="https://user-images.githubusercontent.com/8427242/74480978-2f201b80-4eb2-11ea-920e-3ae3979d32e5.png">

To add:
returned queries print nicely with linked article and line where query is present. Currently, it's very ugly.