### PR TITLE
Fix inconsistencies in Plugin Tutorial

### DIFF
--- a/pages/plugins/_tutorial_readme.html
+++ b/pages/plugins/_tutorial_readme.html
@@ -11,12 +11,12 @@ steps:
   - command: ls
     plugins:
       a-github-user/file-counter#v1.0.0:
-        name: '*.md'
+        pattern: '*.md'
 ```
 
 ## Configuration
 
-### `name` (Required, string)
+### `pattern` (Required, string)
 
 The file name pattern, for example `*.ts`. Supports any pattern supported by [find -name](http://man7.org/linux/man-pages/man1/find.1.html).
 

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -43,7 +43,10 @@ configuration:
 ```
 {: codeblock-file="plugin.yml"}
 
-The `configuration` property defines the validation rules for the plugin configuration using the [JSON Schema](https://json-schema.org) format. We’ve specified that the plugin has a single `name` property, of type `string`.
+The `configuration` property defines the validation rules for the plugin configuration using the [JSON Schema](https://json-schema.org) format. We’ve specified that the plugin has a single `pattern` property, of type `string`.
+
+Configuration properties are available to the hook script as environment variables with the naming pattern `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>`.  In this case, the configured value of `pattern` will be available as `BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN`.
+
 
 ### Add a hook
 
@@ -185,7 +188,7 @@ author: https://github.com/a-github-user
 requirements: []
 configuration:
   pattern:
-    name: string
+    type: string
   additionalProperties: false
 ```
 {: codeblock-file="plugin.yml"}


### PR DESCRIPTION
👋 Hi folks, I found a couple of things in the Plugin tutorial that were not clear to me - hoping these edits make it clearer for someone else!

- The configuration example references both `name` and `pattern` properties in different places. Updates to only use the `pattern` property, the value used in the hook example.

- Adds a short description of how to access the configuration values in the hook script