### PR TITLE
remove unnecessary log prefix in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,9 +66,6 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')


### PR DESCRIPTION
We're using lograge to log a single line per request and in production they come out like this:

    I, [2020-04-02T10:29:20.928310 #1] INFO -- : [e9d8506d-7ccc-49d8-907f-a0381b5536e0] method=GET path=/docs/pipelines/defining-steps format=html controller=PagesController action=show status=200 duration=21.02 view=4.38

By removing this line, they lose the prefix:

    method=GET path=/docs/pipelines/defining-steps format=html controller=PagesController action=show status=200 duration=21.02 view=4.38

The timestamp is unnecessary - cloudwatch records one for us.

The log level (info in this case) isn't too useful. The request ID could be useful at some point , but only if it's logged in the same format as the rest of the line. I'll look into how to achieve that.