### PR TITLE
Remove the filename on the dynamic pipeline upload

### DIFF
--- a/pages/pipelines/defining_steps.md.erb
+++ b/pages/pipelines/defining_steps.md.erb
@@ -168,7 +168,6 @@ To use this script, you'd save it to `.buildkite/pipeline.sh` inside your reposi
 ```bash
 .buildkite/pipeline.sh | buildkite-agent pipeline upload
 ```
-{: codeblock-file=".buildkite/pipeline.sh"}
 
 When the build is run it will execute the script and pipe the output to the `pipeline upload` command. The upload command will insert the steps from the script into the build immediately after the upload step.
 


### PR DESCRIPTION
This removes the incorrect filename on the pipeline upload command example, so it matches the same type of examples further up the page too. In this case, this is the command to run in the pipeline.yml `command` step, not the contents of the file that generates the pipeline.

Fixes:
<img width="859" alt="image" src="https://user-images.githubusercontent.com/153/80045645-74fcfe00-854b-11ea-8c9b-bcfcdf6634b6.png">