### PR TITLE
Add draft content for Command step type

### DIFF
--- a/app/views/quick_reference/pipelines.json.erb
+++ b/app/views/quick_reference/pipelines.json.erb
@@ -14,6 +14,74 @@
             "name": "command",
             "isRequired": true,
             "textContent": <%= render_attribute_content "steps/command/command" %>
+          },
+          {
+            "name": "agents",
+            "textContent": <%= render_attribute_content "steps/command/agents" %>
+          },
+          {
+            "name": "allow_dependency_failure",
+            "textContent": <%= render_attribute_content "steps/command/allow_dependency_failure" %>
+          },
+          {
+            "name": "artifact_paths",
+            "textContent": <%= render_attribute_content "steps/command/artifact_paths" %>
+          },
+          {
+            "name": "branches",
+            "textContent": <%= render_attribute_content "steps/command/branches" %>
+          },
+          {
+            "name": "concurrency",
+            "textContent": <%= render_attribute_content "steps/command/concurrency" %>
+          },
+          {
+            "name": "concurrency_group",
+            "textContent": <%= render_attribute_content "steps/command/concurrency_group" %>
+          },
+          {
+            "name": "depends_on",
+            "textContent": <%= render_attribute_content "steps/command/depends_on" %>
+          },
+          {
+            "name": "env",
+            "textContent": <%= render_attribute_content "steps/command/env" %>
+          },
+          {
+            "name": "if",
+            "textContent": <%= render_attribute_content "steps/command/if" %>
+          },
+          {
+            "name": "key",
+            "textContent": <%= render_attribute_content "steps/command/key" %>
+          },
+          {
+            "name": "label",
+            "textContent": <%= render_attribute_content "steps/command/label" %>
+          },
+          {
+            "name": "parallelism",
+            "textContent": <%= render_attribute_content "steps/command/parallelism" %>
+          },
+          {
+            "name": "plugins",
+            "textContent": <%= render_attribute_content "steps/command/plugins" %>
+          },
+          {
+            "name": "retry",
+            "textContent": <%= render_attribute_content "steps/command/retry" %>
+          },
+          {
+            "name": "skip",
+            "textContent": <%= render_attribute_content "steps/command/skip" %>
+          },
+          {
+            "name": "soft_fail",
+            "textContent": <%= render_attribute_content "steps/command/soft_fail" %>
+          },
+          {
+            "name": "timeout_in_minutes",
+            "textContent": <%= render_attribute_content "steps/command/timeout_in_minutes" %>
           }
         ]
       }

--- a/app/views/quick_reference/steps/_command.md.erb
+++ b/app/views/quick_reference/steps/_command.md.erb
@@ -1,3 +1,1 @@
-# Command
-
-This is the markdown content for the "command" step.
+Run one or more shell commands on an agent

