### PR TITLE
Update GraphQL Relay links

### DIFF
--- a/pages/apis/graphql_api.md.erb
+++ b/pages/apis/graphql_api.md.erb
@@ -107,12 +107,12 @@ query {
 
 ## Relay compatibility
 
-The Buildkite GraphQL API adheres to the [Relay Specification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html), which defines standards for querying [paginated collections](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections) ("Connections" and "Edges"), [identifying objects](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification) directly from the root of a query (avoiding long nested queries), and for providing [mutation input data](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#mutations).
+The Buildkite GraphQL API adheres to the [Relay Specification](https://relay.dev/docs/en/graphql-server-specification.html), which defines standards for querying [paginated collections](https://relay.dev/docs/en/graphql-server-specification.html#connections) ("Connections" and "Edges"), [identifying objects](https://relay.dev/docs/en/graphql-server-specification.html#object-identification) directly from the root of a query (avoiding long nested queries), and for providing [mutation input data](https://relay.dev/docs/en/graphql-server-specification.html#mutations).
 
 ## Learning more about GraphQL
 
 Further resources for learning more about GraphQL:
 
 * Our [Getting Started with GraphQL Queries and Mutations](https://building.buildkite.com/tutorial-getting-started-with-graphql-queries-and-mutations-11211dfe5d64) tutorial
-* [graphql.org/learn](http://graphql.org/learn/) — The Learn section of the official GraphQL website
+* [graphql.org/learn](https://graphql.org/learn/) — The Learn section of the official GraphQL website
 


### PR DESCRIPTION
The links now served by relay.dev, so 1 less page jump when people clicks 😄 