### PR TITLE
Update include_retried_jobs description

### DIFF
--- a/pages/apis/rest_api/_builds_list_query_strings.md.erb
+++ b/pages/apis/rest_api/_builds_list_query_strings.md.erb
@@ -42,7 +42,7 @@
   </tr>
   <tr>
     <th><code>include_retried_jobs</code></th>
-    <td>Include all retried jobs in each build’s jobs list.<p class="Docs__api-param-eg">
+    <td>Include all retried job executions in each build's jobs list. Without this parameter, you'll see only the most recently run job for each step.<p class="Docs__api-param-eg">
       <em>Example:</em> <code>?include_retried_jobs=true</code></p>
     </td>
   </tr>

--- a/pages/apis/rest_api/_builds_list_query_strings.md.erb
+++ b/pages/apis/rest_api/_builds_list_query_strings.md.erb
@@ -42,7 +42,7 @@
   </tr>
   <tr>
     <th><code>include_retried_jobs</code></th>
-    <td>Include all retried job executions in each build's jobs list. Without this parameter, you'll see only the most recently run job for each step.<p class="Docs__api-param-eg">
+    <td>Include all retried job executions in each build’s jobs list. Without this parameter, you'll see only the most recently run job for each step.<p class="Docs__api-param-eg">
       <em>Example:</em> <code>?include_retried_jobs=true</code></p>
     </td>
   </tr>


### PR DESCRIPTION
As pointed out in https://github.com/buildkite/docs/issues/645, our description for the builds API param `include_retried_jobs` isn't super clear. 

The PR updates the description to @dws-uber's words suggestion 🙌🏻 Thanks @dws-uber! 🙇🏻‍♀️

Closes #645  