### PR TITLE
Add graphql_id to example responses

### DIFF
--- a/pages/apis/rest_api/agents.md.erb
+++ b/pages/apis/rest_api/agents.md.erb
@@ -14,6 +14,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/agents"
 [
   {
     "id": "0b461f65-e7be-4c80-888a-ef11d81fd971",
+    "graphql_id": "QWdlbnQtLS1mOTBhNzliNC01YjJlLTQzNzEtYjYxZS03OTA4ZDAyNmUyN2E=",
     "url": "https://api.buildkite.com/v2/organizations/my-great-org/agents/my-agent",
     "web_url": "https://buildkite.com/organizations/buildkite/my-great-org/agents/0b461f65-e7be-4c80-888a-ef11d81fd971",
     "name": "my-agent",
@@ -32,6 +33,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/agents"
     "created_at": "2014-02-24T22:33:45.263Z",
     "job": {
       "id": "cd164055-9649-452b-8d8e-28fe67370a1e",
+      "graphql_id": "Sm9iLS0tMTQ4YWQ0MzgtM2E2My00YWIxLWIzMjItNzIxM2Y3YzJhMWFi",
       "type": "script",
       "name": "rspec",
       "agent_query_rules": ["*"],
@@ -84,6 +86,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}"
 ```json
 {
   "id": "0b461f65-e7be-4c80-888a-ef11d81fd971",
+  "graphql_id": "QWdlbnQtLS1mOTBhNzliNC01YjJlLTQzNzEtYjYxZS03OTA4ZDAyNmUyN2E=",
   "url": "https://api.buildkite.com/v2/organizations/my-great-org/agents/my-agent",
   "web_url": "https://buildkite.com/organizations/buildkite/my-great-org/agents/0b461f65-e7be-4c80-888a-ef11d81fd971",
   "name": "my-agent",
@@ -94,6 +97,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}"
   "version": "2.1.0",
   "creator": {
     "id": "2eba97bc-7cc7-427f-8feb-1008c72aa1d8",
+    "graphql_id": "VXNlci0tLThmNzFlOWI1LTczMDEtNDI4ZS1hMjQ1LWUwOWI0YzI0OWRiZg==",
     "name": "Keith Pitt",
     "email": "me@keithpitt.com",
     "avatar_url": "https://www.gravatar.com/avatar/e14f55d3f939977cecbf51b64ff6f861",
@@ -102,6 +106,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}"
   "created_at": "2015-05-09T21:05:59.874Z",
   "job": {
     "id": "cd164055-9649-452b-8d8e-28fe67370a1e",
+    "graphql_id": "Sm9iLS0tZGM5YTg5MmQtM2I5Ny00MzgyLWEzYzItNWJhZmU5M2RlZWI1",
     "type": "script",
     "name": "rspec",
     "agent_query_rules": ["*"],

--- a/pages/apis/rest_api/builds.md.erb
+++ b/pages/apis/rest_api/builds.md.erb
@@ -50,6 +50,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
 [
   {
     "id": "f62a1b4d-10f9-4790-bc1c-e2c3a0c80983",
+    "graphql_id": "QnVpbGQtLS1mYmQ2Zjk3OS0yOTRhLTQ3ZjItOTU0Ni1lNTk0M2VlMTAwNzE=",
     "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline/builds/1",
     "web_url": "https://buildkite.com/my-great-org/my-pipeline/builds/1",
     "number": 1,
@@ -70,6 +71,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
     "jobs": [
       {
         "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
+        "graphql_id": "Sm9iLS0tMTQ4YWQ0MzgtM2E2My00YWIxLWIzMjItNzIxM2Y3YzJhMWFi",
         "type": "script",
         "name": ":package:",
         "step_key": "package",
@@ -102,6 +104,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
     "pull_request": { },
     "pipeline": {
       "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
+      "graphql_id": "UGlwZWxpbmUtLS1lOTM4ZGQxYy03MDgwLTQ4ZmQtOGQyMC0yNmQ4M2E0ZjNkNDg=",
       "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline",
       "web_url": "https://buildkite.com/my-great-org/my-pipeline",
       "name": "great-pipeline",
@@ -160,6 +163,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
 ```json
 {
   "id": "f62a1b4d-10f9-4790-bc1c-e2c3a0c80983",
+  "graphql_id": "QnVpbGQtLS1mYmQ2Zjk3OS0yOTRhLTQ3ZjItOTU0Ni1lNTk0M2VlMTAwNzE=",
   "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline/builds/1",
   "web_url": "https://buildkite.com/my-great-org/my-pipeline/builds/1",
   "number": 1,
@@ -180,6 +184,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
   "jobs": [
     {
       "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
+      "graphql_id": "VXNlci0tLThmNzFlOWI1LTczMDEtNDI4ZS1hMjQ1LWUwOWI0YzI0OWRiZg==",
       "type": "script",
       "name": ":package:",
       "step_key": "package",
@@ -194,6 +199,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
       "artifact_paths": "",
       "agent": {
         "id": "0b461f65-e7be-4c80-888a-ef11d81fd971",
+        "graphql_id": "QWdlbnQtLS1mOTBhNzliNC01YjJlLTQzNzEtYjYxZS03OTA4ZDAyNmUyN2E=",
         "url": "https://api.buildkite.com/v2/organizations/my-great-org/agents/my-agent",
         "web_url": "https://buildkite.com/organizations/buildkite/my-great-org/agents/0b461f65-e7be-4c80-888a-ef11d81fd971",
         "name": "my-agent",
@@ -225,6 +231,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
   "pull_request": { },
   "pipeline": {
     "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
+    "graphql_id": "UGlwZWxpbmUtLS1lOTM4ZGQxYy03MDgwLTQ4ZmQtOGQyMC0yNmQ4M2E0ZjNkNDg=",
     "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline",
     "name": "Great Pipeline",
     "slug": "great-pipeline",
@@ -278,6 +285,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
 ```json
 {
   "id": "f62a1b4d-10f9-4790-bc1c-e2c3a0c80983",
+  "graphql_id": "QnVpbGQtLS1mYmQ2Zjk3OS0yOTRhLTQ3ZjItOTU0Ni1lNTk0M2VlMTAwNzE=",
   "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline/builds/1",
   "web_url": "https://buildkite.com/my-great-org/my-pipeline/builds/1",
   "number": 1,
@@ -312,6 +320,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
       "artifact_paths": "",
       "agent": {
         "id": "0b461f65-e7be-4c80-888a-ef11d81fd971",
+        "graphql_id": "QWdlbnQtLS1mOTBhNzliNC01YjJlLTQzNzEtYjYxZS03OTA4ZDAyNmUyN2E=",
         "url": "https://api.buildkite.com/v2/organizations/my-great-org/agents/my-agent",
         "web_url": "https://buildkite.com/organizations/buildkite/my-great-org/agents/0b461f65-e7be-4c80-888a-ef11d81fd971",
         "name": "my-agent",
@@ -321,6 +330,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
         "user_agent": "buildkite-agent/1.0.0 (linux; amd64)",
         "creator": {
           "id": "3d3c3bf0-7d58-4afe-8fe7-b3017d5504de",
+          "graphql_id": "VXNlci0tLThmNzFlOWI1LTczMDEtNDI4ZS1hMjQ1LWUwOWI0YzI0OWRiZg==",
           "name": "Keith Pitt",
           "email": "keith@buildkite.com",
           "avatar_url": "https://www.gravatar.com/avatar/e14f55d3f939977cecbf51b64ff6f861",
@@ -343,6 +353,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
   "pull_request": { },
   "pipeline": {
     "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
+    "graphql_id": "UGlwZWxpbmUtLS1lOTM4ZGQxYy03MDgwLTQ4ZmQtOGQyMC0yNmQ4M2E0ZjNkNDg=",
     "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline",
     "name": "Great Pipeline",
     "slug": "great-pipeline",
@@ -416,6 +427,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 ```json
 {
   "id": "f62a1b4d-10f9-4790-bc1c-e2c3a0c80983",
+  "graphql_id": "QnVpbGQtLS1mYmQ2Zjk3OS0yOTRhLTQ3ZjItOTU0Ni1lNTk0M2VlMTAwNzE=",
   "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline/builds/1",
   "web_url": "https://buildkite.com/my-great-org/my-pipeline/builds/1",
   "number": 1,
@@ -428,6 +440,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
   "source": "webhook",
   "creator": {
     "id": "3d3c3bf0-7d58-4afe-8fe7-b3017d5504de",
+    "graphql_id": "QnVpbGQtLS1mYmQ2Zjk3OS0yOTRhLTQ3ZjItOTU0Ni1lNTk0M2VlMTAwNzE=",
     "name": "Keith Pitt",
     "email": "keith@buildkite.com",
     "avatar_url": "https://www.gravatar.com/avatar/e14f55d3f939977cecbf51b64ff6f861",
@@ -436,6 +449,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
   "jobs": [
     {
       "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
+      "graphql_id": "Sm9iLS0tMTQ4YWQ0MzgtM2E2My00YWIxLWIzMjItNzIxM2Y3YzJhMWFi",
       "type": "script",
       "name": ":package:",
       "step_key": "package",
@@ -450,6 +464,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
       "artifact_paths": "",
       "agent": {
         "id": "0b461f65-e7be-4c80-888a-ef11d81fd971",
+        "graphql_id": "QWdlbnQtLS1mOTBhNzliNC01YjJlLTQzNzEtYjYxZS03OTA4ZDAyNmUyN2E=",
         "url": "https://api.buildkite.com/v2/organizations/my-great-org/agents/my-agent",
         "web_url": "https://buildkite.com/organizations/buildkite/my-great-org/agents/0b461f65-e7be-4c80-888a-ef11d81fd971",
         "name": "my-agent",
@@ -459,6 +474,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
         "user_agent": "buildkite-agent/1.0.0 (linux; amd64)",
         "creator": {
           "id": "3d3c3bf0-7d58-4afe-8fe7-b3017d5504de",
+          "graphql_id": "VXNlci0tLThmNzFlOWI1LTczMDEtNDI4ZS1hMjQ1LWUwOWI0YzI0OWRiZg==",
           "name": "Keith Pitt",
           "email": "keith@buildkite.com",
           "avatar_url": "https://www.gravatar.com/avatar/e14f55d3f939977cecbf51b64ff6f861",
@@ -481,6 +497,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
   "pull_request": { },
   "pipeline": {
     "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
+    "graphql_id": "UGlwZWxpbmUtLS1lOTM4ZGQxYy03MDgwLTQ4ZmQtOGQyMC0yNmQ4M2E0ZjNkNDg=",
     "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline",
     "name": "Great Pipeline",
     "slug": "great-pipeline",
@@ -528,6 +545,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 ```json
 {
   "id": "f62a1b4d-10f9-4790-bc1c-e2c3a0c80983",
+  "graphql_id": "QnVpbGQtLS1mYmQ2Zjk3OS0yOTRhLTQ3ZjItOTU0Ni1lNTk0M2VlMTAwNzE=",
   "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline/builds/1",
   "web_url": "https://buildkite.com/my-great-org/my-pipeline/builds/1",
   "number": 2,
@@ -540,6 +558,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
   "source": "api",
   "creator": {
     "id": "3d3c3bf0-7d58-4afe-8fe7-b3017d5504de",
+    "graphql_id": "VXNlci0tLThmNzFlOWI1LTczMDEtNDI4ZS1hMjQ1LWUwOWI0YzI0OWRiZg==",
     "name": "Keith Pitt",
     "email": "keith@buildkite.com",
     "avatar_url": "https://www.gravatar.com/avatar/e14f55d3f939977cecbf51b64ff6f861",
@@ -548,6 +567,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
   "jobs": [
     {
       "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
+      "graphql_id": "Sm9iLS0tMTQ4YWQ0MzgtM2E2My00YWIxLWIzMjItNzIxM2Y3YzJhMWFi",
       "type": "script",
       "name": ":package:",
       "step_key": "package",
@@ -562,6 +582,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
       "artifact_paths": "",
       "agent": {
         "id": "0b461f65-e7be-4c80-888a-ef11d81fd971",
+        "graphql_id": "QWdlbnQtLS1mOTBhNzliNC01YjJlLTQzNzEtYjYxZS03OTA4ZDAyNmUyN2E=",
         "url": "https://api.buildkite.com/v2/organizations/my-great-org/agents/my-agent",
         "web_url": "https://buildkite.com/organizations/buildkite/my-great-org/agents/0b461f65-e7be-4c80-888a-ef11d81fd971",
         "name": "my-agent",
@@ -571,6 +592,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
         "user_agent": "buildkite-agent/1.0.0 (linux; amd64)",
         "creator": {
           "id": "3d3c3bf0-7d58-4afe-8fe7-b3017d5504de",
+          "graphql_id": "VXNlci0tLThmNzFlOWI1LTczMDEtNDI4ZS1hMjQ1LWUwOWI0YzI0OWRiZg==",
           "name": "Keith Pitt",
           "email": "keith@buildkite.com",
           "avatar_url": "https://www.gravatar.com/avatar/e14f55d3f939977cecbf51b64ff6f861",
@@ -593,6 +615,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
   "pull_request": { },
   "pipeline": {
     "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
+    "graphql_id": "UGlwZWxpbmUtLS1lOTM4ZGQxYy03MDgwLTQ4ZmQtOGQyMC0yNmQ4M2E0ZjNkNDg=",
     "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/my-pipeline",
     "name": "Great Pipeline",
     "slug": "great-pipeline",

--- a/pages/apis/rest_api/jobs.md.erb
+++ b/pages/apis/rest_api/jobs.md.erb
@@ -13,6 +13,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 ```json
     {
       "id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
+      "graphql_id": "Sm9iLS0tMTQ4YWQ0MzgtM2E2My00YWIxLWIzMjItNzIxM2Y3YzJhMWFi",
       "type": "script",
       "name": ":package:",
       "step_key": "package",
@@ -70,12 +71,14 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 ```json
 {
   "id": "ded35de2-7de0-4da8-8daa-b4ce0b7f1064",
+  "graphql_id": "Sm9iLS0tZGM5YTg5MmQtM2I5Ny00MzgyLWEzYzItNWJhZmU5M2RlZWI1",
   "type": "manual",
   "label": "Deploy",
   "state": "unblocked",
   "web_url": null,
   "unblocked_by": {
     "id": "cfbb422f-2e4a-41b5-86f0-59e813b3d6e2",
+    "graphql_id": "VXNlci0tLTBmYTQzYjY2LWI5N2YtNDc0Yi04Y2YxLWIxMzQ5NWIxYjRjMQ==",
     "name": "Liam Neeson",
     "email": "liam@evilbatmanvillans.com",
     "avatar_url": "https://www.gravatar.com/avatar/e14f55d3f939977cecbf51b64ff6f861",

--- a/pages/apis/rest_api/organizations.md.erb
+++ b/pages/apis/rest_api/organizations.md.erb
@@ -14,6 +14,7 @@ curl "https://api.buildkite.com/v2/organizations"
 [
   {
     "id": "bb3125de-4dc9-44cf-ad18-65d2b71a5a34",
+    "graphql_id": "T3JnYW5pemF0aW9uLS0tOGEzMjAwOTMtMjE4OC00MmNiLWI5ZGQtNzE4NjZjZTYyYjA4",
     "url": "https://api.buildkite.com/v2/organizations/my-great-org",
     "web_url": "https://buildkite.com/my-great-org",
     "name": "My Great Org",
@@ -39,6 +40,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}"
 ```json
 {
   "id": "bb3125de-4dc9-44cf-ad18-65d2b71a5a34",
+  "graphql_id": "T3JnYW5pemF0aW9uLS0tOGEzMjAwOTMtMjE4OC00MmNiLWI5ZGQtNzE4NjZjZTYyYjA4",
   "url": "https://api.buildkite.com/v2/organizations/my-great-org",
   "web_url": "https://buildkite.com/my-great-org",
   "name": "My Great Org",

--- a/pages/apis/rest_api/pipelines.md.erb
+++ b/pages/apis/rest_api/pipelines.md.erb
@@ -14,6 +14,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines"
 [
   {
     "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
+    "graphql_id": "UGlwZWxpbmUtLS1lOTM4ZGQxYy03MDgwLTQ4ZmQtOGQyMC0yNmQ4M2E0ZjNkNDg=",
     "url": "https://api.buildkite.com/v2/organizations/acme-inc/pipelines/my-pipeline",
     "web_url": "https://buildkite.com/acme-inc/my-pipeline",
     "name": "My Pipeline",
@@ -78,6 +79,7 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{slug}"
 ```json
 {
   "id": "849411f9-9e6d-4739-a0d8-e247088e9b52",
+  "graphql_id": "UGlwZWxpbmUtLS1lOTM4ZGQxYy03MDgwLTQ4ZmQtOGQyMC0yNmQ4M2E0ZjNkNDg=",
   "url": "https://api.buildkite.com/v2/organizations/acme-inc/pipelines/my-pipeline",
   "web_url": "https://buildkite.com/acme-inc/my-pipeline",
   "name": "My Pipeline",
@@ -203,6 +205,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines" \
 ```json
 {
   "id": "14e9501c-69fe-4cda-ae07-daea9ca3afd3",
+  "graphql_id": "UGlwZWxpbmUtLS1lOTM4ZGQxYy03MDgwLTQ4ZmQtOGQyMC0yNmQ4M2E0ZjNkNDg=",
   "url": "https://api.buildkite.com/v2/organizations/acme-inc/pipelines/my-pipeline",
   "web_url": "https://buildkite.com/acme-inc/my-pipeline",
   "name": "My Pipeline",
@@ -430,6 +433,7 @@ curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{
 ```json
 {
   "id": "14e9501c-69fe-4cda-ae07-daea9ca3afd3",
+  "graphql_id": "UGlwZWxpbmUtLS1lOTM4ZGQxYy03MDgwLTQ4ZmQtOGQyMC0yNmQ4M2E0ZjNkNDg=",
   "url": "https://api.buildkite.com/v2/organizations/acme-inc/pipelines/my-pipeline",
   "web_url": "https://buildkite.com/acme-inc/my-pipeline",
   "name": "My Pipeline",

--- a/pages/apis/rest_api/user.md.erb
+++ b/pages/apis/rest_api/user.md.erb
@@ -1,6 +1,6 @@
 # User API
 
-The User API endpoint allows you to inspect details about the user account that owns the API token that is currently being used. 
+The User API endpoint allows you to inspect details about the user account that owns the API token that is currently being used.
 
 {:toc}
 
@@ -15,6 +15,7 @@ curl -H "Authorization: Bearer $BUILDKITE_TOKEN" "https://api.buildkite.com/v2/u
 ```json
 {
   "id": "abc123-4567-8910-...",
+  "graphql_id": "VXNlci0tLWU1N2ZiYTBmLWFiMTQtNGNjMC1iYjViLTY5NTc3NGZmYmZiZQ==",
   "name": "John Smith",
   "email": "john.smith@example.com",
   "avatar_url": "https://www.gravatar.com/avatar/abc123...",


### PR DESCRIPTION
The REST API now returns this `graphql_id` field for various resources to help with people migrating over to GraphQL API.