### PR TITLE
Provide tracing-datadog-addr option

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -420,7 +420,8 @@ _Optional attributes:_
     <tr>
       <th><code>tracing-backend</code></th>
       <td>
-        Address to process <a href="https://github.com/buildkite/agent/pull/1273">APM metrics</a>. Accepts blank string or "datadog"
+        Indicates if tracing should be supplied for builds/jobs with Datadog APM, or not at all.
+        Accepts blank string or "datadog".
         <p class="Docs__api-param-eg"><em>Default:</em> <code>""</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_TRACING_BACKEND</code></p>
       </td>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -418,6 +418,16 @@ _Optional attributes:_
     </tr>
 
     <tr>
+      <th><code>tracing-datadog-addr</code></th>
+      <td>
+        Address to process <a href="https://github.com/buildkite/agent/pull/1273">APM metrics</a>
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>""</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_TRACING_DATADOG_ADDR</code></p>
+      </td>
+    </tr>
+
+    
+    <tr>
       <th><code>wait-for-ec2-tags-timeout</code></th>
       <td>
         The amount of time to wait for tags from EC2 before proceeding.

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -420,7 +420,7 @@ _Optional attributes:_
     <tr>
       <th><code>tracing-backend</code></th>
       <td>
-        Indicates if tracing should be supplied for builds/jobs with Datadog APM, or not at all. When set to Datadog backend, will use default APM address `localhost:8126`, or provided (Datadog) variables like `DD_AGENT_HOST` and `DD_AGENT_APM_PORT`.        
+        Set to <code>datadog</code> to enable Datadog API tracing for builds using the default APM address <code>localhost:8126</code>, or Datadog variables like <code>DD_AGENT_HOST</code> and <code>DD_AGENT_APM_PORT<code>.        
         Accepts blank string or "datadog".
         <p class="Docs__api-param-eg"><em>Default:</em> <code>""</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_TRACING_BACKEND</code></p>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -420,7 +420,7 @@ _Optional attributes:_
     <tr>
       <th><code>tracing-backend</code></th>
       <td>
-        Indicates if tracing should be supplied for builds/jobs with Datadog APM, or not at all.
+        Indicates if tracing should be supplied for builds/jobs with Datadog APM, or not at all. When set to Datadog backend, will use default APM address `localhost:8126`, or provided (Datadog) variables like `DD_AGENT_HOST` and `DD_AGENT_APM_PORT`.        
         Accepts blank string or "datadog".
         <p class="Docs__api-param-eg"><em>Default:</em> <code>""</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_TRACING_BACKEND</code></p>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -418,11 +418,11 @@ _Optional attributes:_
     </tr>
 
     <tr>
-      <th><code>tracing-datadog-addr</code></th>
+      <th><code>tracing-backend</code></th>
       <td>
-        Address to process <a href="https://github.com/buildkite/agent/pull/1273">APM metrics</a>
+        Address to process <a href="https://github.com/buildkite/agent/pull/1273">APM metrics</a>. Accepts blank string or "datadog"
         <p class="Docs__api-param-eg"><em>Default:</em> <code>""</code></p>
-        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_TRACING_DATADOG_ADDR</code></p>
+        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_TRACING_BACKEND</code></p>
       </td>
     </tr>
 

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -517,6 +517,14 @@ A colon separated list of non-private team names that the user who unblocked the
 
 Example: `"everyone:platform"`
 
+<h3 class="h3-caps">BUILDKITE_TRACING_BACKEND</h3>
+
+Set to either `""` or `"datadog"` to send metrics nowhere, or to [Datadog APM](https://docs.datadoghq.com/tracing/)
+
+Defaults to empty string. Also available as a [buildkite agent configuration option.](/docs/agent/v3/configuration#configuration-settings)
+
+Example: `"datadog"`
+
 <h3 class="h3-caps">CI</h3>
 
 Always `"true"`. The value cannot be modified.

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -519,7 +519,7 @@ Example: `"everyone:platform"`
 
 <h3 class="h3-caps">BUILDKITE_TRACING_BACKEND</h3>
 
-Set to either `""` or `"datadog"` to send metrics nowhere, or to [Datadog APM](https://docs.datadoghq.com/tracing/)
+Set to either `""` or `"datadog"` to send metrics nowhere, or to [Datadog APM](https://docs.datadoghq.com/tracing/). When set to `"datadog"`, will send metrics to `localhost:8126`, or `DD_AGENT_HOST` and `DD_AGENT_APM_PORT`.
 
 Defaults to empty string. Also available as a [buildkite agent configuration option.](/docs/agent/v3/configuration#configuration-settings)
 

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -519,7 +519,7 @@ Example: `"everyone:platform"`
 
 <h3 class="h3-caps">BUILDKITE_TRACING_BACKEND</h3>
 
-Set to either `""` or `"datadog"` to send metrics nowhere, or to [Datadog APM](https://docs.datadoghq.com/tracing/). When set to `"datadog"`, will send metrics to `localhost:8126`, or `DD_AGENT_HOST` and `DD_AGENT_APM_PORT`.
+Set to `"datadog"` to send metrics to the [Datadog APM](https://docs.datadoghq.com/tracing/) via `localhost:8126`, or `DD_AGENT_HOST:DD_AGENT_APM_PORT`.
 
 Defaults to empty string. Also available as a [buildkite agent configuration option.](/docs/agent/v3/configuration#configuration-settings)
 


### PR DESCRIPTION
Referencing recent agent release (3.27.0) and https://github.com/buildkite/agent/pull/1273