### PR TITLE
Add step_key to jobs REST API responses

### DIFF
--- a/pages/apis/rest_api/builds.md.erb
+++ b/pages/apis/rest_api/builds.md.erb
@@ -71,7 +71,8 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
       {
         "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
         "type": "script",
-        "name": "scripts/build.sh",
+        "name": ":package:",
+        "step_key": "package",
         "agent_query_rules": ["*"],
         "state": "passed",
         "web_url": "https://buildkite.com/my-great-org/my-pipeline/builds/1#b63254c0-3271-4a98-8270-7cfbd6c2f14e",
@@ -180,7 +181,8 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
     {
       "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
       "type": "script",
-      "name": "scripts/build.sh",
+      "name": ":package:",
+      "step_key": "package",
       "agent_query_rules": ["*"],
       "state": "scheduled",
       "web_url": "https://buildkite.com/my-great-org/my-pipeline/builds/1#b63254c0-3271-4a98-8270-7cfbd6c2f14e",
@@ -297,7 +299,8 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
     {
       "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
       "type": "script",
-      "name": "scripts/build.sh",
+      "name": ":package:",
+      "step_key": "package",
       "agent_query_rules": ["*"],
       "state": "scheduled",
       "web_url": "https://buildkite.com/my-great-org/my-pipeline/builds/1#b63254c0-3271-4a98-8270-7cfbd6c2f14e",
@@ -434,7 +437,8 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
     {
       "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
       "type": "script",
-      "name": "scripts/build.sh",
+      "name": ":package:",
+      "step_key": "package",
       "agent_query_rules": ["*"],
       "state": "scheduled",
       "web_url": "https://buildkite.com/my-great-org/my-pipeline/builds/1#b63254c0-3271-4a98-8270-7cfbd6c2f14e",
@@ -545,7 +549,8 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
     {
       "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
       "type": "script",
-      "name": "scripts/build.sh",
+      "name": ":package:",
+      "step_key": "package",
       "agent_query_rules": ["*"],
       "state": "scheduled",
       "web_url": "https://buildkite.com/my-great-org/my-pipeline/builds/1#b63254c0-3271-4a98-8270-7cfbd6c2f14e",

--- a/pages/apis/rest_api/jobs.md.erb
+++ b/pages/apis/rest_api/jobs.md.erb
@@ -14,7 +14,8 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
     {
       "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
       "type": "script",
-      "name": "scripts/build.sh",
+      "name": ":package:",
+      "step_key": "package",
       "agent_query_rules": ["*"],
       "state": "scheduled",
       "build_url": "https://buildkite.com/my-great-org/my-pipeline/builds/1",


### PR DESCRIPTION
This adds the `step_key` field to the REST API job responses. It also updates the `name` examples, in order to make it clear what the three different fields are: `command`, `name` and `step_key`.