### PR TITLE
Add BADGE_DOMAIN env

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -19,7 +19,7 @@
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
   policy.font_src    :self, 'https://www2.buildkiteassets.com/'
-  policy.img_src     :self, 'https://buildkiteassets.com/', 'https://buildkite.com/', Matomo::URL
+  policy.img_src     :self, 'https://buildkiteassets.com/', 'https://buildkite.com/', Matomo::URL, ENV.fetch('BADGE_DOMAIN', 'https://badge.buildkite.com')
   policy.object_src  :none
   policy.script_src  :self, Matomo::URL
   policy.style_src   :self, :unsafe_inline

--- a/deploy/task-definition-template.json
+++ b/deploy/task-definition-template.json
@@ -31,6 +31,10 @@
         {
           "name": "MATOMO_TRACKER_URL",
           "value": "https://analytics.buildkite.com/tracker"
+        },
+        {
+          "name": "BADGE_DOMAIN",
+          "value": "https://badge.buildkite.com"
         }
       ],
       "secrets": [


### PR DESCRIPTION
That points to our https://badge.buildkite.com.

This will fix the svg not showing on our [status badges page](https://buildkite.com/docs/integrations/build-status-badges).