### PR TITLE
Typo: pipeline.yaml -> pipeline.yml

### DIFF
--- a/pages/pipelines/defining_steps.md.erb
+++ b/pages/pipelines/defining_steps.md.erb
@@ -179,7 +179,7 @@ To use this script, you'd save it to `.buildkite/pipeline.sh` inside your reposi
 
 When the build is run it will execute the script and pipe the output to the `pipeline upload` command. The upload command will insert the steps from the script into the build immediately after the upload step.
 
-In the below `pipeline.yaml` example, when the build runs it will execute the `.buildkite/pipeline.sh` script, then the test steps from the script will be added to the build before the wait step and command step. After the test steps have run, the wait and command step will run.
+In the below `pipeline.yml` example, when the build runs it will execute the `.buildkite/pipeline.sh` script, then the test steps from the script will be added to the build before the wait step and command step. After the test steps have run, the wait and command step will run.
 
 ```bash
 steps:


### PR DESCRIPTION
Better to be consistent with the rest of the page.