### PR TITLE
Some more URL-related tweaks to make /docs-fargate work nicely

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,13 +4,13 @@ module ApplicationHelper
   end
 
   def sidebar_link_to(name, path, options = {})
-    url = "/docs/#{path}"
+    full_path = docs_page_path(path, prefix: params.fetch(:prefix, "docs"))
 
     options[:class] = [options[:class]].flatten.compact
     options[:class] << 'Docs__nav__sub-nav__item__link Link--on-white Link--no-underline'
-    options[:class] << "active" if current_page?(url)
+    options[:class] << "active" if current_page?(full_path)
 
-    link_to(name, url, options)
+    link_to name, full_path, options
   end
 
   def open_source_url

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,7 +70,7 @@
         <div class="Docs__page-container__inner PageContainer">
 
           <nav class="Docs__nav">
-            <% if request.url.include?('/docs/tutorials') %>
+            <% if request.url.include?('/docs/tutorials') || request.url.include?('/docs-fargate/tutorials')%>
               <p class="Docs__nav__section-heading">Tutorials</p>
               <ul class="Docs__nav__sub-nav">
                 <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Getting Started", 'tutorials/getting-started' %></li>
@@ -85,7 +85,7 @@
               </p>
             <% end %>
 
-            <% if request.url.include?('/docs/agent') %>
+            <% if request.url.include?('/docs/agent') || request.url.include?('/docs-fargate/agent') %>
               <% current_agent_ver = request.url[%r{agent/v(\d)}, 1] || '2' %>
 
               <p class="Docs__nav__section-heading">Agent</p>
@@ -184,7 +184,7 @@
                 </p>
               <% end %>
 
-              <% if request.url.include?('/docs/pipelines') %>
+              <% if request.url.include?('/docs/pipelines') || request.url.include?('/docs-fargate/pipelines') %>
                 <p class="Docs__nav__section-heading">Pipelines</p>
                 <ul class="Docs__nav__sub-nav">
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Overview", 'pipelines' %></li>
@@ -223,7 +223,7 @@
                 </p>
               <% end %>
 
-              <% if request.url.include?('/docs/deployments') %>
+              <% if request.url.include?('/docs/deployments') || request.url.include?('/docs-fargate/deployments')%>
               <p class="Docs__nav__section-heading">Deployments</p>
               <ul class="Docs__nav__sub-nav">
                 <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Overview", 'deployments' %></li>
@@ -236,7 +236,7 @@
                 </p>
               <% end %>
 
-              <% if request.url.include?('/docs/integrations') %>
+              <% if request.url.include?('/docs/integrations') || request.url.include?('/docs-fargate/integrations')%>
                 <p class="Docs__nav__section-heading">Integrations</p>
                 <ul class="Docs__nav__sub-nav">
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "GitHub Enterprise", 'integrations/github-enterprise' %></li>
@@ -266,7 +266,7 @@
                 </p>
               <% end %>
 
-              <% if request.url.include?('/docs/apis') %>
+              <% if request.url.include?('/docs/apis') || request.url.include?('/docs-fargate/apis')%>
                 <p class="Docs__nav__section-heading">APIs</p>
                 <ul class="Docs__nav__sub-nav">
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Managing API Tokens", 'apis/managing-api-tokens' %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,9 +63,15 @@ Rails.application.routes.draw do
   get "/docs/integrations/sso/cloud-identity",    to: redirect("/docs/integrations/sso/g-cloud-identity")
 
   # Doc sections that don't have overview/index pages, so need redirecting
-  get "/docs/tutorials",    to: redirect("/docs/tutorials/getting-started",      status: 302)
-  get "/docs/integrations", to: redirect("/docs/integrations/github-enterprise", status: 302)
-  get "/docs/apis",         to: redirect("/docs/apis/webhooks",                  status: 302)
+  # While testing this on fargate, we're temporarily supporting two prefixes so we can load
+  # the fargate-hosted docs at https://buildkite.com/docs-fargate
+  # After moving /docs/ to be served by the fargate-hosted app, we can revert support
+  # for the docs-fargate prefix
+  scope ":prefix", constraints: { prefix: /docs|docs-fargate/}, defaults: { prefix: "docs" } do
+    get "tutorials",    to: redirect { |params| "/#{params[:prefix]}/tutorials/getting-started" }, status: 302
+    get "integrations", to: redirect { |params| "/#{params[:prefix]}/integrations/github-enterprise" }, status: 302
+    get "apis",         to: redirect { |params| "/#{params[:prefix]}/apis/webhooks" }, status: 302
+  end
 
   # The old un-versioned URLs have a lot of Google juice, so we redirect them to
   # the current version. But these are also linked from within the v2 agent


### PR DESCRIPTION
While we're in the process of migrating docs to be hosted on fargate, we're routing https://buildkite.com/docs-fargate/* to the fargate containers.

This set of tweaks makes it possible to click around the site at https://buildkite.com/docs-fargate/* and stay on the  `/docs-fargate` prefix. Hopefully this makes it easier to test, with much less URL hacking.

@matthewd has pointed out that it might've been easier to leave the URLs as `/docs/*` and use an ALB rule that routes the *host* `pre.buildkite.com` to the new fargate service. he's right, that would've been easier. We've sunk the time into this approach now and I think it's done. Oops.