### PR TITLE
Refactor installation and upgrade docs

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -116,7 +116,7 @@
                 <ul class="Docs__nav__sub-nav">
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Overview", 'agent/v2' %></li>
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Installation", 'agent/v2/installation' %></li>
-                  <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Upgrading to v2", 'agent/v2/upgrading-to-v2' %></li>
+                  <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Upgrading to v3", 'agent/v3/upgrading' %></li>
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Configuration", 'agent/v2/configuration' %></li>
                   <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "SSH Keys", 'agent/v2/ssh-keys' %></li>
                   <li class="Docs__nav__sub-nav__item--sub"><%= sidebar_link_to "GitHub SSH Keys", 'agent/v2/github-ssh-keys' %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -89,6 +89,22 @@
               </p>
             <% end %>
 
+            <p class="Docs__nav__section-heading">Installation</p>
+            <ul class="Docs__nav__sub-nav">
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Overview", 'agent/v3/installation' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Upgrading", 'agent/v3/upgrading' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Ubuntu Linux", 'agent/v3/ubuntu' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Debian Linux", 'agent/v3/debian' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Red Hat/CentOS Linux", 'agent/v3/redhat' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "FreeBSD", 'agent/v3/freebsd' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "macOS", 'agent/v3/osx' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Windows", 'agent/v3/windows' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Other Linux", 'agent/v3/linux' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Docker", 'agent/v3/docker' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "AWS", 'agent/v3/aws' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Google Cloud", 'agent/v3/gcloud' %></li>
+            </ul>
+
             <% if request.url.include?('/docs/agent') %>
               <% current_agent_ver = request.url[%r{agent/v(\d)}, 1] || '2' %>
 
@@ -147,8 +163,6 @@
                 <% elsif current_agent_ver == "3" %>
                   <ul class="Docs__nav__sub-nav">
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Overview", 'agent/v3' %></li>
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Installation", 'agent/v3/installation' %></li>
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Upgrading", 'agent/v3/upgrading' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Configuration", 'agent/v3/configuration' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "SSH Keys", 'agent/v3/ssh-keys' %></li>
                     <li class="Docs__nav__sub-nav__item--sub"><%= sidebar_link_to "GitHub SSH Keys", 'agent/v3/github-ssh-keys' %></li>
@@ -157,19 +171,6 @@
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Prioritization", 'agent/v3/prioritization' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Securing", 'agent/v3/securing' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Tokens", 'agent/v3/tokens' %></li>
-                  </ul>
-                  <p class="Docs__nav__section-subheading">Agent Installers</p>
-                  <ul class="Docs__nav__sub-nav">
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Ubuntu", 'agent/v3/ubuntu' %></li>
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Debian", 'agent/v3/debian' %></li>
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Red Hat/CentOS", 'agent/v3/redhat' %></li>
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "FreeBSD", 'agent/v3/freebsd' %></li>
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "macOS", 'agent/v3/osx' %></li>
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Windows", 'agent/v3/windows' %></li>
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Linux", 'agent/v3/linux' %></li>
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Docker", 'agent/v3/docker' %></li>
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "AWS", 'agent/v3/aws' %></li>
-                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Google Cloud", 'agent/v3/gcloud' %></li>
                   </ul>
                   <p class="Docs__nav__section-subheading">Command-Line Reference</p>
                   <ul class="Docs__nav__sub-nav">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -92,7 +92,6 @@
             <p class="Docs__nav__section-heading">Installation</p>
             <ul class="Docs__nav__sub-nav">
               <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Overview", 'agent/v3/installation' %></li>
-              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Upgrading", 'agent/v3/upgrading' %></li>
               <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Ubuntu Linux", 'agent/v3/ubuntu' %></li>
               <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Debian Linux", 'agent/v3/debian' %></li>
               <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Red Hat/CentOS Linux", 'agent/v3/redhat' %></li>
