### PR TITLE
Configure the app to serve pages at /docs/* and /docs-fargate/*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ COPY . /app
 # Compile sprockets
 RUN if [ "$RAILS_ENV" = "production" ]; then \
       echo "--- :sprockets: Precompiling assets" \
-      && RAILS_ENV=production RAILS_GROUPS=assets bundle exec rake assets:precompile; \
+      && RAILS_ENV=production RAILS_GROUPS=assets bundle exec rake assets:precompile \
+      && cp -r /app/public/docs-fargate/assets /app/public/assets; \
     fi
 
 EXPOSE 3000

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,4 +13,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
-Rails.application.config.assets.prefix = "/docs-assets"
+Rails.application.config.assets.prefix = "/docs-fargate/assets"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,7 +112,14 @@ Rails.application.routes.draw do
   get "/docs/agent/v3/agent-meta-data", to: redirect("/docs/agent/v3/cli-start#setting-tags",     status: 301)
 
   # All other standard docs pages
-  get "/docs/*path" => "pages#show", as: :docs_page
+  # While testing this on fargate, we're temporarily supporting two prefixes so we can load
+  # the fargate-hosted docs at https://buildkite.com/docs-fargate
+  # After moving /docs/ to be served by the fargate-hosted app, we can revert support
+  # for the docs-fargate prefix
+  scope ":prefix", constraints: { prefix: /docs|docs-fargate/}, defaults: { prefix: "docs" } do
+    get "*path" => "pages#show", as: :docs_page
+  end
+  #get "/doc/*path" => "pages#show", as: :docs_page
 
   # Top level redirect. Needs to be at the end so it doesn't match /docs/sub-page
   get "/docs", to: redirect("/docs/tutorials/getting-started", status: 302), as: :docs


### PR DESCRIPTION
We're preparing to serve https://buildkite.com/docs with this app deployed to fargate.

During the preparation we'd like to serve https://buildkite.com/docs from the current location, and https://buildkite.com/docs-fargate from this app on fargate.

Once we're happy that the rails app on fargate is working correctly, we can change the ALB to route https://buildkite.com/docs to it.

This PR attempts to make the app capable of working under both route prefixes, so there's no code changes required to start serving production traffic (and we can then remove support for `/docs-fargate`) at our leisure.

Note that assets will be loaded from `/docs-fargate/assets/*`. We'll need to revert the change in `config/initializers/assets.rb` before we remove `/docs-fargate` from the ALB.