### PR TITLE
Homebrew install does not currently work with the token argument

### DIFF
--- a/pages/agent/v2/osx.md.erb
+++ b/pages/agent/v2/osx.md.erb
@@ -15,7 +15,7 @@ If you have <a href="http://brew.sh/">Homebrew</a> installed you can use our <a 
 
 ```shell
 brew tap buildkite/buildkite
-brew install --token='INSERT-YOUR-AGENT-TOKEN-HERE' buildkite-agent
+brew install buildkite-agent
 ```
 
 If you don't use Homebrew you should follow the [Linux](/docs/agent/v2/linux) install instructions.

--- a/pages/agent/v3/install/_osx.md.erb
+++ b/pages/agent/v3/install/_osx.md.erb
@@ -2,7 +2,7 @@ If you have <a href="http://brew.sh/">Homebrew</a> installed you can use our <a 
 
 ```shell
 brew tap buildkite/buildkite
-brew install --token='INSERT-YOUR-AGENT-TOKEN-HERE' buildkite-agent
+brew install buildkite-agent
 ```
 
 If you don't use Homebrew you should follow the [Linux](/docs/agent/v3/linux) install instructions.

--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -10,7 +10,7 @@ If you have <a href="http://brew.sh/">Homebrew</a> installed you can use our <a 
 
 ```shell
 brew tap buildkite/buildkite
-brew install --token='INSERT-YOUR-AGENT-TOKEN-HERE' buildkite-agent
+brew install buildkite-agent
 ```
 
 If you don't use Homebrew you should follow the [Linux](/docs/agent/v3/linux) install instructions.


### PR DESCRIPTION
We have an issue raised in the agent https://github.com/buildkite/agent/issues/1284 around a bug with installing using brew and the config not storing the token value. From initial investigations it does not look like this is something that is going to work with changes to homebrew so this PR removes those references.

