### PR TITLE
ensure the session cookie for docs is different to the bk/bk session cookie

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,4 @@
+Docs::Application.config.session_store :cookie_store, key: '_bk_docs_sess',
+                                                      expire_after: 1.year,
+                                                      secure: Rails.env.production?
+


### PR DESCRIPTION
In production both bk/bk and docs are hosted under the buildkite.com domain, so in theory they can read each others cookies.

However, the rails session cookie is encrypted and we use different encryption keys for both apps. If we configure them to use the same session cookie, they'll only both be able to read the data if we use the same encryption key. I've done that before elsewhere and it works, but coupling codebases like that is awkward and brittle.

The docs app has no logged in state anyway, so for now there's no need for it to read the bk/bk session. The safest path is to just give them distinct session cookies until that becomes a problem.

In any case, the docs app currently doesn't write to the session anywhere. Setting this is a defensive move so if we start writing to the session in the future, we don't break things.