### PR TITLE
configure puma to run in single (non-clustered) mode

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 10 }
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 20 }
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 0 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
this app is being deployed as a container on fargate, where we can size the tasks to a low-ish amount of cpu/memory resources.

In a container it's often nice to keep the processes as simple as possible, but have more of them.

I've also upped the thread count, on the assumption that with no DB most requests will be super fast and we can handle a fair number at the same time.