### PR TITLE
log 404s to stdout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
   helper_method :probably_authenticated?
 
+  def route_not_found
+    render file: Rails.root.join("public","404.html"), layout: false, status: 404
+  end
+
   private
 
   # When you login to Buildkite, we set this cookie as an indicator for other

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,4 +119,7 @@ Rails.application.routes.draw do
 
   # Take us straight to the docs when running standalone
   root to: redirect("/docs")
+
+  # Ensure 404s for unmatched routes are logged by lograge
+  get '*unmatched_route', to: 'application#route_not_found'
 end


### PR DESCRIPTION
This app is using [lograge](https://rubygems.org/gems/lograge) to log requests one-per line. Like this:

    method=GET path=/docs/tutorials/getting-started format=html controller=PagesController action=show status=200 duration=1771.03 view=44.04

It renders some 404s (like when ActiveRecord::NotFound is raised), but it's unable to log requests for unmatched routes. The workaround [described in the README](https://github.com/roidrage/lograge#handle-actioncontrollerroutingerror) is to add a catch-all route at the lowest priority and render the 404 page with a controller action.

With this change, we got 404 logs:

    method=GET path=/docs-fargate/tutorials/getting-started format=html controller=ApplicationController action=route_not_found status=404 duration=4.73 view=4.52

This will be helpful for debugging the new deployment on fargate.