### PR TITLE
environment_variables.md: BUILDKITE_PULL_REQUEST may be unset

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -349,7 +349,7 @@ Default: `"false"`
 
 The number of the pull request, if this branch is a pull request. The value cannot be modified.
 
-Example: `"123"` for pull request #123, or `"false"` if not a pull request.
+Example: `"123"` for pull request #123, or `"false"` or not set at all if not a pull request.
 
 <h3 class="h3-caps">BUILDKITE_PULL_REQUEST_BASE_BRANCH</h3>
 


### PR DESCRIPTION
We have noted that BUILDKITE_PULL_REQUEST
may be not set at all when a build is triggered by a
branch push (no PR yet created).