### PR TITLE
Link to docs of the latest Bazel release

### DIFF
--- a/pages/tutorials/bazel.md.erb
+++ b/pages/tutorials/bazel.md.erb
@@ -7,16 +7,16 @@ Bazel supports large codebases across multiple repositories, and large numbers o
 
 ## Using Bazel on Buildkite
 
-1. [Install Bazel](https://docs.bazel.build/versions/2.2.0/install.html) on one or more Buildkite Agents.
-2. Add an empty [`WORKSPACE` file](https://docs.bazel.build/versions/2.2.0/tutorial/cpp.html#set-up-the-workspace) to your project to mark it as a Bazel workspace.
-3. Add a [`BUILD` file](https://docs.bazel.build/versions/2.2.0/tutorial/cpp.html#understand-the-build-file) to your project to tell Bazel how to build it.
+1. [Install Bazel](https://docs.bazel.build/install.html) on one or more Buildkite Agents.
+2. Add an empty [`WORKSPACE` file](https://docs.bazel.build/tutorial/cpp.html#set-up-the-workspace) to your project to mark it as a Bazel workspace.
+3. Add a [`BUILD` file](https://docs.bazel.build/tutorial/cpp.html#understand-the-build-file) to your project to tell Bazel how to build it.
 4. Add the Bazel build target(s) to your Buildkite [Pipeline](/docs/pipelines/defining-steps).
 
 ## Buildkite C++ Bazel example
 
 We've made a short Bazel example which you can run and customize.
 
-Make sure you're signed into your [Buildkite account](http://buildkite.com) and have access to a Buildkite Agent [running Bazel](https://docs.bazel.build/versions/2.2.0/install.html), then click through to the example:
+Make sure you're signed into your [Buildkite account](http://buildkite.com) and have access to a Buildkite Agent [running Bazel](https://docs.bazel.build/install.html), then click through to the example:
 
 <a class="Docs__example-repo" href="https://github.com/buildkite/bazel-example">
   <span class="icon">:memo:</span>
@@ -29,5 +29,5 @@ Make sure you're signed into your [Buildkite account](http://buildkite.com) and 
 
 ## Further reading
 
-* The [Bazel C++ tutorial](https://docs.bazel.build/versions/2.2.0/tutorial/cpp.html#refine-your-bazel-build) goes into more detail about how to configure more complex Bazel builds, covering multiple build targets and multiple packages.
-* The Bazel [external dependencies docs](https://docs.bazel.build/versions/2.2.0/external.html) show you how to build other local and remote repositories.
+* The [Bazel C++ tutorial](https://docs.bazel.build/tutorial/cpp.html#refine-your-bazel-build) goes into more detail about how to configure more complex Bazel builds, covering multiple build targets and multiple packages.
+* The Bazel [external dependencies docs](https://docs.bazel.build/external.html) show you how to build other local and remote repositories.


### PR DESCRIPTION
Previously all Bazel documentation links pointed to the docs for Bazel 2.2.0, which was released in March 2020 and is thus unlikely to be used by people new to Buildkite & Bazel. Consequently, this PR changes the links to always point to the documentation of the *latest* Bazel release.