--- a/app/views/quick_reference/steps/command/_agents.md.erb
+++ b/app/views/quick_reference/steps/command/_agents.md.erb
@@ -1,0 +1,7 @@
+### agents
+
+A map of [agent tag](https://buildkite.com/docs/agent/v3/cli-start#setting-tags) keys to values to [target specific agents](https://buildkite.com/docs/agent/v3/cli-start#agent-targeting) for this step. 
+
+```yaml
+npm: "true"
+```

--- a/app/views/quick_reference/steps/command/_agents.md.erb
+++ b/app/views/quick_reference/steps/command/_agents.md.erb
@@ -1,5 +1,3 @@
-### agents
-
 A map of [agent tag](https://buildkite.com/docs/agent/v3/cli-start#setting-tags) keys to values to [target specific agents](https://buildkite.com/docs/agent/v3/cli-start#agent-targeting) for this step. 
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_allow_dependency_failure.md.erb
+++ b/app/views/quick_reference/steps/command/_allow_dependency_failure.md.erb
@@ -1,5 +1,3 @@
-### allow_dependency_failure
-
 Whether to continue to run this step if any of the steps named in the <code>depends_on</code> attribute fail.  (Default: `false`)
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_allow_dependency_failure.md.erb
+++ b/app/views/quick_reference/steps/command/_allow_dependency_failure.md.erb
@@ -1,0 +1,7 @@
+### allow_dependency_failure
+
+Whether to continue to run this step if any of the steps named in the <code>depends_on</code> attribute fail.  (Default: `false`)
+
+```yaml
+allow_dependency_failure: true
+```

--- a/app/views/quick_reference/steps/command/_artifact_paths.md.erb
+++ b/app/views/quick_reference/steps/command/_artifact_paths.md.erb
@@ -1,0 +1,14 @@
+### artifact_paths
+
+The [glob path](https://buildkite.com/docs/agent/v3/cli-artifact#uploading-artifacts) or paths of [artifacts](https://buildkite.com/docs/agent/v3/cli-artifact) to upload from this step. This can be a single line of paths separated by semicolons, or a list.
+
+```yaml
+- artifact_paths
+  - "logs/**/*;coverage/**/*"
+```
+
+```yaml
+- artifact_paths
+  - "logs/**/*"
+  - "coverage/**/*"
+```

--- a/app/views/quick_reference/steps/command/_artifact_paths.md.erb
+++ b/app/views/quick_reference/steps/command/_artifact_paths.md.erb
@@ -1,5 +1,3 @@
-### artifact_paths
-
 The [glob path](https://buildkite.com/docs/agent/v3/cli-artifact#uploading-artifacts) or paths of [artifacts](https://buildkite.com/docs/agent/v3/cli-artifact) to upload from this step. This can be a single line of paths separated by semicolons, or a list.
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_branches.md.erb
+++ b/app/views/quick_reference/steps/command/_branches.md.erb
@@ -1,5 +1,3 @@
-### branches
-
 The [branch pattern](https://buildkite.com/docs/pipelines/branch-configuration#branch-pattern-examples) defining which branches will include this step in their builds.
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_branches.md.erb
+++ b/app/views/quick_reference/steps/command/_branches.md.erb
@@ -1,0 +1,8 @@
+### branches
+
+The [branch pattern](https://buildkite.com/docs/pipelines/branch-configuration#branch-pattern-examples) defining which branches will include this step in their builds.
+
+```yaml
+- branches
+  - "master stable/*"
+```

--- a/app/views/quick_reference/steps/command/_command.md.erb
+++ b/app/views/quick_reference/steps/command/_command.md.erb
@@ -1,3 +1,11 @@
-# Command
+### command
 
-This is the markdown content for the "command" attribute.
+The shell command/s to run during this step. This can be a single line of commands, or a list of commands that must all pass. Also available as the alias `commands`.
+
+```yaml
+steps:
+  - commands:
+    - "npm install && npm test"
+    - "moretests.sh"
+    - "build.sh"
+```

--- a/app/views/quick_reference/steps/command/_command.md.erb
+++ b/app/views/quick_reference/steps/command/_command.md.erb
@@ -1,5 +1,3 @@
-### command
-
 The shell command/s to run during this step. This can be a single line of commands, or a list of commands that must all pass. Also available as the alias `commands`.
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_concurrency.md.erb
+++ b/app/views/quick_reference/steps/command/_concurrency.md.erb
@@ -1,5 +1,3 @@
-### command
-
 The **maximum number of jobs** created from this step that are allowed to run at the same time. If you use this attribute, you must also define a label for it with the <code>concurrency_group</code> attribute.
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_concurrency.md.erb
+++ b/app/views/quick_reference/steps/command/_concurrency.md.erb
@@ -1,0 +1,8 @@
+### command
+
+The **maximum number of jobs** created from this step that are allowed to run at the same time. If you use this attribute, you must also define a label for it with the <code>concurrency_group</code> attribute.
+
+```yaml
+concurrency: 3
+```
+

--- a/app/views/quick_reference/steps/command/_concurrency_group.md.erb
+++ b/app/views/quick_reference/steps/command/_concurrency_group.md.erb
@@ -1,0 +1,7 @@
+### concurrency_group
+
+A unique name for the concurrency group that you are creating with the <code>concurrency</code> attribute.
+
+```yaml
+concurrency_group: 'our-payment-gateway/deploy'
+```

--- a/app/views/quick_reference/steps/command/_concurrency_group.md.erb
+++ b/app/views/quick_reference/steps/command/_concurrency_group.md.erb
@@ -1,5 +1,3 @@
-### concurrency_group
-
 A unique name for the concurrency group that you are creating with the <code>concurrency</code> attribute.
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_depends_on.md.erb
+++ b/app/views/quick_reference/steps/command/_depends_on.md.erb
@@ -1,5 +1,3 @@
-### depends_on
-
 A list of step keys that this step depends on. This step will only run after the named steps have completed. See managing step dependencies for more information.
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_depends_on.md.erb
+++ b/app/views/quick_reference/steps/command/_depends_on.md.erb
@@ -1,0 +1,7 @@
+### depends_on
+
+A list of step keys that this step depends on. This step will only run after the named steps have completed. See managing step dependencies for more information.
+
+```yaml
+depends_on: "text-suite"
+```

--- a/app/views/quick_reference/steps/command/_env.md.erb
+++ b/app/views/quick_reference/steps/command/_env.md.erb
@@ -1,5 +1,3 @@
-### env
-
 A map of [environment variables](https://buildkite.com/docs/pipelines/environment-variables) for this step.
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_env.md.erb
+++ b/app/views/quick_reference/steps/command/_env.md.erb
@@ -1,0 +1,7 @@
+### env
+
+A map of [environment variables](https://buildkite.com/docs/pipelines/environment-variables) for this step.
+
+```yaml
+RAILS_ENV: "test"
+```

--- a/app/views/quick_reference/steps/command/_if.md.erb
+++ b/app/views/quick_reference/steps/command/_if.md.erb
@@ -1,0 +1,7 @@
+### if
+
+A boolean expression that omits the step when false. See [Using conditionals](https://buildkite.com/docs/pipelines/conditionals) for supported expressions.
+
+```yaml
+if: build.message != "skip me"
+```

--- a/app/views/quick_reference/steps/command/_if.md.erb
+++ b/app/views/quick_reference/steps/command/_if.md.erb
@@ -1,5 +1,3 @@
-### if
-
 A boolean expression that omits the step when false. See [Using conditionals](https://buildkite.com/docs/pipelines/conditionals) for supported expressions.
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_key.md.erb
+++ b/app/views/quick_reference/steps/command/_key.md.erb
@@ -1,0 +1,5 @@
+### key
+
+A unique string to identify the step. The value is available in the `BUILDKITE_STEP_KEY` environment variable. Also available as the alias `identifier`.
+
+Keys can not have the same pattern as a UUID (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`).

--- a/app/views/quick_reference/steps/command/_key.md.erb
+++ b/app/views/quick_reference/steps/command/_key.md.erb
@@ -1,5 +1,3 @@
-### key
-
 A unique string to identify the step. The value is available in the `BUILDKITE_STEP_KEY` environment variable. Also available as the alias `identifier`.
 
 Keys can not have the same pattern as a UUID (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`).

--- a/app/views/quick_reference/steps/command/_label.md.erb
+++ b/app/views/quick_reference/steps/command/_label.md.erb
@@ -1,5 +1,3 @@
-### label
-
 The label that will be displayed in the pipeline visualisation in Buildkite. Supports emoji.
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_label.md.erb
+++ b/app/views/quick_reference/steps/command/_label.md.erb
@@ -1,0 +1,7 @@
+### label
+
+The label that will be displayed in the pipeline visualisation in Buildkite. Supports emoji.
+
+```yaml
+label: ":hammer: Tests"
+```

--- a/app/views/quick_reference/steps/command/_parallelism.md.erb
+++ b/app/views/quick_reference/steps/command/_parallelism.md.erb
@@ -1,5 +1,3 @@
-### parallelism
-
 The number of [parallel jobs](https://buildkite.com/docs/tutorials/parallel-builds#parallel-jobs) that will be created based on this step. 
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_parallelism.md.erb
+++ b/app/views/quick_reference/steps/command/_parallelism.md.erb
@@ -1,0 +1,7 @@
+### parallelism
+
+The number of [parallel jobs](https://buildkite.com/docs/tutorials/parallel-builds#parallel-jobs) that will be created based on this step. 
+
+```yaml
+parallelism: 3
+```

--- a/app/views/quick_reference/steps/command/_plugins.md.erb
+++ b/app/views/quick_reference/steps/command/_plugins.md.erb
@@ -1,0 +1,8 @@
+### plugins
+
+An array of [plugins](https://buildkite.com/docs/plugins) for this step.
+
+```yaml
+- docker-compose#v1.0.0:
+    run: app
+```

--- a/app/views/quick_reference/steps/command/_plugins.md.erb
+++ b/app/views/quick_reference/steps/command/_plugins.md.erb
@@ -1,5 +1,3 @@
-### plugins
-
 An array of [plugins](https://buildkite.com/docs/plugins) for this step.
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_retry.md.erb
+++ b/app/views/quick_reference/steps/command/_retry.md.erb
@@ -1,0 +1,12 @@
+### retry
+
+The conditions for retrying this step.  
+
+```yaml
+retry: automatic
+```
+
+```yaml
+retry: manual
+```
+

--- a/app/views/quick_reference/steps/command/_retry.md.erb
+++ b/app/views/quick_reference/steps/command/_retry.md.erb
@@ -1,5 +1,3 @@
-### retry
-
 The conditions for retrying this step.  
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_skip.md.erb
+++ b/app/views/quick_reference/steps/command/_skip.md.erb
@@ -1,5 +1,3 @@
-### skip
-
 Whether to skip this step or not. Passing a string provides a reason for skipping this command. Passing an empty string is equivalent to `false`. Note: Skipped steps will be hidden in the pipeline view by default, but can be made visible by toggling the 'Skipped jobs' icon.
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_skip.md.erb
+++ b/app/views/quick_reference/steps/command/_skip.md.erb
@@ -1,0 +1,15 @@
+### skip
+
+Whether to skip this step or not. Passing a string provides a reason for skipping this command. Passing an empty string is equivalent to `false`. Note: Skipped steps will be hidden in the pipeline view by default, but can be made visible by toggling the 'Skipped jobs' icon.
+
+```yaml
+skip: false
+```
+
+```yaml
+skip: true
+```
+
+```yaml
+skip: "Reason for skipping"
+```

--- a/app/views/quick_reference/steps/command/_soft_fail.md.erb
+++ b/app/views/quick_reference/steps/command/_soft_fail.md.erb
@@ -1,5 +1,3 @@
-### soft_fail
-
 Whether this step should cause the build to fail if it exits with a non-zero status. Can be either an array of soft failure exit statuses or true to make all exit statuses soft-fail.  
 
 ```yaml

--- a/app/views/quick_reference/steps/command/_soft_fail.md.erb
+++ b/app/views/quick_reference/steps/command/_soft_fail.md.erb
@@ -1,0 +1,13 @@
+### soft_fail
+
+Whether this step should cause the build to fail if it exits with a non-zero status. Can be either an array of soft failure exit statuses or true to make all exit statuses soft-fail.  
+
+```yaml
+soft_fail: true
+```
+
+```yaml
+soft_fail: 
+  - exit_status: 1
+  - exit_status: "*"
+```

--- a/app/views/quick_reference/steps/command/_timeout_in_minutes.md.erb
+++ b/app/views/quick_reference/steps/command/_timeout_in_minutes.md.erb
@@ -1,0 +1,7 @@
+### timeout_in_minutes
+
+The number of minutes a job created from this step is allowed to run. If the job does not finish within this limit, it will be automatically canceled and the build will fail.
+
+```yaml
+timeout_in_minutes: 60
+```

--- a/app/views/quick_reference/steps/command/_timeout_in_minutes.md.erb
+++ b/app/views/quick_reference/steps/command/_timeout_in_minutes.md.erb
@@ -1,5 +1,3 @@
-### timeout_in_minutes
-
 The number of minutes a job created from this step is allowed to run. If the job does not finish within this limit, it will be automatically canceled and the build will fail.
 
 ```yaml


### PR DESCRIPTION
Adding more representative draft content for Command step type (mostly copied wholesale from existing docs content) to ensure there's nothing we're missing with regards to how we want to serve up and display sidebar content.