### PR TITLE
Add CORS headers to quick-reference JSON

### DIFF
--- a/app/controllers/quick_reference_controller.rb
+++ b/app/controllers/quick_reference_controller.rb
@@ -1,3 +1,12 @@
 class QuickReferenceController < ApplicationController
+  before_action :add_cors_headers
+
   def pipelines; end
+
+  private
+
+  def add_cors_headers
+    headers["Access-Control-Allow-Methods"] = "GET, OPTIONS"
+    headers["Access-Control-Allow-Origin"] = '*'
+  end
 end


### PR DESCRIPTION
This will allow any domain to request and use the quick reference JSON.