### PR TITLE
Fix the stub example in the Writing Plugins guide

### DIFF
--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -90,17 +90,21 @@ Create the following `tests/post-command.bats` file:
 
 load '/usr/local/lib/bats/load.bash'
 
+# Uncomment the following line to debug stub failures
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+
 @test "Creates an annotation with the file count" {
   export BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN="*.bats"
 
-  stub buildkite-agent annotate "Found 1 files matching *.bats"
+  stub buildkite-agent 'annotate "Found 1 files matching *.bats" : echo Annotation created'
 
   run "$PWD/hooks/post-command"
 
-  unstub buildkite-agent
-
   assert_success
   assert_output --partial "Found 1 files matching *.bats"
+  assert_output --partial "Annotation created"
+
+  unstub buildkite-agent
 }
 ```
 {: codeblock-file="tests/post-command.bats"}

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -15,6 +15,7 @@ steps:
       - a-github-user/file-counter#v1.0.0:
           pattern: '*.md'
 ```
+{: codeblock-file="pipeline.yml"}
 
 ### Create a new git repository
 
@@ -72,6 +73,7 @@ echo "Found ${COUNT} files matching ${PATTERN}"
 
 buildkite-agent annotate "Found ${COUNT} files matching ${PATTERN}"
 ```
+  {: codeblock-file="hooks/post-command"}
 
 ### Add a test
 


### PR DESCRIPTION
This primarily fixes the stub syntax in the Writing Plugins guide, which was incorrect, as well as adding a few missing filenames to the code blocks.

Fixes #868