### PR TITLE
Update installation instructions

### DIFF
--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -22,7 +22,7 @@ Next, ensure you have the `apt-transport-https` package installed for the HTTPS 
 sudo apt-get install -y apt-transport-https dirmngr
 ```
 
-Now you can add our signed apt repository:
+Now you can add our signed apt repository. The default version of the agent is `stable`, but you can get the beta version by using `unstable` instead of `stable` in the following command, or the agent built from the `main` branch of the repository by using `experimental` instead of `stable`.
 
 ```shell
 sudo apt-key adv --keyserver ipv4.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198

--- a/pages/agent/v3/redhat.md.erb
+++ b/pages/agent/v3/redhat.md.erb
@@ -6,7 +6,7 @@ The Buildkite Agent can be installed on Red Hat, CentOS and Amazon Linux using o
 
 ## Installation
 
-Firstly, add our yum repository for your architecture (run `uname -m` to find your system’s arch).
+Firstly, add our yum repository for your architecture (run `uname -m` to find your system’s arch). The default version of the agent is `stable`, but you can get the beta version by using `unstable` instead of `stable` in the following command, or the agent built from the `main` branch of the repository by using `experimental` instead of `stable`.
 
 For 64-bit (x86_64):
 
@@ -18,6 +18,12 @@ For 32-bit (i386):
 
 ```shell
 sudo sh -c 'echo -e "[buildkite-agent]\nname = Buildkite Pty Ltd\nbaseurl = https://yum.buildkite.com/buildkite-agent/stable/i386/\nenabled=1\ngpgcheck=0\npriority=1" > /etc/yum.repos.d/buildkite-agent.repo'
+```
+
+For ARM 64-bit (aarch64)):
+
+```shell
+sudo sh -c 'echo -e "[buildkite-agent]\nname = Buildkite Pty Ltd\nbaseurl = https://yum.buildkite.com/buildkite-agent/stable/aarch64/\nenabled=1\ngpgcheck=0\npriority=1" > /etc/yum.repos.d/buildkite-agent.repo'
 ```
 
 Then, install the agent:

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -6,7 +6,7 @@ The Buildkite Agent can be installed on Ubuntu versions 14.04 and above using ou
 
 ## Installation
 
-First, add our signed apt repository:
+First, add our signed apt repository. The default version of the agent is `stable`, but you can get the beta version by using `unstable` instead of `stable` in the following command, or the agent built from the `main` branch of the repository by using `experimental` instead of `stable`.
 
 ```shell
 echo "deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list


### PR DESCRIPTION
Add `unstable`, `experimental` installation options to Debian, Ubuntu and Red Hat.
Add `aarch64` to Red Hat.

Fixes #775 
Fixes #774 