### PR TITLE
Clarification of soft-fail / timeout

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -165,12 +165,11 @@ _Optional attributes:_
   <tr>
     <td><code>soft_fail</code></td>
     <td>
-      Should this step cause the build to fail if it exits with a non-zero status.
-      Can be either an array of soft failure exit statuses or <code>true</code> to make all exit statuses soft-fail.<br>
+      Allow specified non-zero exit statuses not to fail the build. Note that a timeout always causes a build to fail.
+      Can be either an array of allowed soft failure exit statuses or <code>true</code> to make all exit statuses soft-fail.<br>
       <em>Example:</em> <code>true</code><br>
       <em>Example:</em><br>
       <code>- exit_status: 1</code><br>
-      <code>- exit_status: "*"</code><br>
     </td>
   </tr>
   <tr>
@@ -321,7 +320,8 @@ _Optional Attributes_
   <tr>
     <td><code>exit_status</code></td>
     <td>
-      The exit status number that will cause this job to be soft-failed. <br>
+      Allow specified non-zero exit statuses not to fail the build.
+      Note that a timeout always causes a build to fail. <br>
       <em>Example:</em> <code>"*"</code><br>
       <em>Example:</em> <code>1</code>
     </td>


### PR DESCRIPTION
I'm not super keen on the double negative, but I think this is an improvement. 

Is the `*` the same as `true` here? Regardless, we should pick one.

Fix for #772 