### PR TITLE
Mention include_retried_jobs works for 'Get a build', ignores value

### DIFF
--- a/pages/apis/rest_api/_builds_list_query_strings.md.erb
+++ b/pages/apis/rest_api/_builds_list_query_strings.md.erb
@@ -44,6 +44,7 @@
     <th><code>include_retried_jobs</code></th>
     <td>Include all retried job executions in each build’s jobs list. Without this parameter, you'll see only the most recently run job for each step.<p class="Docs__api-param-eg">
       <em>Example:</em> <code>?include_retried_jobs=true</code></p>
+      Note: The value of this parameter is ignored, <code>?include_retried_jobs=false</code> <em>will include</em> retried jobs.
     </td>
   </tr>
   <tr>

--- a/pages/apis/rest_api/builds.md.erb
+++ b/pages/apis/rest_api/builds.md.erb
@@ -249,6 +249,20 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
 }
 ```
 
+Optional [query string parameters](/docs/api#query-string-parameters):
+
+<table>
+<tbody>
+  <tr>
+    <th><code>include_retried_jobs</code></th>
+    <td>Include all retried job executions in each build’s jobs list. Without this parameter, you'll see only the most recently run job for each step.<p class="Docs__api-param-eg">
+      <em>Example:</em> <code>?include_retried_jobs=true</code></p>
+      Note: The value of this parameter is ignored, <code>?include_retried_jobs=false</code> <em>will include</em> retried jobs.
+    </td>
+  </tr>
+</tbody>
+</table>
+
 Required scope: `read_builds`
 
 Success response: `200 OK`


### PR DESCRIPTION
* the flag `include_retried_jobs` also works for 'Get a build'
* the value of `include_retried_jobs` is ignored, so `?include_retried_jobs=false` is interpreted as `?include_retried_jobs=true`.