### PR TITLE
Revert "Fix yarn error building docker image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ADD https://dl.yarnpkg.com/debian/pubkey.gpg /etc/apt/trusted.gpg.d/yarn.asc
 RUN echo "--- :package: Installing system deps" \
     # Make sure apt can see trusted keys downloaded above (simpler than apt-key)
     && chmod +r /etc/apt/trusted.gpg.d/*.asc \
+    # Yarn's key has carriage returns which confuses debian, so remove them
+    && sed -i 's/\r//' /etc/apt/trusted.gpg.d/*.asc \
     # Cache apt
     && rm -f /etc/apt/apt.conf.d/docker-clean \
     && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG RAILS_ENV
 ENV RAILS_ENV=${RAILS_ENV:-production}
 
 ADD https://deb.nodesource.com/gpgkey/nodesource.gpg.key /etc/apt/trusted.gpg.d/nodesource.asc
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+ADD https://dl.yarnpkg.com/debian/pubkey.gpg /etc/apt/trusted.gpg.d/yarn.asc
 RUN echo "--- :package: Installing system deps" \
     # Make sure apt can see trusted keys downloaded above (simpler than apt-key)
     && chmod +r /etc/apt/trusted.gpg.d/*.asc \


### PR DESCRIPTION
Reverts buildkite/docs#913

The original `ADD` command should have noticed the update, but didn't for some reason, so the change to a `RUN` busted the cache. But the `RUN` will never have the opportunity to notice upstream changes and so will cause the same problem in the future, whereas the `ADD` should notice updates and also creates lighter layers and maintains consistency.