### PR TITLE
Update to match latest Okta app install instructions

### DIFF
--- a/pages/integrations/sso/okta.md.erb
+++ b/pages/integrations/sso/okta.md.erb
@@ -10,9 +10,11 @@ Log into your Okta account, and follow these steps:
 1. In the Shortcuts menu, click 'Add Applications' to search the Okta application directory
 1. Search for 'Buildkite'
 1. Click 'Add' to add the Buildkite app to your Okta account
-1. Fill out the 'General Settings' form, entering your case sensitive Buildkite organization slug as the 'Organization ID'
+1. Give your application a name in the 'General Settings' form
 1. In the Buildkite application in Okta, select the tab labelled 'Sign On'
 1. In the Sign On section 'Settings', click the 'Identity Provider Metadata' link and copy the URL for use in the next step
+1. Select the tab labelled 'Applications'
+1. Assign your user account or group to the application so that you will be able to complete a test login
 
 ### Step 2. Create an SSO Provider
 


### PR DESCRIPTION
Our Okta instructions were a bit out of data, and some folks were having trouble getting set up! I added a new Okta app to our test account to run through it again while I updated this doc, so it should be all good now.

This PR removes the mention of an org slug field and adds in a couple of points about adding your user account before testing.