### PR TITLE
Make h3's linkable, and provide the ability for `id` and `class` overrides

### DIFF
--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -16,6 +16,7 @@ class Page::Renderer
     doc = add_custom_ids(doc)
     doc = add_custom_classes(doc)
     doc = add_automatic_ids_to_headings(doc)
+    doc = add_heading_anchor_links(doc)
     doc = add_table_of_contents(doc)
     doc = fix_curl_highlighting(doc)
     doc = add_code_filenames(doc)
@@ -68,9 +69,8 @@ class Page::Renderer
     doc
   end
 
-  def add_table_of_contents(doc)
-    # First, we find all the top-level h2s
-    headings = doc.search('./h2')
+  def add_heading_anchor_links(doc)
+    headings = doc.search('./h2', './h3')
 
     # Second, we make them all linkable and give them the right classes.
     headings.each do |node|
@@ -79,6 +79,12 @@ class Page::Renderer
         <a href="##{node['id']}" aria-hidden="true" class="Docs__heading__anchor"></a>
       HTML
     end
+
+    doc
+  end
+
+  def add_table_of_contents(doc)
+    headings = doc.search('./h2')
 
     # Third, we generate and replace the actual toc.
     doc.search('./p').each do |node|

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -13,6 +13,9 @@ class Page::Renderer
     # It's like our own little HTML::Pipeline. These methods are easily
     # switchable to HTML::Pipeline steps in the future, if we so wish.
     doc = Nokogiri::HTML.fragment(html)
+    doc = add_custom_ids(doc)
+    doc = add_custom_classes(doc)
+    doc = add_automatic_ids_to_headings(doc)
     doc = add_table_of_contents(doc)
     doc = fix_curl_highlighting(doc)
     doc = add_code_filenames(doc)
@@ -46,6 +49,25 @@ class Page::Renderer
     end
   end
 
+  def add_automatic_ids_to_headings(doc)
+    doc.search('./h2').each do |node|
+      node['id'] = node.text.to_url if node['id'].blank?
+
+      # Next we find all the h3 siblings between this, and the next h2, and add
+      # automatic ids to them if they don't have a manual one set already
+      sibling_node = node
+      while sibling_node = sibling_node.next_sibling
+        break if sibling_node.matches?('h2')
+
+        next unless sibling_node['id'].blank? && sibling_node.matches?('h3')
+
+        sibling_node['id'] = node['id'] + "-" + sibling_node.text.to_url
+      end
+    end
+
+    doc
+  end
+
   def add_table_of_contents(doc)
     # First, we find all the top-level h2s
     headings = doc.search('./h2')
@@ -53,7 +75,6 @@ class Page::Renderer
     # Second, we make them all linkable and give them the right classes.
     headings.each do |node|
       node['class'] = 'Docs__heading'
-      node['id'] = node.text.to_url
       node.add_child(<<~HTML)
         <a href="##{node['id']}" aria-hidden="true" class="Docs__heading__anchor"></a>
       HTML
@@ -108,6 +129,32 @@ class Page::Renderer
       node.previous_element.add_child(figure)
 
       node.previous_element.first_element_child.parent = figure
+      node.remove
+    end
+    
+    doc
+  end
+
+  def add_custom_ids(doc)
+    doc.search('./p').each do |node|
+      next unless node.to_html.starts_with?('<p>{: id=')
+
+      id = node.content[/id="(.*)"}/, 1]
+
+      node.previous_element['id'] = id
+      node.remove
+    end
+    
+    doc
+  end
+  
+  def add_custom_classes(doc)
+    doc.search('./p').each do |node|
+      next unless node.to_html.starts_with?('<p>{: class=')
+
+      css_class = node.content[/class="(.*)"}/, 1]
+
+      node.previous_element['class'] = css_class
       node.remove
     end
     

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -7,6 +7,7 @@ For best practices and recommendations about using secrets in your environment v
 {:toc}
 
 ## Buildkite environment variables
