### PR TITLE
Agent token links for OS pages

### DIFF
--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -35,7 +35,7 @@ Then install the agent:
 sudo apt-get update && sudo apt-get install -y buildkite-agent
 ```
 
-Then configure your agent token:
+Configure your [agent token](/docs/agent/v3/tokens):
 
 ```shell
 sudo sed -i "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" /etc/buildkite-agent/buildkite-agent.cfg

--- a/pages/agent/v3/freebsd.md.erb
+++ b/pages/agent/v3/freebsd.md.erb
@@ -23,7 +23,7 @@ sudo chsh -s /usr/local/bin/bash `whoami`
 bash
 ```
 
-Once they have been installed, you can run the following script (<a href="https://raw.githubusercontent.com/buildkite/agent/master/install.sh">view the source</a>), which will download and install the correct binary for your system and architecture:
+Once they have been installed, you can run the following script (<a href="https://raw.githubusercontent.com/buildkite/agent/master/install.sh">view the source</a>), which will download and install the correct binary for your system and architecture (you will need your [agent token](/docs/agent/v3/tokens)):
 
 ```shell
 TOKEN="INSERT-YOUR-AGENT-TOKEN-HERE" bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"

--- a/pages/agent/v3/linux.md.erb
+++ b/pages/agent/v3/linux.md.erb
@@ -6,7 +6,7 @@ You can install Buildkite Agent on most Linux based systems (including macOS).
 
 ## Installation
 
-Run the following script (<a href="https://raw.githubusercontent.com/buildkite/agent/master/install.sh">view the source</a>), which will download and install the correct binary for your system and architecture:
+Run the following script (<a href="https://raw.githubusercontent.com/buildkite/agent/master/install.sh">view the source</a>), which will download and install the correct binary for your system and architecture (you will need your [agent token](/docs/agent/v3/tokens)):
 
 ```shell
 TOKEN="INSERT-YOUR-AGENT-TOKEN-HERE" bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"

--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -12,7 +12,7 @@ If you have <a href="http://brew.sh/">Homebrew</a> installed you can use our <a 
 brew install buildkite/buildkite/buildkite-agent
 ```
 
-Then configure your agent token:
+Then configure your [agent token](/docs/agent/v3/tokens):
 
 ```shell
 sed -i '' "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" "$(brew --prefix)"/etc/buildkite-agent/buildkite-agent.cfg

--- a/pages/agent/v3/redhat.md.erb
+++ b/pages/agent/v3/redhat.md.erb
@@ -20,13 +20,13 @@ For 32-bit (i386):
 sudo sh -c 'echo -e "[buildkite-agent]\nname = Buildkite Pty Ltd\nbaseurl = https://yum.buildkite.com/buildkite-agent/stable/i386/\nenabled=1\ngpgcheck=0\npriority=1" > /etc/yum.repos.d/buildkite-agent.repo'
 ```
 
-Then, install the agent:
+Then install the agent:
 
 ```shell
 sudo yum -y install buildkite-agent
 ```
 
-Configure your agent token:
+Configure your [agent token](/docs/agent/v3/tokens):
 
 ```shell
 sudo sed -i "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" /etc/buildkite-agent/buildkite-agent.cfg

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -19,7 +19,7 @@ Then install the agent:
 sudo apt-get update && sudo apt-get install -y buildkite-agent
 ```
 
-Then configure your agent token:
+Configure your [agent token](/docs/agent/v3/tokens):
 
 ```shell
 sudo sed -i "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" /etc/buildkite-agent/buildkite-agent.cfg

--- a/pages/agent/v3/windows.md.erb
+++ b/pages/agent/v3/windows.md.erb
@@ -26,7 +26,7 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercon
 
 1. Download the latest Windows release from <a href="https://github.com/buildkite/agent/releases">Buildkite Agent releases on GitHub</a>
 2. Extract the files to a directory of your choice (we recommend `C:\buildkite-agent`)
-3. Edit `buildkite-agent.cfg` and add your token
+3. Edit `buildkite-agent.cfg` and add your [agent token](/docs/agent/v3/tokens)
 4. Run `buildkite-agent.exe start` from a command prompt
 
 ## SSH Key Configuration


### PR DESCRIPTION
Added links to clarify where to find the agent token to pages that dealt with OSystems.