### PR TITLE
Unrendered link in Automatic Retry Attributes blockquote

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -248,7 +248,7 @@ _Optional Attributes_
 
 <div class="Docs__note">
 <p class="Docs__note__heading">-1 Exit Status</p>
-<p>A job will fail with an exit status of -1 if communication with the agent has been lost (e.g. the agent has been forcefully terminated, or the agent machine was shut down without allowing the agent to disconnect). See the section on [Exit Codes](/docs/agent/v3#exit-codes) for information on other exit codes.</p>
+<p>A job will fail with an exit status of -1 if communication with the agent has been lost (e.g. the agent has been forcefully terminated, or the agent machine was shut down without allowing the agent to disconnect). See the section on <a href="/docs/agent/v3#exit-codes">Exit Codes</a> for information on other exit codes.</p>
 </div>
 
 ```yml


### PR DESCRIPTION
A link in a blockquote for [Automatic Retry Attributes](https://buildkite.com/docs/pipelines/command-step#automatic-retry-attributes) had a link that was still in markdown:

![image](https://user-images.githubusercontent.com/4923990/82709724-385a1a80-9c4f-11ea-9c9a-a7e3cfb2623b.png)

The markdown links only seem to work if they are not nested under HTML, so I updated it to an HTML link like the majority of the links on the page:

![image](https://user-images.githubusercontent.com/4923990/82710993-380f4e80-9c52-11ea-8a6c-d2b5268cd12e.png)