### PR TITLE
Add AWS Quick Start examples

### DIFF
--- a/pages/integrations/amazon_eventbridge.md.erb
+++ b/pages/integrations/amazon_eventbridge.md.erb
@@ -119,9 +119,32 @@ exports.handler = (event, context, callback) => {
 
 AWS have published three example implementations of using Buildkite with Amazon Eventbridge:
 
-* [Build Workflows with Amazon SNS](https://aws.amazon.com/quickstart/eventbridge/buildkite-build-workflow/)
-* [Build Event Visualization with Amazon QuickSight](https://aws.amazon.com/quickstart/eventbridge/buildkite-visualization/)
-* [Build Alerts with Amazon SNS and Webhooks](https://aws.amazon.com/quickstart/eventbridge/buildkite-pipeline-alerts/)
+<a class="Docs__example-repo" href="https://aws.amazon.com/quickstart/eventbridge/buildkite-build-workflow/">
+  <span class="icon">:aws:</span>
+  <span class="detail">
+    <strong>Build Workflows with Amazon SNS</strong>
+    <span class="description">Combine EventBridge with a workflow to evaluate, store, and publish build events.</span>
+    <span class="repo">aws.amazon.com/quickstart/eventbridge/buildkite-build-workflow/</span>
+  </span>
+</a>
+
+<a class="Docs__example-repo" href="https://aws.amazon.com/quickstart/eventbridge/buildkite-visualization/">
+  <span class="icon">:aws:</span>
+  <span class="detail">
+    <strong>Build Event Visualization with Amazon QuickSight</strong>
+    <span class="description">Store and visualize build events from continuous-integration pipelines.</span>
+    <span class="repo">aws.amazon.com/quickstart/eventbridge/buildkite-visualization/</span>
+  </span>
+</a>
+
+<a class="Docs__example-repo" href="https://aws.amazon.com/quickstart/eventbridge/buildkite-pipeline-alerts/">
+  <span class="icon">:aws:</span>
+  <span class="detail">
+    <strong>Build Alerts with Amazon SNS and Webhooks</strong>
+    <span class="description">Send customized notifications when builds complete.</span>
+    <span class="repo">aws.amazon.com/quickstart/eventbridge/buildkite-pipeline-alerts/</span>
+  </span>
+</a>
 
 Each AWS Quick Start example has a corresponding GitHub repository with full example code.
 

--- a/pages/integrations/amazon_eventbridge.md.erb
+++ b/pages/integrations/amazon_eventbridge.md.erb
@@ -115,6 +115,16 @@ exports.handler = (event, context, callback) => {
 };
 ```
 
+## Official AWS Quick Start Examples
+
+AWS have published three example implementations of using Buildkite with Amazon Eventbridge:
+
+* [Build Workflows with Amazon SNS](https://aws.amazon.com/quickstart/eventbridge/buildkite-build-workflow/)
+* [Build Event Visualization with Amazon QuickSight](https://aws.amazon.com/quickstart/eventbridge/buildkite-visualization/)
+* [Build Alerts with Amazon SNS and Webhooks](https://aws.amazon.com/quickstart/eventbridge/buildkite-pipeline-alerts/)
+
+Each AWS Quick Start example has a corresponding GitHub repository with full example code.
+
 ## Example Event Payloads
 
 <h3 id="events-build-created">Build Created</h3>

--- a/vale/vocab.txt
+++ b/vale/vocab.txt
@@ -37,6 +37,7 @@ dogstatsd
 env
 eval
 Explainshell
+Eventbridge
 fff
 ffxdq
 Firewalled


### PR DESCRIPTION
AWS published a number of EventBridge example implementations which could be very useful for people building custom Buildkite event-based integrations. This adds links to all three of them.

- [x] Add the links
- [x] Perhaps we use the example repo style from https://buildkite.com/docs/plugins/tools