### PR TITLE
Fix yarn error building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG RAILS_ENV
 ENV RAILS_ENV=${RAILS_ENV:-production}
 
 ADD https://deb.nodesource.com/gpgkey/nodesource.gpg.key /etc/apt/trusted.gpg.d/nodesource.asc
-ADD https://dl.yarnpkg.com/debian/pubkey.gpg /etc/apt/trusted.gpg.d/yarn.asc
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "--- :package: Installing system deps" \
     # Make sure apt can see trusted keys downloaded above (simpler than apt-key)
     && chmod +r /etc/apt/trusted.gpg.d/*.asc \


### PR DESCRIPTION
This fixes the following error:

```
GPG error: http://dl.yarnpkg.com/debian stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 23E7166788B63E1E
```

which is currently breaking our build 😅