### PR TITLE
Change to Command Step for consistency

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -1,4 +1,4 @@
-# Command Steps
+# Command Step
 
 A *command* step runs one or more shell commands on an agent.
 


### PR DESCRIPTION
I notice across all step types, only command steps are plural and we probably want to keep them consistent, so changed to singular command step. Also the URL is singular https://buildkite.com/docs/pipelines/command-step.



<img width="563" alt="スクリーンショット 2020-07-28 16 17 29" src="https://user-images.githubusercontent.com/1000669/88632131-246ae300-d0ee-11ea-9c03-8fb676aa7922.png">
<img width="735" alt="スクリーンショット 2020-07-28 16 17 52" src="https://user-images.githubusercontent.com/1000669/88632140-259c1000-d0ee-11ea-9aef-a8150837706a.png">
<img width="754" alt="スクリーンショット 2020-07-28 16 17 46" src="https://user-images.githubusercontent.com/1000669/88632144-26cd3d00-d0ee-11ea-9618-00ea3c7609fe.png">
<img width="737" alt="スクリーンショット 2020-07-28 16 17 40" src="https://user-images.githubusercontent.com/1000669/88632147-2765d380-d0ee-11ea-8aa2-3ac1d5e10a4b.png">
<img width="717" alt="スクリーンショット 2020-07-28 16 17 36" src="https://user-images.githubusercontent.com/1000669/88632150-27fe6a00-d0ee-11ea-8026-5693943f9583.png">
