### PR TITLE
nokogiri 1.10.8; fix CVE-2020-7595

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    nokogiri (1.10.5)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     public_suffix (3.0.3)
     puma (3.12.2)
@@ -173,4 +173,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.0.2
+   2.1.4


### PR DESCRIPTION
> xmlStringLenDecodeEntities in parser.c in libxml2 2.9.10 has an infinite
> loop in a certain end-of-file situation.  The Nokogiri RubyGem has
> patched it's vendored copy of libxml2 in order to prevent this issue
> from affecting nokogiri.

-- https://github.com/advisories/GHSA-7553-jr98-vx47

I haven't tested this locally, but I'd be surprised if a point release of nokogiri broke anything.