### PR TITLE
Fix - plugins list should be an array error

### DIFF
--- a/pages/plugins/_tutorial_readme.html
+++ b/pages/plugins/_tutorial_readme.html
@@ -11,7 +11,7 @@ steps:
   - command: ls
     plugins:
       - a-github-user/file-counter#v1.0.0:
-        pattern: '*.md'
+          pattern: '*.md'
 ```
 
 ## Configuration

--- a/pages/plugins/_tutorial_readme.html
+++ b/pages/plugins/_tutorial_readme.html
@@ -10,7 +10,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      a-github-user/file-counter#v1.0.0:
+      - a-github-user/file-counter#v1.0.0:
         pattern: '*.md'
 ```
 


### PR DESCRIPTION
This error had been fixed in other places on the tutorial, but I ran the linter and found we are getting errors in the README.md

```
Creating file-counter-buildkite-plugin_lint_run ... done
TAP version 13
ok 1 - plugin.yml is valid
not ok 2 - Plugins list should be an array, not a map
  ---
  example:
    steps:
      - command: ls
        plugins:
          a-github-user/file-counter#v1.0.0:
            pattern: "*.md"
  ...
```