### PR TITLE
Adds support for code block filenames

### DIFF
--- a/app/assets/stylesheets/public/utils/_text_content.scss
+++ b/app/assets/stylesheets/public/utils/_text_content.scss
@@ -52,4 +52,21 @@
   .dark-gray { color: #8E8E8E; }
   .border { border: 1px solid; }
   .border-gray { border-color: #ddd; }
+
+  .highlight-figure {
+    figcaption {
+      border: 1px solid #ddd;
+      padding: .8em 1em;
+      border-top-left-radius: 5px;
+      border-top-right-radius: 5px;
+      border-bottom: none;
+      font-size: 14px;
+      color: #777;
+    }
+    pre {
+      margin-top: 0;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
+  }
 }

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Page::Renderer do
     MD
 
     html = <<~HTML
-      <div class="highlight"><figure><figcaption class="highlight-filename">file.json</figcaption><pre class="highlight json"><code><span class="p">{</span><span class="w"> </span><span class="s2">"key"</span><span class="p">:</span><span class="w"> </span><span class="s2">"value"</span><span class="w"> </span><span class="p">}</span><span class="w">
+      <div class="highlight"><figure class="highlight-figure"><figcaption>file.json</figcaption><pre class="highlight json"><code><span class="p">{</span><span class="w"> </span><span class="s2">"key"</span><span class="p">:</span><span class="w"> </span><span class="s2">"value"</span><span class="w"> </span><span class="p">}</span><span class="w">
       </span></code></pre></figure></div>
     HTML
 

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -105,4 +105,20 @@ RSpec.describe Page::Renderer do
 
     expect(Page::Renderer.render(md).strip).to eql(html.strip)
   end
+
+  it "supports {: code-filename=\"file.md\"} filenames for code blocks" do
+    md = <<~MD
+      ```json
+      { "key": "value" }
+      ```
+      {: codeblock-file="file.json"}
+    MD
+
+    html = <<~HTML
+      <div class="highlight"><figure><figcaption class="highlight-filename">file.json</figcaption><pre class="highlight json"><code><span class="p">{</span><span class="w"> </span><span class="s2">"key"</span><span class="p">:</span><span class="w"> </span><span class="s2">"value"</span><span class="w"> </span><span class="p">}</span><span class="w">
+      </span></code></pre></figure></div>
+    HTML
+
+    expect(Page::Renderer.render(md).strip).to eql(html.strip)
+  end
 end


### PR DESCRIPTION
Adds support for code blocks with filenames.

For example:

~~~markdown
Here's a example of a `docker-compose.yml` file for a Ruby on Rails application that depends on Postgres, Redis and Memcache:

```yml
version: '2'
services:
  db:
    image: postgres
  redis:
    image: redis
  memcache:
    image: memcached
  app:
    build: .
    working_dir: /app
    volumes:
```
{: codeblock-file="docker-compose.yml"}
~~~

<img width="512" alt="image" src="https://user-images.githubusercontent.com/153/77645171-66581100-6fb6-11ea-826e-2e4db3568d3f.png">

Closes #666