### PR TITLE
[Amazon EventBridge] Fix event pattern rule

### DIFF
--- a/pages/integrations/amazon_eventbridge.md.erb
+++ b/pages/integrations/amazon_eventbridge.md.erb
@@ -50,12 +50,13 @@ For example, to only process [Build Finished](#events-build-finished) events you
 
 You can use any event property in your custom event pattern. For example, the following event pattern allows only “Build Started" and "Build Finished" events containing a particular pipeline slug:
 
+
 ```json
 {
   "detail-type": [ "Build Started", "Build Finished" ],
   "detail": {
     "pipeline": {
-      "slug": "some-pipeline"
+      "slug": [ "some-pipeline" ]
     }
   }
 }

--- a/pages/integrations/amazon_eventbridge.md.erb
+++ b/pages/integrations/amazon_eventbridge.md.erb
@@ -50,7 +50,6 @@ For example, to only process [Build Finished](#events-build-finished) events you
 
 You can use any event property in your custom event pattern. For example, the following event pattern allows only “Build Started" and "Build Finished" events containing a particular pipeline slug:
 
-
 ```json
 {
   "detail-type": [ "Build Started", "Build Finished" ],


### PR DESCRIPTION
Using the original example raised the following error in EventBridge:
`
Event pattern is not valid. Reason: "slug" must be an object or an array at [Source: (String)"{ "detail-type": [ "Build Started", "Build Finished" ], "detail": { "pipeline": { "slug": "some-pipeline" } } }"; line: 5, column: 16]
`

It turns out the correct pattern is `"pipeline": { "slug": [ "some-pipeline" ] }` according to [Event Patterns docs](https://docs.aws.amazon.com/eventbridge/latest/userguide/filtering-examples-structure.html)