### PR TITLE
Remove link to frontend repo that doesn't exist

### DIFF
--- a/pages/apis/graphql_api.md.erb
+++ b/pages/apis/graphql_api.md.erb
@@ -115,5 +115,4 @@ Further resources for learning more about GraphQL:
 
 * Our [Getting Started with GraphQL Queries and Mutations](https://building.buildkite.com/tutorial-getting-started-with-graphql-queries-and-mutations-11211dfe5d64) tutorial
 * [graphql.org/learn](http://graphql.org/learn/) — The Learn section of the official GraphQL website
-* [github.com/buildkite/frontend](https://github.com/buildkite/frontend) — Buildkite’s web interface makes extensive use of the GraphQL API
 


### PR DESCRIPTION
Our frontend code isn't its own repo anymore! Removing the link from the graphql guide 😊 