### PR TITLE
Add job.scheduled to Job Event details docs

### DIFF
--- a/pages/apis/webhooks/job_events.md.erb
+++ b/pages/apis/webhooks/job_events.md.erb
@@ -7,6 +7,10 @@
 <table>
 <tbody>
   <tr>
+    <th><code>job.scheduled</code></th>
+    <td>A command step job has been scheduled to run on an agent</td>
+  </tr>
+  <tr>
     <th><code>job.started</code></th>
     <td>A command step job has started running on an agent</td>
   </tr>


### PR DESCRIPTION
This event is present on the overview page: https://buildkite.com/docs/apis/webhooks but not on the detail page: https://buildkite.com/docs/apis/webhooks/job-events