+{: id="bk-env-vars"}
 
 The following environment variables may be visible in your commands, plugins, hooks.
 

--- a/spec/features/reading_pages_spec.rb
+++ b/spec/features/reading_pages_spec.rb
@@ -68,6 +68,9 @@ RSpec.feature "reading pages" do
             # Ignore emails
             next if uri.is_a?(URI::MailTo)
 
+            # Ignore the hidden links that make our headings clickable
+            next if a[:class] == 'Docs__heading__anchor'
+
             # We have to resolve paths relative to the current page, so that both
             # '/docs/tutorials/getting-started' and 'getting-started' (from
             # '/docs/tutorials/other') work okay, similarly to in the browser.

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -47,16 +47,20 @@ RSpec.describe Page::Renderer do
         <h2 id="section-1" class="Docs__heading">Section 1<a href="#section-1" aria-hidden="true" class="Docs__heading__anchor"></a>
         </h2>
 
-        <h3 id="section-1-subsection-1-dot-1">Subsection 1.1</h3>
+        <h3 id="section-1-subsection-1-dot-1" class="Docs__heading">Subsection 1.1<a href="#section-1-subsection-1-dot-1" aria-hidden="true" class="Docs__heading__anchor"></a>
+        </h3>
 
-        <h3 id="section-1-subsection-1-dot-2">Subsection 1.2</h3>
+        <h3 id="section-1-subsection-1-dot-2" class="Docs__heading">Subsection 1.2<a href="#section-1-subsection-1-dot-2" aria-hidden="true" class="Docs__heading__anchor"></a>
+        </h3>
 
         <h2 id="section-2" class="Docs__heading">Section 2<a href="#section-2" aria-hidden="true" class="Docs__heading__anchor"></a>
         </h2>
 
-        <h3 id="section-2-subsection-2-dot-1">Subsection 2.1</h3>
+        <h3 id="section-2-subsection-2-dot-1" class="Docs__heading">Subsection 2.1<a href="#section-2-subsection-2-dot-1" aria-hidden="true" class="Docs__heading__anchor"></a>
+        </h3>
 
-        <h3 id="section-2-subsection-2-dot-2">Subsection 2.2</h3>
+        <h3 id="section-2-subsection-2-dot-2" class="Docs__heading">Subsection 2.2<a href="#section-2-subsection-2-dot-2" aria-hidden="true" class="Docs__heading__anchor"></a>
+        </h3>
       HTML
 
       expect(Page::Renderer.render(md).strip).to eql(html.strip)
@@ -112,7 +116,8 @@ RSpec.describe Page::Renderer do
         
         
         
-        <h3 id="short-id-subsection">Subsection</h3>
+        <h3 id="short-id-subsection" class="Docs__heading">Subsection<a href="#short-id-subsection" aria-hidden="true" class="Docs__heading__anchor"></a>
+        </h3>
       HTML
 
       expect(Page::Renderer.render(md).strip).to eql(html.strip)

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -22,19 +22,41 @@ RSpec.describe Page::Renderer do
       md = <<~MD
         {:toc}
 
-        ## Section
-      MD
+        ## Section 1
+
+        ### Subsection 1.1
+
+        ### Subsection 1.2
+
+        ## Section 2
+
+        ### Subsection 2.1
+
+        ### Subsection 2.2
+        MD
 
       html = <<~HTML
         <div class="Docs__toc">
           <p>On this page:</p>
           <ul>
-            <li><a href="#section">Section</a></li>
+            <li><a href="#section-1">Section 1</a></li>
+        <li><a href="#section-2">Section 2</a></li>
           </ul>
         </div>
 
-        <h2 class="Docs__heading" id="section">Section<a href="#section" aria-hidden="true" class="Docs__heading__anchor"></a>
+        <h2 id="section-1" class="Docs__heading">Section 1<a href="#section-1" aria-hidden="true" class="Docs__heading__anchor"></a>
         </h2>
