### PR TITLE
Add multiple agents info to the macos agent install doc

### DIFF
--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -79,24 +79,32 @@ tail -f ~/.buildkite-agent/log/buildkite-agent.log
 
 ## Running multiple agents
 
-- can have one launchd service that uses the --spawn flag
-- use existing plist, uncomment the spawn flag and change the number to how many agents you want to run 
+Launching and managing multiple agents can be done using `launchd`. 
 
-    <key>ProgramArguments</key>
-    <array>
-      <string>/Users/your-build-user/.buildkite-agent/bin/buildkite-agent</string>
-      <string>start</string>
-      <!-- <string>--debug</string> -->
-      <!-- <string>--spawn=5</string> -->
-    </array>
+If you need the same configuration on each agent, configure a `launchd` service to use the `--spawn` flag on the `buildkite-agent` command.
 
-- if you need different config for your agents, you can create multiple launchd services
-- if you installed with homebrew you can find find your plist in your user's ~/Library/LaunchAgents directory
-- if you installed with the Linux script, you can find it a template `https://raw.githubusercontent.com/buildkite/agent/master/templates/launchd_local_with_gui.plist`
-- copy the plist as many times as you need, give each one a unique label
+Using the existing agent `plist`, add the spawn flag to the `ProgramArguments` and change the number to how many agents you want to run.
 
-- once you've edited your plist/s, ensure all the referenced paths exist and have the correct permissions, see Starting on Login for examples
-- use launchctl to load each plist into launchd
+The below example will start five agents each time the service is started:
+
+```xml
+<key>ProgramArguments</key>
+<array>
+  <string>/Users/your-build-user/.buildkite-agent/bin/buildkite-agent</string>
+  <string>start</string>
+  <string>--spawn=5</string>
+</array>
+```
+
+If your agents each need different configuration, you can create multiple `launchd` services:
+
+1. Find your agent's `plist`. If you installed the agent with homebrew you can find the `plist` in your user's `~/Library/LaunchAgents` directory. If you installed with the Linux script, you can take a copy of the [template plist](https://raw.githubusercontent.com/buildkite/agent/master/templates/launchd_local_with_gui.plist) from the Agent's GitHub repository.
+
+2. Make as many copies of the plist as you require, one per configuration, ensuring that each has a unique label.
+
+3. Once you've edited your plist/s with your custom config, make sure that all the referenced paths exist and have the correct permissions. See the [Starting on Login](#starting-on-login) section above for an example of how to check directories and permissions. 
+
+4. Load each `plist` into `launchd` using `launchctl`. 
 
 ## Upgrading
 

--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -77,6 +77,27 @@ tail -f ~/.buildkite-agent/log/buildkite-agent.log
   <p>Ensure that you have a user logged in to the macOS host, then re-run:<br><code>launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist</code></p>
 </section>
 
+## Running multiple agents
+
+- can have one launchd service that uses the --spawn flag
+- use existing plist, uncomment the spawn flag and change the number to how many agents you want to run 
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/Users/your-build-user/.buildkite-agent/bin/buildkite-agent</string>
+      <string>start</string>
+      <!-- <string>--debug</string> -->
+      <!-- <string>--spawn=5</string> -->
+    </array>
+
+- if you need different config for your agents, you can create multiple launchd services
+- if you installed with homebrew you can find find your plist in your user's ~/Library/LaunchAgents directory
+- if you installed with the Linux script, you can find it a template `https://raw.githubusercontent.com/buildkite/agent/master/templates/launchd_local_with_gui.plist`
+- copy the plist as many times as you need, give each one a unique label
+
+- once you've edited your plist/s, ensure all the referenced paths exist and have the correct permissions, see Starting on Login for examples
+- use launchctl to load each plist into launchd
+
 ## Upgrading
 
 If you installed the agent using Homebrew you can use the standard brew upgrade command to update the agent:


### PR DESCRIPTION
So far this is just some notes, but eventually it will be full sentences and have some example code too. We already supply people with a plist, so I'm adding some explainers on how to add the --spawn option or how to dupe the whole plist. 

This PR adds a section on Running multiple agents to the macos agent installer doc, mirroring the one we've got in the Linux agent installer doc. 

Closes https://github.com/buildkite/docs/issues/730