### PR TITLE
Fix incorrect use of wildcard for host source

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,7 +25,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src   :self, :unsafe_inline
 
   # allow AJAX queries against our search vendor
-  policy.connect_src "https://#{ENV['ALGOLIA_APP_ID']}-dsn.algolia.net", "https://#{ENV['ALGOLIA_APP_ID']}-*.algolianet.com", Posthog::URL
+  policy.connect_src "https://#{ENV['ALGOLIA_APP_ID']}-dsn.algolia.net", "https://#{ENV['ALGOLIA_APP_ID']}-1.algolianet.com", "https://#{ENV['ALGOLIA_APP_ID']}-2.algolianet.com", "https://#{ENV['ALGOLIA_APP_ID']}-3.algolianet.com", Posthog::URL
 
   # Specify URI for violation reports
   policy.report_uri "/_csp-violation-reports"


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src

Either use `*.algolianet.com` or be specific with each host.