### PR TITLE
Escape emoji in codeblock

### DIFF
--- a/pages/pipelines/defining_steps.md.erb
+++ b/pages/pipelines/defining_steps.md.erb
@@ -131,7 +131,7 @@ By default the pipeline upload step reads your pipeline definition from `.buildk
 
 ```yml
 steps:
-  - label: ":pipeline: Pipeline upload"
+  - label: "\:pipeline\: Pipeline upload"
     command: buildkite-agent pipeline upload .buildkite/deploy.yml
 ```
 


### PR DESCRIPTION
This fixes the single issue.

we should be able to implement a vale rule a little like

```yml
extends: existence
message: You need to escape emoji colons in codeblocks
level: error
nonword: True
scope: code
tokens:
    - ':[a-z]*:'
```

to check for this, but it currently detects emoji that aren't in codeblocks as well. :-(