@@ -103,30 +102,14 @@
               <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Docker", 'agent/v3/docker' %></li>
               <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "AWS", 'agent/v3/aws' %></li>
               <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Google Cloud", 'agent/v3/gcloud' %></li>
+              <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Upgrading", 'agent/v3/upgrading' %></li>
+
             </ul>
 
             <% if request.url.include?('/docs/agent') %>
               <% current_agent_ver = request.url[%r{agent/v(\d)}, 1] || '2' %>
 
               <p class="Docs__nav__section-heading">Agent</p>
-
-              <select id="agent-version-selector" class="Docs__nav__version-selector">
-                <option value="<%= docs_page_path("agent/v3") %>" <% if current_agent_ver == "3" %>selected<% end %>>Version 3.x (Current)</option>
-                <option value="<%= docs_page_path("agent/v2") %>" <% if current_agent_ver == "2" %>selected<% end %>>Version 2.x</option>
-              </select>
-
-              <%= javascript_tag nonce: true do %>
-                (function() {
-                  var select = document.getElementById('agent-version-selector');
-                  select.addEventListener("change", function() {
-                    var agentVersionDocsURL = select.options[select.selectedIndex].value;
-
-                    if (String(window.location.pathname).indexOf(agentVersionDocsURL) == -1) {
-                      window.location = agentVersionDocsURL;
-                    }
-                  });
-                })();
-              <% end %>
 
               <% if current_agent_ver == '2' %>
                 <ul class="Docs__nav__sub-nav">
@@ -171,6 +154,8 @@
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Prioritization", 'agent/v3/prioritization' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Securing", 'agent/v3/securing' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "Tokens", 'agent/v3/tokens' %></li>
+                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "v2 Agent Docs", 'agent/v2' %></li>
+
                   </ul>
                   <p class="Docs__nav__section-subheading">Command-Line Reference</p>
                   <ul class="Docs__nav__sub-nav">

--- a/pages/agent/v2.md.erb
+++ b/pages/agent/v2.md.erb
@@ -5,6 +5,8 @@
   <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3">see the latest version of this document</a>.
 </section>
 
