### PR TITLE
Correct usage string for agent artifact upload

### DIFF
--- a/pages/agent/v3/help/_artifact_upload.txt
+++ b/pages/agent/v3/help/_artifact_upload.txt
@@ -1,6 +1,6 @@
 Usage:
 
-   buildkite-agent artifact upload <pattern> <destination> [arguments...]
+   buildkite-agent artifact upload <pattern> [arguments...]
 
 Description:
 


### PR DESCRIPTION
`buildkite-agent artifact upload` doesn't actually accept a `<destination>` argument. This is already indicated in the docs:

> Buildkite will store the file at log/test.log. If you want it to be stored as test.log without the full path, then you'll need to change into the file's directory before running your upload command:

https://buildkite.com/docs/agent/v3/cli-artifact#uploading-artifacts

This PR removes the `<destination>` argument from the `buildkite-agent artifact upload` usage string.