### PR TITLE
remove all mention of the /docs-fargate URL prefix

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
   end
 
   def sidebar_link_to(name, path, options = {})
-    full_path = docs_page_path(path, prefix: params.fetch(:prefix, "docs"))
+    full_path = docs_page_path(path)
 
     options[:class] = [options[:class]].flatten.compact
     options[:class] << 'Docs__nav__sub-nav__item__link Link--on-white Link--no-underline'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -73,7 +73,7 @@
         <div class="Docs__page-container__inner PageContainer">
 
           <nav class="Docs__nav">
-            <% if request.url.include?('/docs/tutorials') || request.url.include?('/docs-fargate/tutorials')%>
+            <% if request.url.include?('/docs/tutorials') %>
               <p class="Docs__nav__section-heading">Tutorials</p>
               <ul class="Docs__nav__sub-nav">
                 <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Getting Started", 'tutorials/getting-started' %></li>
@@ -88,7 +88,7 @@
               </p>
             <% end %>
 
-            <% if request.url.include?('/docs/agent') || request.url.include?('/docs-fargate/agent') %>
+            <% if request.url.include?('/docs/agent') %>
               <% current_agent_ver = request.url[%r{agent/v(\d)}, 1] || '2' %>
 
               <p class="Docs__nav__section-heading">Agent</p>
@@ -187,7 +187,7 @@
                 </p>
               <% end %>
 
-              <% if request.url.include?('/docs/pipelines') || request.url.include?('/docs-fargate/pipelines') %>
+              <% if request.url.include?('/docs/pipelines') %>
                 <p class="Docs__nav__section-heading">Pipelines</p>
                 <ul class="Docs__nav__sub-nav">
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Overview", 'pipelines' %></li>
@@ -224,7 +224,7 @@
                 <%= sidebar_link_to "Pipelines", 'pipelines', class: 'Link Link--on-white Link--underline Docs__nav__section-heading-link', data: { prefetch: true } %>
                 </p>
               <% end %>
-              <% if request.url.include?('/docs/plugins') || request.url.include?('/docs-fargate/plugins') %>
+              <% if request.url.include?('/docs/plugins') %>
                 <p class="Docs__nav__section-heading">Plugins</p>
                 <ul class="Docs__nav__sub-nav">
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Overview", 'plugins' %></li>
@@ -239,7 +239,7 @@
                 </p>
               <% end %>
 
-              <% if request.url.include?('/docs/deployments') || request.url.include?('/docs-fargate/deployments') %>
+              <% if request.url.include?('/docs/deployments') %>
                 <p class="Docs__nav__section-heading">Deployments</p>
                 <ul class="Docs__nav__sub-nav">
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Overview", 'deployments' %></li>
@@ -252,7 +252,7 @@
                 </p>
               <% end %>
 
-              <% if request.url.include?('/docs/integrations') || request.url.include?('/docs-fargate/integrations')%>
+              <% if request.url.include?('/docs/integrations') %>
                 <p class="Docs__nav__section-heading">Integrations</p>
                 <ul class="Docs__nav__sub-nav">
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "GitHub", 'integrations/github' %></li>
@@ -283,7 +283,7 @@
                 </p>
               <% end %>
 
-              <% if request.url.include?('/docs/apis') || request.url.include?('/docs-fargate/apis')%>
+              <% if request.url.include?('/docs/apis') %>
                 <p class="Docs__nav__section-heading">APIs</p>
                 <ul class="Docs__nav__sub-nav">
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Managing API Tokens", 'apis/managing-api-tokens' %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,15 +64,9 @@ Rails.application.routes.draw do
   get "/docs/integrations/sso/cloud-identity",    to: redirect("/docs/integrations/sso/g-cloud-identity")
 
   # Doc sections that don't have overview/index pages, so need redirecting
-  # While testing this on fargate, we're temporarily supporting two prefixes so we can load
-  # the fargate-hosted docs at https://buildkite.com/docs-fargate
-  # After moving /docs/ to be served by the fargate-hosted app, we can revert support
-  # for the docs-fargate prefix
-  scope ":prefix", constraints: { prefix: /docs|docs-fargate/}, defaults: { prefix: "docs" } do
-    get "tutorials",    to: redirect { |params| "/#{params[:prefix]}/tutorials/getting-started" }, status: 302
-    get "integrations", to: redirect { |params| "/#{params[:prefix]}/integrations/github" }, status: 302
-    get "apis",         to: redirect { |params| "/#{params[:prefix]}/apis/webhooks" }, status: 302
-  end
+  get "/docs/tutorials",    to: redirect("/docs/tutorials/getting-started"), status: 302
+  get "/docs/integrations", to: redirect("/docs/integrations/github"), status: 302
+  get "/docs/apis",         to: redirect("/docs/apis/webhooks"), status: 302
 
   # The old un-versioned URLs have a lot of Google juice, so we redirect them to
   # the current version. But these are also linked from within the v2 agent
@@ -119,20 +113,10 @@ Rails.application.routes.draw do
   get "/docs/agent/v3/agent-meta-data", to: redirect("/docs/agent/v3/cli-start#setting-tags",     status: 301)
 
   # All other standard docs pages
-  # While testing this on fargate, we're temporarily supporting two prefixes so we can load
-  # the fargate-hosted docs at https://buildkite.com/docs-fargate
-  # After moving /docs/ to be served by the fargate-hosted app, we can revert support
-  # for the docs-fargate prefix
-  scope ":prefix", constraints: { prefix: /docs|docs-fargate/}, defaults: { prefix: "docs" } do
-    get "*path" => "pages#show", as: :docs_page
-  end
-  #get "/doc/*path" => "pages#show", as: :docs_page
+  get "/docs/*path" => "pages#show", as: :docs_page
 
   # Top level redirect. Needs to be at the end so it doesn't match /docs/sub-page
   get "/docs", to: redirect("/docs/tutorials/getting-started", status: 302), as: :docs
-
-  # A temporary redirect while we're testing this app at https://buildkite.com/docs-fargate
-  get "/docs-fargate", to: redirect("/docs-fargate/tutorials/getting-started", status: 302), as: :docs_fargate
 
   # Take us straight to the docs when running standalone
   root to: redirect("/docs")

--- a/scripts/deploy-ecs
+++ b/scripts/deploy-ecs
@@ -8,7 +8,7 @@ task_family="docs"
 service_name="docs"
 image="${ECR_REPO}:${BUILDKITE_BUILD_NUMBER}"
 executionRole="${ECS_EXECUTION_ROLE_ARN}"
-http_host="https://buildkite.com/docs-fargate/"
+http_host="https://buildkite.com/docs/"
 templateFile="$(dirname $0)/../deploy/task-definition-template.json"
 tmpfile="/tmp/task-definition.json"
 


### PR DESCRIPTION
We used this prefix while testing the docs app on fargate. That fargate service is no serving production user traffic under /docs, and we don't need the testing prefix any more.

This is mostly reverting #672 and #674 