### PR TITLE
Highlight Agent targeting

### DIFF
--- a/pages/pipelines/defining_steps.md.erb
+++ b/pages/pipelines/defining_steps.md.erb
@@ -203,6 +203,24 @@ The below example URL will copy the steps from the 'My Llamas Pipeline' into the
 https://buildkite.com/organizations/acme-inc/pipelines/new?clone=my-llamas-pipeline
 ```
 
+## Targeting specific agents
+
+To run [command steps](/docs/pipelines/command-step) only on specific agents:
+
+1. In the agent configuration file, [tag the agent](/docs/agent/v3/cli-start#setting-tags)
+2. In the pipeline command step, [set the agent property](/docs/agent/v3/cli-start#agent-targeting) in the command step
+
+For example to run commands only on agents running on macOS:
+
+```yaml
+steps:
+  - command: "script.sh"
+    agents:
+      os: "macOS"
+```
+{: codeblock-file="pipeline.yml"}
+
+
 ## Further documentation
 
 You can also upload pipelines from the command line using the `buildkite-agent` command line tool. See the [buildkite-agent pipeline documentation](/docs/agent/v3/cli-pipeline) for a full list of the available parameters.

--- a/pages/pipelines/example_pipelines.md.erb
+++ b/pages/pipelines/example_pipelines.md.erb
@@ -209,6 +209,16 @@ A list of repositories containing example [pipelines](/docs/pipelines).
   </span>
 </a>
 
+<a class="Docs__example-repo" href="https://gist.github.com/toolmantim/1337952c8b5b1e5b0b5ea10c40e9efe4">
+ <span class="icon">:buildkite:</span>
+  <span class="detail">
+    <strong>Targeting specific agents</strong>
+     <span class="description">Run command steps only on specific agents</span>
+    <span class="repo">gist.github.com/toolmantim/1337952c8b5b1e5b0b5ea10c40e9efe4</span>
+  </span>
+</a>
+
+
 ## Third-party tools
 
 <a class="Docs__example-repo" href="https://github.com/saymedia/jobsworth">


### PR DESCRIPTION
Make things easier to find.

See https://forum.buildkite.community/t/how-to-restrict-steps-to-specific-agents/1411

Are we ok to just link to the example in the gist? Seems overkill to add a repo for it. 