### PR TITLE
Tweak agent v2 indexing

### DIFF
--- a/config/algolia.json
+++ b/config/algolia.json
@@ -4,7 +4,7 @@
     "https://buildkite.com/docs"
   ],
   "stop_urls": [
-    "/v2/"
+    "agent/v2"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
Make sure that old agent v2 posts aren't indexed. The starting `/` was preventing the match.

https://docsearch.algolia.com/docs/config-file/#stop_urls-optional