### PR TITLE
Bugsnag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Choo choo 🚝 (only include the Rails gems we need)
 gem "actionpack"
@@ -10,45 +10,45 @@ gem "railties"
 gem "sprockets-rails"
 
 # Use Puma as the app server
-gem 'puma'
+gem "puma"
 
 # Use SCSS for stylesheets
-gem 'sass-rails'
+gem "sass-rails"
 
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier'
+gem "uglifier"
 
 # Helps with running the server locally
-gem 'foreman'
+gem "foreman"
 
 # For converting strings to URL friendly versions
-gem 'stringex'
+gem "stringex"
 
 # Rendering markdown
-gem 'redcarpet'
+gem "redcarpet"
 
 # Parsing markdown
-gem 'commonmarker'
+gem "commonmarker"
 
 # Syntax highlighting code
-gem 'rouge', '3.3.0'
+gem "rouge", "3.3.0"
 
 # For escaping code snippets in markdown
-gem 'escape_utils'
+gem "escape_utils"
 
 # One rails log line per request, instead of enraging quantity
-gem 'lograge'
+gem "lograge"
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  # Call "byebug" anywhere in the code to stop execution and get a debugger console
+  gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
 end
 
 group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console'
-  gem 'listen'
-  gem 'pry'
+  # Access an interactive console on exception pages or by calling `console` anywhere in the code.
+  gem "web-console"
+  gem "listen"
+  gem "pry"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem "escape_utils"
 # One rails log line per request, instead of enraging quantity
 gem "lograge"
 
+# Error reporting
+gem "bugsnag"
+
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,8 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     bindex (0.8.1)
+    bugsnag (6.15.0)
+      concurrent-ruby (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.32.2)
@@ -157,6 +159,7 @@ DEPENDENCIES
   actionpack
   actionview
   activesupport
+  bugsnag
   byebug
   capybara
   commonmarker

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,0 +1,3 @@
+Bugsnag.configure do |config|
+  config.api_key = ENV["BUGSNAG_API_KEY"]
+end

--- a/deploy/task-definition-template.json
+++ b/deploy/task-definition-template.json
@@ -53,6 +53,10 @@
         {
           "name": "ALGOLIA_INDEX_NAME",
           "valueFrom": "/ecs/docs/ALGOLIA_INDEX_NAME"
+        },
+        {
+          "name": "BUGSNAG_API_KEY",
+          "valueFrom": "/ecs/docs/BUGSNAG_API_KEY"
         }
       ],
       "logConfiguration": {


### PR DESCRIPTION
Adds Bugsnag for error tracking. The SSM parameter for `BUGSNAG_API_KEY` is already in place, with an appropriate project setup in Bugsnag: https://app.bugsnag.com/buildkite/buildkite-docs/errors