### PR TITLE
Update policy connect_src for Algolia

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,7 +25,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src   :self, :unsafe_inline
 
   # allow AJAX queries against our search vendor
-  policy.connect_src "https://#{ENV['ALGOLIA_APP_ID']}-dsn.algolia.net", "https://#{ENV['ALGOLIA_APP_ID']}-dsn.algolianet.com", Posthog::URL
+  policy.connect_src "https://#{ENV['ALGOLIA_APP_ID']}-dsn.algolia.net", "https://#{ENV['ALGOLIA_APP_ID']}-*.algolianet.com", Posthog::URL
 
   # Specify URI for violation reports
   policy.report_uri "/_csp-violation-reports"


### PR DESCRIPTION
The `.com` ones are not behind dsn.

- appid-dsn.algolia.net
- appid-1.algolianet.com
- appid-2.algolianet.com
- appid-3.algolianet.com

https://www.algolia.com/doc/guides/scaling/distributed-search-network-dsn/#technical-details
