### PR TITLE
Update troubleshooting headers from h1s to h3s

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -282,7 +282,7 @@ a.Docs__example-repo {
   border-left-color: orange;
   margin-top: 2rem;
   margin-bottom: 2rem;
-  h1 {
+  h1, h3 {
     font: inherit;
     color: inherit;
     font-weight: bold;

--- a/pages/agent/v3/docker.md.erb
+++ b/pages/agent/v3/docker.md.erb
@@ -24,7 +24,7 @@ docker run -d -t --name buildkite-agent buildkite/agent:3-ubuntu start --token "
 ```
 
 <section class="Docs__troubleshooting-note">
-  <h1>Caveats for builds that need Docker access.</h1>
+  <h3>Caveats for builds that need Docker access.</h3>
   <p>If your build jobs require Docker access, and you’re passing through the Docker socket, you must ensure the build path is consistent between the Docker host and the agent container. See <a href="#allowing-builds-to-use-docker">Allowing builds to use Docker</a> for more details.</a>.
 </section>
 
@@ -115,7 +115,7 @@ docker run \
 ```
 
 <section class="Docs__troubleshooting-note">
-  <h1>Security considerations</h1>
+  <h3>Security considerations</h3>
   <p>Providing builds with a Docker socket gives them access to whatever the docker daemon has access to on the host system. Typically this is <code>root</code>, which means builds have full root system access. This can be mitigated somewhat with <a href="https://docs.docker.com/engine/security/userns-remap/">user namespace remapping</a>, but caution should still be exercised.</p>
 </section>
 

--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -78,7 +78,7 @@ tail -f ~/.buildkite-agent/log/buildkite-agent.log
 ```
 
 <section class="Docs__troubleshooting-note">
-  <h1>Troubleshooting: <code>launchctl</code> fails with "Could not find domain for"</h1>
+  <h3>Troubleshooting: <code>launchctl</code> fails with "Could not find domain for"</h3>
   <p>Ensure that you have a user logged in to the macOS host, then re-run:<br><code>launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist</code></p>
 </section>
 

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -37,8 +37,8 @@ To disable command line evaluation use one of the following settings:
 * Configuration setting: `no-command-eval=true`
 
 <div class="Docs__troubleshooting-note">
-<h1>Custom hooks</h1>
-<p>If you have a custom 'command' hook, using <code>no-command-eval</code> will have no effect on your command execution. See <a href="#allowing-a-list-of-plugins">Allowing a List of Plugins</a> and <a href="#customizing-the-bootstrap">Custom bootstrap scripts</a> for examples of how to completely lock down your agent from arbitrary code execution.</p>
+  <h3>Custom hooks</h3>
+  <p>If you have a custom 'command' hook, using <code>no-command-eval</code> will have no effect on your command execution. See <a href="#allowing-a-list-of-plugins">Allowing a List of Plugins</a> and <a href="#customizing-the-bootstrap">Custom bootstrap scripts</a> for examples of how to completely lock down your agent from arbitrary code execution.</p>
 </div>
 
 ## Disabling plugins

--- a/pages/apis/rest_api.md.erb
+++ b/pages/apis/rest_api.md.erb
@@ -54,7 +54,7 @@ curl -H "Authorization: Bearer $TOKEN" https://api.buildkite.com/v2/user
 ```
 
 <section class="Docs__troubleshooting-note">
-  <h1>Basic Authentication</h1>
+  <h3>Basic Authentication</h3>
   <p>Access using basic authentication is no longer available.</p>
 </section>
 

--- a/pages/apis/rest_api/artifacts.md.erb
+++ b/pages/apis/rest_api/artifacts.md.erb
@@ -23,7 +23,7 @@ An artifact is a file uploaded by your agent during the execution of a build’s
 </table>
 
 <section class="Docs__troubleshooting-note">
-  <h1>Deprecated fields</h1>
+  <h3>Deprecated fields</h3>
   <p>Artifacts previously included <code>glob_path</code> and <code>original_path</code> but these were <a href="https://buildkite.com/changelog/71-artifacts-glob-path-and-original-path-fields-are-deprecated">deprecated</a> and now return <code>null</code>.</p>
 </section>
 

--- a/pages/apis/rest_api/pipelines.md.erb
+++ b/pages/apis/rest_api/pipelines.md.erb
@@ -413,7 +413,7 @@ curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{
 ```
 
 <div class="Docs__troubleshooting-note">
-<p>Patch requests can only update attributes already present in the pipeline YAML.</p>
+  <p>Patch requests can only update attributes already present in the pipeline YAML.</p>
 </div>
 
 ```json
@@ -550,7 +550,7 @@ Error responses:
 </table>
 
 <div class="Docs__troubleshooting-note">
-<p>To update a pipeline's teams, please use the <a href="/docs/apis/graphql-api">GraphQL API</a>.</p>
+  <p>To update a pipeline's teams, please use the <a href="/docs/apis/graphql-api">GraphQL API</a>.</p>
 </div>
 
 ## Delete a pipeline

--- a/pages/pipelines/branch_configuration.md.erb
+++ b/pages/pipelines/branch_configuration.md.erb
@@ -11,7 +11,7 @@ In step-level and pipeline-level branch filtering you can use `*` as a wildcard,
 By default a pipeline will trigger builds for all branches (`*` or blank). In your pipeline settings you can set specific branch patterns for the entire pipeline. If a commit doesn't match the branch pattern, no build will be created.
 
 <section class="Docs__troubleshooting-note">
-  <h1>Pull Request Builds</h1>
+  <h3>Pull Request Builds</h3>
   <p>Builds created for pull requests will ignore any pipeline-level branch filters. If you want to limit the branches that can build pull requests, add an additional branch filter in your pipeline's source control settings.</p>
   <p>This filter can be found under 'Build pull requests' if you have chosen the 'Trigger builds after pushing code' option.</p>
 </section>

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -94,8 +94,8 @@ The below expressions are supported by the `if` attribute:
 
 
 <div class="Docs__troubleshooting-note">
-<h1>Formatting regular expressions</h1>
-<p>When using regular expressions in conditionals, the regular expression must be on the right hand side, and the use of the <code>$</code> anchor symbol must be escaped to avoid <a href="/docs/agent/v3/cli-pipeline#environment-variable-substitution">environment variable substitution</a>. For example, to match branches ending in <code>"/feature"</code> the conditional statement would be <code>build.branch =~ /\/feature$$/</code>.
+  <h3>Formatting regular expressions</h3>
+  <p>When using regular expressions in conditionals, the regular expression must be on the right hand side, and the use of the <code>$</code> anchor symbol must be escaped to avoid <a href="/docs/agent/v3/cli-pipeline#environment-variable-substitution">environment variable substitution</a>. For example, to match branches ending in <code>"/feature"</code> the conditional statement would be <code>build.branch =~ /\/feature$$/</code>.
 </div>
 
 ## Supported variables
@@ -248,7 +248,7 @@ The below variables are supported by the `if` attribute:
 </table>
 
 <div class="Docs__troubleshooting-note">
-<h1>Using <code>build.env()</code> with custom environment variables</h1>
+<h3>Using <code>build.env()</code> with custom environment variables</h3>
 <p>To access custom environment variables with the <code>build.env()</code> function, ensure that the <a href="https://buildkite.com/changelog/32-defining-pipeline-build-steps-with-yaml">YAML pipeline steps editor</a> has been enabled in the Pipeline Settings menu.</p>
 </div>
 

--- a/pages/pipelines/controlling_concurrency.md.erb
+++ b/pages/pipelines/controlling_concurrency.md.erb
@@ -15,7 +15,7 @@ Setting a concurrency limit of `1` on a step in your pipeline will ensure that n
 You can add concurrency limits to steps either through Buildkite, or your `pipeline.yml` file. When adding a concurrency limit, you'll also need the `concurrency_group` attribute so that steps in other pipelines can use it as well.
 
 <section class="Docs__troubleshooting-note">
-    <h1>I'm seeing an error about a missing `concurrency_group_id` when I run my pipeline upload</h1>
+    <h3>I'm seeing an error about a missing `concurrency_group_id` when I run my pipeline upload</h3>
     <p>This error is caused by a missing `concurrency_group` attribute. Add this attribute to the same step where you defined the `concurrency` attribute.</p>
 </section>
 

--- a/pages/pipelines/dependencies.md.erb
+++ b/pages/pipelines/dependencies.md.erb
@@ -51,8 +51,8 @@ steps:
 In the above example, the second command step (build) will not run until the first command step (tests) has completed. Without the `depends_on` attribute, and given enough agents, these steps would run in parallel.
 
 <div class="Docs__troubleshooting-note">
-<h1>depends_on and block/wait</h1>
-<p>Note that a step with an explicit dependency specified with the <code>depends_on</code> attribute will run immediately after the dependency step has completed, without waiting for <code>block</code> or <code>wait</code> steps unless those are also explicit dependencies.</p>
+  <h3>depends_on and block/wait</h3>
+  <p>Note that a step with an explicit dependency specified with the <code>depends_on</code> attribute will run immediately after the dependency step has completed, without waiting for <code>block</code> or <code>wait</code> steps unless those are also explicit dependencies.</p>
 </div>
 
 Dependencies can also be added as a list of strings, or a list of steps.

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -555,7 +555,7 @@ You can define environment variables in your jobs in a few ways, depending on th
 * An `environment` or `pre-command` [agent hook](/docs/agent/v3/hooks) — for values that are secret or agent-specific.
 
 <section class="Docs__troubleshooting-note">
-  <h1>Secrets in environment variables</h1>
+  <h3>Secrets in environment variables</h3>
   <p>Do not print or export secrets in your pipelines. See the <a href="/docs/pipelines/secrets">Secrets</a> documentation for further information and best practices.</p>
 </section>
 
@@ -691,7 +691,7 @@ After the agent variables have been merged, the bootstrap script is run.
 The bootstrap runs any local and global <a href="/docs/agent/v3/hooks">hooks</a> that have been defined on the agent machine, and any hooks provided by <a href="/docs/plugins">plugins</a>. Variables that are set in these hooks will be merged into the runtime environment, and will override any previous values that are set.
 
 <div class="Docs__troubleshooting-note">
-  <h1>Take care with environment variables in hooks</h1>
+  <h3>Take care with environment variables in hooks</h3>
   <p>Variables that are defined in hooks can override anything that exists in the environment.</p>
 </div>
 

--- a/pages/pipelines/ignoring_a_commit.md.erb
+++ b/pages/pipelines/ignoring_a_commit.md.erb
@@ -22,6 +22,6 @@ Fix readme typos
 For more advanced build filtering and commit skipping, see the [Using conditionals](/docs/pipelines/conditionals) guide.
 
 <div class="Docs__troubleshooting-note">
-<h1>Skipping Commits with Bitbucket Server</h1>
-<p>Not all webhooks from Bitbucket Server contain the commit message. When a commit message is not included in a webhook, the build will run.</p>
+  <h3>Skipping Commits with Bitbucket Server</h3>
+  <p>Not all webhooks from Bitbucket Server contain the commit message. When a commit message is not included in a webhook, the build will run.</p>
 </div>

--- a/pages/pipelines/my_builds.md.erb
+++ b/pages/pipelines/my_builds.md.erb
@@ -30,6 +30,6 @@ The My Builds page lists all of your past builds in reverse chronological order,
 <%= image "builds-page.png", width: 1940/2, height: 1018/2, alt: "Screenshot of the My Builds page" %>
 
 <section class="Docs__troubleshooting-note">
-  <h1>The build I just created is running, but isn't showing up in My Builds</h1>
+  <h3>The build I just created is running, but isn't showing up in My Builds</h3>
   <p>The most common reason for a build to not be included in My Builds is that the email address associated with your commit isn't linked to your account. Make sure that the email in your git config is <a href="/user/emails">linked to your Buildkite account</a>. Without this link, we won't know which builds are yours!</p>
 </section>

--- a/pages/pipelines/writing_build_scripts.md.erb
+++ b/pages/pipelines/writing_build_scripts.md.erb
@@ -48,7 +48,7 @@ run_tests
 For a full list of options, see the [Bash Reference Manual](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html).
 
 <section class="Docs__troubleshooting-note">
-  <h1>Unbound variable errors</h1>
+  <h3>Unbound variable errors</h3>
   <p>Note that while enabling the <code>u</code> option is generally a good default to use for all build scripts, it can cause some tools like <a href="https://rvm.io">rvm</a> to fail with “unbound variable” errors. If you encounter errors, you can either remove <code>u</code> from the list of options, or you can surround the command causing the error with <code>set +u</code> and <code>set -u</code> to temporarily disable the option.</p>
 </section>
 
@@ -113,7 +113,7 @@ some_command
 If you require more environment information, you can execute `env` to print out all the environment variable names and their values. If you use `env` you should filter the output using a tool such as `grep` or `egrep`, to ensure you don't leak private keys or other information.
 
 <section class="Docs__troubleshooting-note">
-  <h1>Security recommendation</h1>
+  <h3>Security recommendation</h3>
   <p>If you use environment variables to define sensitive data such as API keys or Secret Access Keys, you should always filter the output of <code>env</code> to ensure you’re not exposing any secrets in your build log.</p>
 </section>
 


### PR DESCRIPTION
Update stylesheet and content for the orange troubleshooting headers from H1s (typically used once on a page, for page title) to H3s.

<img width="760" alt="image" src="https://user-images.githubusercontent.com/2824446/104381410-84f8ba00-5580-11eb-995a-8b4b3989f388.png">

Resolves #878 