+<!-- We could turn on a v2 Menu group for agent/v2/* similar to how it works now but only when visiting this page -->
+
 <!--alex ignore easy-->
 
 The buildkite agent is a small, reliable and cross-platform build runner that makes it easy to run automated builds on your own infrastructure. Its main responsibilities are polling buildkite.com for work, running build jobs, reporting back the status code and output log of the job, and uploading the job's artifacts.

--- a/pages/agent/v3/installation.md.erb
+++ b/pages/agent/v3/installation.md.erb
@@ -2,6 +2,8 @@
 
 The Buildkite Agent runs on your own machine, whether it's a VPS, server, desktop computer, embedded device. There are installers for:
 
+<!-- We need to single-source this list so it matches the one in the menu -->
+
 * [Ubuntu](ubuntu)
 * [Debian](debian)
 * [CentOS/Redhat](redhat)

--- a/pages/agent/v3/upgrading.md.erb
+++ b/pages/agent/v3/upgrading.md.erb
@@ -1,10 +1,23 @@
-# Upgrading to Buildkite Agent v3
+# Upgrading your Buildkite Agents
 
-The Buildkite Agent has changed a lot in v3, but we've tried to keep it as backwards compatible as possible. We'll cover what’s changed and how to upgrade to new agents.
+Upgrade your Agents using your operating system package manager, or by re-running the installation script.
 
 {:toc}
 
-## Overview of what has changed
+## Upgrading Agents on Ubuntu Linux
+
+<%= render_markdown 'agent/v3/apt_upgrading' %>
+
+## Upgrading Agents on Debian Linux
+
+<%= render_markdown 'agent/v3/apt_upgrading' %>
+
+## Upgrading to Buildkite Agent v3
+
+The Buildkite Agent has changed a lot in v3, but we've tried to keep it as backwards compatible as possible. We'll cover what’s changed and how to upgrade to new agents.
+
+
+### Overview of what has changed
 
 Added:
 
@@ -24,17 +37,17 @@ Deprecated:
 
 * Built-in [Docker and Docker Compose support](/docs/tutorials/docker-containerized-builds) has been deprecated. The same functionality is available from the dedicated plugins: [docker-compose](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin) and [docker](https://github.com/buildkite-plugins/docker-buildkite-plugin).
 
-## Bootstrap customizations
+### Bootstrap customizations
 
 If you customized your `bootstrap.sh` file, you will need to move the changes to [hooks](hooks), or update your bootstrap.sh to call `buildkite-agent bootstrap`.
 
-## Docker and Docker Compose support
+### Docker and Docker Compose support
 
 In v2 we supported a variety of environment variables like `BUILDKITE_DOCKER_COMPOSE_CONTAINER` and `BUILDKITE_DOCKER`. These are deprecated in favour of the [docker-compose](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin) and [docker](https://github.com/buildkite-plugins/docker-buildkite-plugin) pipeline plugin.
 
 You can keep using the old environment variables in v3, but they will be removed in v4.
 
-### Steps using `BUILDKITE_DOCKER_COMPOSE_CONTAINER`
+#### Steps using `BUILDKITE_DOCKER_COMPOSE_CONTAINER`
 
 This is a step that uses the v2 `BUILDKITE_DOCKER_COMPOSE_CONTAINER` environment variable to run the command in a docker-compose container:
 
@@ -57,7 +70,7 @@ steps:
           run: app
 ```
 
-### Steps using `BUILDKITE_DOCKER`
+#### Steps using `BUILDKITE_DOCKER`
 
 This is a step that uses the v2 `BUILDKITE_DOCKER` environment variable to run the command in docker container:
 
@@ -81,23 +94,23 @@ steps:
           workdir: /app
 ```
 
-## Environment variables in your pipeline.yml
+### Environment variables in your pipeline.yml
 
 Previously we didn't support environment variable interpolation, such as `${MY_VARIABLE_NAME}` or `$MY_VARIABLE_NAME`. If you have any of these in your `pipeline.yml`, they will now be interpolated. To render the literal text, you will need to escape the dollar signs, for example `$$MY_VARIABLE_NAME`.
 
 See the [environment variable substitution](/docs/agent/v3/cli-pipeline#environment-variable-substitution) for more details.
 
-## Checkout clean no longer ignores files in `.gitignore`
+### Checkout clean no longer ignores files in `.gitignore`
 
 Older agents didn't remove files from your working directory that were ignored by git. The new default values for git clean are `-fxdq`. If you've previously overridden your `git-clean-flags` in your config, it might be a good chance to comment them out and use the standard behavior.
 
-## Upgrading from a 2.0 agent
+### Upgrading from a 2.0 agent
 
 To upgrade, install the new 3.0 agent using one of the [standard installation methods](installation). To make installation easier, there are packages for each of the major operating systems.
 
 You can test your updated agents in parallel to your existing agents by using agent tags to create a new queue for 3.0 builds.
 
-## Upgrading from 3.0-beta to a stable 3.0 agent
+### Upgrading from 3.0-beta to a stable 3.0 agent
 
 To upgrade a _Ubuntu / Debian_ 3.0 beta agent:
 


### PR DESCRIPTION
I started looking at getting rid of the "Upgrade from 2 to 3" docs, and then started thinking about promoting the installer sections out of Agent (note the formatting is off due to the JS path detection) 

![image](https://user-images.githubusercontent.com/95874/85413939-c20d4880-b56b-11ea-9788-d85c9b85ce45.png)

I think we could go further and remove the v2/v3 selector from prime page real estate, and just leave a tiny 2 page with links in the menu, untill we can deprecate v2 altogether. 

![image](https://user-images.githubusercontent.com/95874/85414576-9048b180-b56c-11ea-923c-7104509f7f0b.png)

Slight caveat around removing the selector code if we're in any danger of introducing a v4

This work isn't actually done, I'm just looking at low effort ways of streamlining the navigation. 
