### PR TITLE
Mention in docs that include_retried_jobs works for 'Get a build'

### DIFF
--- a/pages/apis/rest_api/builds.md.erb
+++ b/pages/apis/rest_api/builds.md.erb
@@ -249,6 +249,19 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
 }
 ```
 
+Optional [query string parameters](/docs/api#query-string-parameters):
+
+<table>
+<tbody>
+  <tr>
+    <th><code>include_retried_jobs</code></th>
+    <td>Include all retried job executions in each build’s jobs list. Without this parameter, you'll see only the most recently run job for each step.<p class="Docs__api-param-eg">
+      <em>Example:</em> <code>?include_retried_jobs=true</code></p>
+    </td>
+  </tr>
+</tbody>
+</table>
+
 Required scope: `read_builds`
 
 Success response: `200 OK`


### PR DESCRIPTION
The flag `include_retried_jobs` also works for 'Get a build', but this is missing in the [docs](https://buildkite.com/docs/apis/rest-api/builds#get-a-build). Re-opens #823.