### PR TITLE
Update text contrast for accessibility

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -45,7 +45,7 @@ $Docs__bp_stacked: 600px;
 
 .Docs__nav__section-subheading {
   text-transform: uppercase;
-  color: #777777;
+  color: #767676;
   font-size: 11px;
   line-height: 1.2;
   margin: 15px 0 10px 0;

--- a/app/assets/stylesheets/public/utils/_text_content.scss
+++ b/app/assets/stylesheets/public/utils/_text_content.scss
@@ -32,7 +32,7 @@
   }
   p { max-width: 37em; }
   li, p, dt, td, th {
-    > code { border: 1px solid #ddd; color: #8E8E8E; font-size: 85%; padding: .1em .25em; }
+    > code { border: 1px solid #ddd; font-size: 85%; padding: .1em .25em; }
   }
   table { font-size: #{(16/18)}rem; }
   table, tbody, tr, th, td { color: currentColor; }
@@ -49,7 +49,7 @@
 
   /* Some styles from Bass that our Markdown render outputs */
   .rounded { border-radius: 3px; }
-  .dark-gray { color: #8E8E8E; }
+  .dark-gray { color: #767676; }
   .border { border: 1px solid; }
   .border-gray { border-color: #ddd; }
 
@@ -61,7 +61,7 @@
       border-top-right-radius: 5px;
       border-bottom: none;
       font-size: 14px;
-      color: #777;
+      color: #767676;
     }
     pre {
       margin-top: 0;


### PR DESCRIPTION
Updates the colour of the inline code blocks, the sidebar subheading and any other elements using the .dark-gray class, in order to meet the 4.5:1 contrast ratio required to meet WCAG AA accessibility requirements.