### PR TITLE
assume assets are served under /docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY . /app
 RUN if [ "$RAILS_ENV" = "production" ]; then \
       echo "--- :sprockets: Precompiling assets" \
       && RAILS_ENV=production RAILS_GROUPS=assets bundle exec rake assets:precompile \
-      && cp -r /app/public/docs-fargate/assets /app/public/assets; \
+      && cp -r /app/public/docs/assets /app/public/assets; \
     fi
 
 EXPOSE 3000

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,4 +13,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 Rails.application.config.assets.precompile += %w( docsearch.js docsearch.css )
 
-Rails.application.config.assets.prefix = "/docs-fargate/assets"
+Rails.application.config.assets.prefix = "/docs/assets"


### PR DESCRIPTION
While testing this app on fargate we were serving assets from `/docs-fargate`. However, now that this app is serving user traffic under `/docs`, we can remove the temporary asset path