### PR TITLE
Update pipeline update to reflect recent changes.

### DIFF
--- a/pages/apis/rest_api/pipelines.md.erb
+++ b/pages/apis/rest_api/pipelines.md.erb
@@ -396,14 +396,14 @@ Error responses:
 Updates one or more properties of an existing pipeline:
 
 <div class="Docs__troubleshooting-note">
-<p>To update a pipeline's YAML steps, you can use the cconfiguration value as shown below.</p>
+<p>To update a pipeline's YAML steps, you can use the cconfiguration value as shown.</p>
 </div>
 
 ```bash
 curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{slug}" \
   -d '{
     "repository": "git@github.com:acme-inc/new-repo.git",
-    "configuration": "steps:\n  - command: \"new.sh\"\n"
+    "configuration": "steps:\n  - command: \"new.sh\"\n    agents:\n    - \"myqueue=true\""
   }'
 ```
 
@@ -449,7 +449,7 @@ curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{
       "env": {},
       "timeout_in_minutes": null,
       "agent_query_rules": [
-        "something=true"
+        "myqueue=true"
       ],
       "concurrency": null,
       "parallelism": null

--- a/pages/apis/rest_api/pipelines.md.erb
+++ b/pages/apis/rest_api/pipelines.md.erb
@@ -395,10 +395,15 @@ Error responses:
 
 Updates one or more properties of an existing pipeline:
 
+<div class="Docs__troubleshooting-note">
+<p>To update a pipeline's YAML steps, you can use the cconfiguration value as shown below.</p>
+</div>
+
 ```bash
 curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{slug}" \
   -d '{
-    "repository": "git@github.com:acme-inc/new-repo.git"
+    "repository": "git@github.com:acme-inc/new-repo.git",
+    "configuration": "steps:\n  - command: \"new.sh\"\n"
   }'
 ```
 
@@ -433,16 +438,21 @@ curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{
   "builds_url": "https://api.buildkite.com/v2/organizations/acme-inc/pipelines/my-pipeline/builds",
   "badge_url": "https://badge.buildkite.com/58b3da999635d0ad2daae5f784e56d264343eb02526f129bfb.svg",
   "created_at": "2015-03-01 06:44:40 UTC",
+  "configuration": "steps:\n  - command: \"new.sh\"\n    agents:\n    - \"something=true\"",
   "steps": [
     {
       "type": "script",
-      "name": "Build \:package\:",
-      "command": "script/release.sh",
-      "artifact_paths": "pkg/*",
+      "name": null,
+      "command": "new.sh",
+      "artifact_paths": null,
       "branch_configuration": null,
-      "env": { },
+      "env": {},
       "timeout_in_minutes": null,
-      "agent_query_rules": [ ]
+      "agent_query_rules": [
+        "something=true"
+      ],
+      "concurrency": null,
+      "parallelism": null
     }
   ],
   "env": {

--- a/pages/apis/rest_api/pipelines.md.erb
+++ b/pages/apis/rest_api/pipelines.md.erb
@@ -396,7 +396,7 @@ Error responses:
 Updates one or more properties of an existing pipeline:
 
 <div class="Docs__troubleshooting-note">
-<p>To update a pipeline's YAML steps, you can use the cconfiguration value as shown.</p>
+<p>To update a pipeline's YAML steps, you can use the configuration value as shown.</p>
 </div>
 
 ```bash


### PR DESCRIPTION
We made some changes here to allow the `configuration` value to be used to set the steps in the pipeline update patch, these are just some small changes to make that a little clearer, we could possibly do an overhaul of all accept values here long term.

Changes:

Adds configuration and tip

<img width="895" alt="Screen Shot 2020-08-26 at 2 04 37 pm" src="https://user-images.githubusercontent.com/585588/91255918-2be0e300-e7a5-11ea-870e-60dea0d76f4b.png">

Updates the returned value

<img width="815" alt="Screen Shot 2020-08-26 at 2 04 55 pm" src="https://user-images.githubusercontent.com/585588/91255930-31d6c400-e7a5-11ea-82d3-c0fa1f1b1845.png">




