### PR TITLE
Update vertical margins on list items

### DIFF
--- a/app/assets/stylesheets/public/utils/_text_content.scss
+++ b/app/assets/stylesheets/public/utils/_text_content.scss
@@ -2,7 +2,7 @@
   line-height: 1.3;
   h2, h3, h4, blockquote, pre, p { margin: 1em 0; }
   h2 { font-size: #{(24/18)}rem; margin-top: 1.5em; }
-  li { margin-left: 2em; }
+  li { margin: 0.5em 0 0.5em 2em; }
   ul > li { list-style: disc; }
   ol > li { list-style: decimal; }
   li li { margin-left: 1em; }


### PR DESCRIPTION
Fixes #441 

Updated spacing: 
![image](https://user-images.githubusercontent.com/2824446/81993540-41644e00-9689-11ea-97d2-9aeb89dd6afd.png)

Note that this also applies to the TOC lists, where it's also an improvement:
![image](https://user-images.githubusercontent.com/2824446/81993581-580aa500-9689-11ea-8489-4bae22e026f4.png)
