### PR TITLE
Typo: <file> -> [<file>]

### DIFF
--- a/pages/agent/v3/help/_pipeline_upload.txt
+++ b/pages/agent/v3/help/_pipeline_upload.txt
@@ -1,6 +1,6 @@
 Usage:
 
-   buildkite-agent pipeline upload <file> [arguments...]
+   buildkite-agent pipeline upload [<file>] [arguments...]
 
 Description:
 


### PR DESCRIPTION
`<file>` is an optional parameter and, as such, should be enclosed in square brackets.