### PR TITLE
use a plain old logger in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,8 +71,6 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.logger    = ActiveSupport::Logger.new(STDOUT)
   end
 end


### PR DESCRIPTION
the default TaggedLogging decorator prefixes log lines with the request ID, like this:

    [4959e5bb-c638-4174-9219-d4310c26c8ab] method=GET path=/docs/pipelines/links-and-images-in-log-output format=html controller=PagesController action=show status=200 duration=21.12 view=4.50

We're using lograge and we just want plain, un-prefixed output to stdout, like this:

    method=GET path=/docs/pipelines/links-and-images-in-log-output format=html controller=PagesController action=show status=200 duration=21.12 view=4.50

If we want to log the request ID, we can do it within the lograge format