### PR TITLE
[AWS] Link to RH/CentOS and fix typo

### DIFF
--- a/pages/agent/v2/aws.md.erb
+++ b/pages/agent/v2/aws.md.erb
@@ -12,16 +12,17 @@ The Buildkite Agent can be run easily on AWS using our Elastic CI Stack for AWS.
 ## Install the Agent on your own AWS instance
 
 To run the agent on your own AWS instances use whichever installer matches your
-instance type. For Amazon Linux use the RH/CentOS installer.
+instance type. For Amazon Linux use the [Red Hat/CentOS installer].
 
 ## Use our pre-built Elastic CI Stack for AWS
 
 The [Elastic CI Stack for AWS][github] is a pre-built CloudFormation template
 that gives you an autoscaling Buildkite Agent cluster in your own AWS. The
-stack includes Docker, S3 and CloudWatch integration, and is suitable for
+stack includes Docker, S3 and Cloudwatch integration, and is suitable for
 parallelizing large legacy test suites, testing any Linux-based project that can run within Docker, and performing AWS ops related tasks.
 
 [Read the documentation][github] on GitHub, and launch it easily using the
 button on your organization’s Agents page.
 
    [github]: https://github.com/buildkite/elastic-ci-stack-for-aws
+   [Red Hat/CentOS installer]: /docs/agent/v2/redhat

--- a/pages/agent/v3/aws.md.erb
+++ b/pages/agent/v3/aws.md.erb
@@ -7,16 +7,17 @@ The Buildkite Agent can be run easily on AWS using our Elastic CI Stack for AWS.
 ## Install the Agent on your own AWS instance
 
 To run the agent on your own AWS instances use whichever installer matches your
-instance type. For Amazon Linux use the RH/CentOS installer.
+instance type. For Amazon Linux use the [Red Hat/CentOS installer].
 
 ## Use our pre-built Elastic CI Stack for AWS
 
 The [Elastic CI Stack for AWS][github] is a pre-built CloudFormation template
 that gives you an autoscaling Buildkite Agent cluster in your own AWS. The
-stack includes Docker, S3 and CloudWatch integration, and is suitable for
+stack includes Docker, S3 and Cloudwatch integration, and is suitable for
 parallelizing large legacy test suites, testing any Linux-based project that can run within Docker, and performing AWS ops related tasks.
 
 [Read the documentation][github] on GitHub, and launch it easily using the
 button on your organization’s Agents page.
 
    [github]: https://github.com/buildkite/elastic-ci-stack-for-aws
+   [Red Hat/CentOS installer]: /docs/agent/v3/redhat

--- a/vale/vocab.txt
+++ b/vale/vocab.txt
@@ -27,6 +27,7 @@ chatbot
 chroot
 chroots
 cli
+Cloudwatch
 composable
 config
 cpu


### PR DESCRIPTION
Came across this guide so update it a bit.

Crosslink to RH/CentOS guide and fix typo for Cloudwatch.