### PR TITLE
Invite people under Users in Organization Settings

### DIFF
--- a/pages/tutorials/getting_started.md.erb
+++ b/pages/tutorials/getting_started.md.erb
@@ -34,7 +34,7 @@ Congratulations, you’ve just run your first Buildkite build! :tada:
 
 ## Invite your team to the organization
 
-To invite your team so they can see your build, go to your organization’s *Settings*, and under *Members* you’ll be able to paste in their email addresses.
+To invite your team so they can see your build, go to your organization’s *Settings*, and under *Users* you’ll be able to paste in their email addresses.
 
 ## Using a private repository
 


### PR DESCRIPTION
Fix a typo in [Invite your team](https://buildkite.com/docs/tutorials/getting-started#invite-your-team-to-the-organization) page :)

Should be Users instead of Members.

<img width="1205" alt="スクリーンショット 2020-04-27 19 52 08" src="https://user-images.githubusercontent.com/1000669/80364273-9863d800-88c0-11ea-8b05-7d85184edd0f.png">

### Before

<img width="729" alt="スクリーンショット 2020-04-27 19 55 52" src="https://user-images.githubusercontent.com/1000669/80364621-33f54880-88c1-11ea-8e5d-c469b246d460.png">

### After

<img width="736" alt="スクリーンショット 2020-04-27 19 56 04" src="https://user-images.githubusercontent.com/1000669/80364618-32c41b80-88c1-11ea-89d6-dd4399b8cd28.png">


[View updated doc on docs-review-invite-user-r8tgcf](https://docs-review-invite-user-r9tgcf.herokuapp.com/docs/tutorials/getting-started#invite-your-team-to-the-organization)