### PR TITLE
redirect /docs-fargate to somewhere that renders a page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,9 @@ Rails.application.routes.draw do
   # Top level redirect. Needs to be at the end so it doesn't match /docs/sub-page
   get "/docs", to: redirect("/docs/tutorials/getting-started", status: 302), as: :docs
 
+  # A temporary redirect while we're testing this app at https://buildkite.com/docs-fargate
+  get "/docs-fargate", to: redirect("/docs-fargate/tutorials/getting-started", status: 302), as: :docs_fargate
+
   # Take us straight to the docs when running standalone
   root to: redirect("/docs")
 


### PR DESCRIPTION
At the moment we're testing this app in production at https://buildkite.com/docs-fargate, and it's helpful to have that URL work (just like https://buildkite.com/docs).

Once this app is moved to service requests for https://buildkite.com/docs, we can remove this.