### PR TITLE
API/Webhook authentication clarification

### DIFF
--- a/pages/apis.md.erb
+++ b/pages/apis.md.erb
@@ -2,7 +2,7 @@
 
 ## Authentication
 
-The Buildkite REST and GraphQL APIs expect the authentication token to be provided via the `Authorization` HTTP header:
+The Buildkite REST and GraphQL APIs expect an access token to be provided via the `Authorization` HTTP header:
 
 ```bash
 curl -H "Authorization: Bearer $TOKEN" https://api.buildkite.com/v2/user

--- a/pages/apis.md.erb
+++ b/pages/apis.md.erb
@@ -8,11 +8,7 @@ The Buildkite REST and GraphQL APIs expect an access token to be provided via th
 curl -H "Authorization: Bearer $TOKEN" https://api.buildkite.com/v2/user
 ```
 
-All Webhooks contain the `X-Buildkite-Token` which allows you to verify the authenticity of the request.
-
-```yaml
-Example: 309c9c842d8565adec5d7469160059f9
-```
+All webhooks contain an [`X-Buildkite-Token` header](/docs/apis/webhooks#http-headers) which allows you to verify the authenticity of the request.
 
 Generate an [Access Token](https://buildkite.com/user/api-access-tokens).
 

--- a/pages/apis.md.erb
+++ b/pages/apis.md.erb
@@ -8,9 +8,9 @@ The Buildkite REST and GraphQL APIs expect an access token to be provided via th
 curl -H "Authorization: Bearer $TOKEN" https://api.buildkite.com/v2/user
 ```
 
-All webhooks contain an [`X-Buildkite-Token` header](/docs/apis/webhooks#http-headers) which allows you to verify the authenticity of the request.
-
 Generate an [Access Token](https://buildkite.com/user/api-access-tokens).
+
+All webhooks contain an [`X-Buildkite-Token` header](/docs/apis/webhooks#http-headers) which allows you to verify the authenticity of the request.
 
 ## REST API
 


### PR DESCRIPTION
I found the opening of [this page](https://buildkite.com/docs/apis) a little confusing after re-reading it today:

<img width="906" alt="Screen Shot 2020-09-15 at 6 24 07 pm" src="https://user-images.githubusercontent.com/14028/93186718-4b56a480-f782-11ea-8ca7-15f06a730a60.png">

The words a little interchanged, and suggest that webhook tokens and access tokens are interrelated.

A little shuffling of words and reordering of paragraphs makes more sense, to me:

![image](https://user-images.githubusercontent.com/14028/93187360-126aff80-f783-11ea-8924-da9a4652d858.png)
