### PR TITLE
Safer index selection

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,5 +8,5 @@ Rails.application.load_tasks
 # Update test search index with whatever is in config/algolia.json
 
 task :update_test_index do
-   sh 'docker run -it --env-file=.env -e "CONFIG=$(cat config/algolia.json | sed "s/prod_docs/test_docs/" | jq -r tostring)" algolia/docsearch-scraper'
+   sh 'docker run -it --env-file=.env -e "CONFIG=$(jq -r \'.index_name |= "test_docs" | tostring\' config/algolia.json)" algolia/docsearch-scraper'
 end


### PR DESCRIPTION
If the sed command doesn't find a match it would push to production. :-(

The new jq command explicitly replaces the value of `index_name`, which seems better.
