### PR TITLE
Revert "Make h3's linkable, and provide the ability for `id` and `class` overrides"

### DIFF
--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -13,10 +13,6 @@ class Page::Renderer
     # It's like our own little HTML::Pipeline. These methods are easily
     # switchable to HTML::Pipeline steps in the future, if we so wish.
     doc = Nokogiri::HTML.fragment(html)
-    doc = add_custom_ids(doc)
-    doc = add_custom_classes(doc)
-    doc = add_automatic_ids_to_headings(doc)
-    doc = add_heading_anchor_links(doc)
     doc = add_table_of_contents(doc)
     doc = fix_curl_highlighting(doc)
     doc = add_code_filenames(doc)
@@ -50,41 +46,18 @@ class Page::Renderer
     end
   end
 
-  def add_automatic_ids_to_headings(doc)
-    doc.search('./h2').each do |node|
-      node['id'] = node.text.to_url if node['id'].blank?
-
-      # Next we find all the h3 siblings between this, and the next h2, and add
-      # automatic ids to them if they don't have a manual one set already
-      sibling_node = node
-      while sibling_node = sibling_node.next_sibling
-        break if sibling_node.matches?('h2')
-
-        next unless sibling_node['id'].blank? && sibling_node.matches?('h3')
-
-        sibling_node['id'] = node['id'] + "-" + sibling_node.text.to_url
-      end
-    end
-
-    doc
-  end
-
-  def add_heading_anchor_links(doc)
-    headings = doc.search('./h2', './h3')
+  def add_table_of_contents(doc)
+    # First, we find all the top-level h2s
+    headings = doc.search('./h2')
 
     # Second, we make them all linkable and give them the right classes.
     headings.each do |node|
       node['class'] = 'Docs__heading'
+      node['id'] = node.text.to_url
       node.add_child(<<~HTML)
         <a href="##{node['id']}" aria-hidden="true" class="Docs__heading__anchor"></a>
       HTML
     end
-
-    doc
-  end
-
-  def add_table_of_contents(doc)
-    headings = doc.search('./h2')
 
     # Third, we generate and replace the actual toc.
     doc.search('./p').each do |node|
@@ -135,32 +108,6 @@ class Page::Renderer
       node.previous_element.add_child(figure)
 
       node.previous_element.first_element_child.parent = figure
-      node.remove
-    end
-    
-    doc
-  end
-
-  def add_custom_ids(doc)
-    doc.search('./p').each do |node|
-      next unless node.to_html.starts_with?('<p>{: id=')
-
-      id = node.content[/id="(.*)"}/, 1]
-
-      node.previous_element['id'] = id
-      node.remove
-    end
-    
-    doc
-  end
-  
-  def add_custom_classes(doc)
-    doc.search('./p').each do |node|
-      next unless node.to_html.starts_with?('<p>{: class=')
-
-      css_class = node.content[/class="(.*)"}/, 1]
-
-      node.previous_element['class'] = css_class
       node.remove
     end
     

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -7,7 +7,6 @@ For best practices and recommendations about using secrets in your environment v
 {:toc}
 
 ## Buildkite environment variables
-{: id="bk-env-vars"}
 
 The following environment variables may be visible in your commands, plugins, hooks.
 

--- a/spec/features/reading_pages_spec.rb
+++ b/spec/features/reading_pages_spec.rb
@@ -68,9 +68,6 @@ RSpec.feature "reading pages" do
             # Ignore emails
             next if uri.is_a?(URI::MailTo)
 
-            # Ignore the hidden links that make our headings clickable
-            next if a[:class] == 'Docs__heading__anchor'
-
             # We have to resolve paths relative to the current page, so that both
             # '/docs/tutorials/getting-started' and 'getting-started' (from
             # '/docs/tutorials/other') work okay, similarly to in the browser.

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -22,45 +22,19 @@ RSpec.describe Page::Renderer do
       md = <<~MD
         {:toc}
 
-        ## Section 1
-
-        ### Subsection 1.1
-
-        ### Subsection 1.2
-
-        ## Section 2
-
-        ### Subsection 2.1
-
-        ### Subsection 2.2
-        MD
+        ## Section
+      MD
 
       html = <<~HTML
         <div class="Docs__toc">
           <p>On this page:</p>
           <ul>
