### PR TITLE
Fix link to buildkite CLI

### DIFF
--- a/pages/plugins/tools.md.erb
+++ b/pages/plugins/tools.md.erb
@@ -29,7 +29,7 @@ The following tools can be helpful when creating and maintaining your own Buildk
   </span>
 </a>
 
-<a class="Docs__example-repo" href="https://github.com/buildkite-plugins/shellcheck-buildkite-plugin">
+<a class="Docs__example-repo" href="https://github.com/buildkite/cli">
   <span class="icon">:terminal:</span>
   <span class="detail">
     <strong>Buildkite CLI</strong>


### PR DESCRIPTION
The link to the Buildkite CLI on the plugin tools page was pointing to the shellcheck plugin.