+
+        <h3 id="section-1-subsection-1-dot-1">Subsection 1.1</h3>
+
+        <h3 id="section-1-subsection-1-dot-2">Subsection 1.2</h3>
+
+        <h2 id="section-2" class="Docs__heading">Section 2<a href="#section-2" aria-hidden="true" class="Docs__heading__anchor"></a>
+        </h2>
+
+        <h3 id="section-2-subsection-2-dot-1">Subsection 2.1</h3>
+
+        <h3 id="section-2-subsection-2-dot-2">Subsection 2.2</h3>
       HTML
 
       expect(Page::Renderer.render(md).strip).to eql(html.strip)
@@ -62,7 +84,7 @@ RSpec.describe Page::Renderer do
           </ul>
         </div>
         
-        <h2 class="Docs__heading" id="section">Section<a href="#section" aria-hidden="true" class="Docs__heading__anchor"></a>
+        <h2 id="section" class="Docs__heading">Section<a href="#section" aria-hidden="true" class="Docs__heading__anchor"></a>
         </h2>
         
         <section>
@@ -71,6 +93,26 @@ RSpec.describe Page::Renderer do
             <h2>Subheading</h2>
           </hgroup>
         </section>
+      HTML
+
+      expect(Page::Renderer.render(md).strip).to eql(html.strip)
+    end
+
+    it "handles custom ids" do
+      md = <<~MD
+        ## A Super Long Section Title
+        {: id="short-id"}
+
+        ### Subsection
+        MD
+
+      html = <<~HTML
+        <h2 id="short-id" class="Docs__heading">A Super Long Section Title<a href="#short-id" aria-hidden="true" class="Docs__heading__anchor"></a>
+        </h2>
+        
+        
+        
+        <h3 id="short-id-subsection">Subsection</h3>
       HTML
 
       expect(Page::Renderer.render(md).strip).to eql(html.strip)
@@ -117,6 +159,20 @@ RSpec.describe Page::Renderer do
     html = <<~HTML
       <div class="highlight"><figure class="highlight-figure"><figcaption>file.json</figcaption><pre class="highlight json"><code><span class="p">{</span><span class="w"> </span><span class="s2">"key"</span><span class="p">:</span><span class="w"> </span><span class="s2">"value"</span><span class="w"> </span><span class="p">}</span><span class="w">
       </span></code></pre></figure></div>
+    HTML
+
+    expect(Page::Renderer.render(md).strip).to eql(html.strip)
+  end
+
+  it "supports {: id=\"some-id\"} for manually specifying an id of the previous bit of content" do
+    md = <<~MD
+      ## This is a section
+      {: id="some-id"}
+    MD
+
+    html = <<~HTML
+      <h2 id="some-id" class="Docs__heading">This is a section<a href="#some-id" aria-hidden="true" class="Docs__heading__anchor"></a>
+      </h2>
     HTML
 
     expect(Page::Renderer.render(md).strip).to eql(html.strip)


### PR DESCRIPTION
Makes all the `h3` elements linkable by adding an automatic id, and let's you customize the `id` and `class`.

For example, the following markdown:

```markdown
## A long complicated section description
{: id="short-id"}

### Subsection 1

## Section 2

### Subsection 2
```

generates:

```html
<h2 id="short-id">A long complicated section description</h2>

<h3 id="short-id-subsection-1">Subsection 1</h3>

<h2 id="section-2">Section 2</h2>

<h3 id="section-2-subsection-2">Subsection 2</h3>
```

This means we can now link to individual [environment variables](https://buildkite.com/docs/pipelines/environment-variables#buildkite-environment-variables), and instead of `#buildkite-environment-variables-buildkite-agent-pid` we can have `#bk-env-vars-buildkite-agent-pid` for example.

Fixes #708