### PR TITLE
Add `skip` key to Trigger step docs

### DIFF
--- a/pages/pipelines/trigger_step.md.erb
+++ b/pages/pipelines/trigger_step.md.erb
@@ -129,6 +129,16 @@ _Optional_ `build` _attributes:_
     </td>
   </tr>
   <tr>
+    <td><code>skip</code></td>
+    <td>
+      Whether to skip this step or not. Passing a string provides a reason for skipping this command. Passing an empty string is equivalent to <code>false</code>.
+      Note: Skipped steps will be hidden in the pipeline view by default, but can be made visible by toggling the 'Skipped jobs' icon.<br>
+      <em>Example:</em> <code>true</code><br>
+      <em>Example:</em> <code>false</code><br>
+      <em>Example:</em> <code>"My reason"</code>
+    </td>
+  </tr>
+  <tr>
     <td><code>env</code></td>
     <td>
       A map of <a href="/docs/pipelines/environment-variables">environment variables</a> for the build.<br>


### PR DESCRIPTION
The trigger step supports the `skip` key but it’s not documented.