-            <li><a href="#section-1">Section 1</a></li>
-        <li><a href="#section-2">Section 2</a></li>
+            <li><a href="#section">Section</a></li>
           </ul>
         </div>
 
-        <h2 id="section-1" class="Docs__heading">Section 1<a href="#section-1" aria-hidden="true" class="Docs__heading__anchor"></a>
+        <h2 class="Docs__heading" id="section">Section<a href="#section" aria-hidden="true" class="Docs__heading__anchor"></a>
         </h2>
-
-        <h3 id="section-1-subsection-1-dot-1" class="Docs__heading">Subsection 1.1<a href="#section-1-subsection-1-dot-1" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h3>
-
-        <h3 id="section-1-subsection-1-dot-2" class="Docs__heading">Subsection 1.2<a href="#section-1-subsection-1-dot-2" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h3>
-
-        <h2 id="section-2" class="Docs__heading">Section 2<a href="#section-2" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h2>
-
-        <h3 id="section-2-subsection-2-dot-1" class="Docs__heading">Subsection 2.1<a href="#section-2-subsection-2-dot-1" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h3>
-
-        <h3 id="section-2-subsection-2-dot-2" class="Docs__heading">Subsection 2.2<a href="#section-2-subsection-2-dot-2" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h3>
       HTML
 
       expect(Page::Renderer.render(md).strip).to eql(html.strip)
@@ -88,7 +62,7 @@ RSpec.describe Page::Renderer do
           </ul>
         </div>
         
-        <h2 id="section" class="Docs__heading">Section<a href="#section" aria-hidden="true" class="Docs__heading__anchor"></a>
+        <h2 class="Docs__heading" id="section">Section<a href="#section" aria-hidden="true" class="Docs__heading__anchor"></a>
         </h2>
         
         <section>
@@ -97,27 +71,6 @@ RSpec.describe Page::Renderer do
             <h2>Subheading</h2>
           </hgroup>
         </section>
-      HTML
-
-      expect(Page::Renderer.render(md).strip).to eql(html.strip)
-    end
-
-    it "handles custom ids" do
-      md = <<~MD
-        ## A Super Long Section Title
-        {: id="short-id"}
-
-        ### Subsection
-        MD
-
-      html = <<~HTML
-        <h2 id="short-id" class="Docs__heading">A Super Long Section Title<a href="#short-id" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h2>
-        
-        
-        
-        <h3 id="short-id-subsection" class="Docs__heading">Subsection<a href="#short-id-subsection" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h3>
       HTML
 
       expect(Page::Renderer.render(md).strip).to eql(html.strip)
@@ -164,20 +117,6 @@ RSpec.describe Page::Renderer do
     html = <<~HTML
       <div class="highlight"><figure class="highlight-figure"><figcaption>file.json</figcaption><pre class="highlight json"><code><span class="p">{</span><span class="w"> </span><span class="s2">"key"</span><span class="p">:</span><span class="w"> </span><span class="s2">"value"</span><span class="w"> </span><span class="p">}</span><span class="w">
       </span></code></pre></figure></div>
-    HTML
-
-    expect(Page::Renderer.render(md).strip).to eql(html.strip)
-  end
-
-  it "supports {: id=\"some-id\"} for manually specifying an id of the previous bit of content" do
-    md = <<~MD
-      ## This is a section
-      {: id="some-id"}
-    MD
-
-    html = <<~HTML
-      <h2 id="some-id" class="Docs__heading">This is a section<a href="#some-id" aria-hidden="true" class="Docs__heading__anchor"></a>
-      </h2>
     HTML
 
     expect(Page::Renderer.render(md).strip).to eql(html.strip)


### PR DESCRIPTION
Reverts buildkite/docs#710

More context in https://3.basecamp.com/3453178/buckets/1735271/messages/2629087723

TL;DR: nokogiri is taking 10-30 seconds to do its thing on https://buildkite.com/docs/pipelines/environment-variables in production and development.

Here's a flamegraph of the interesting part:

![image](https://user-images.githubusercontent.com/15759/80583193-41dad300-8a53-11ea-96f6-ef82fdcef5f9.png)

