### PR TITLE
Fix invalid command substitution in plugin docs.

### DIFF
--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -93,7 +93,7 @@ The [Buildkite Plugin Linter](https://github.com/buildkite-plugins/buildkite-plu
 You can run the plugin linter with the following Docker command:
 
 ```shell
-docker run -it --rm -v "$(PWD):/plugin:ro" buildkite/plugin-linter --id a-github-user/file-counter
+docker run -it --rm -v "$PWD:/plugin:ro" buildkite/plugin-linter --id a-github-user/file-counter
 ```
 
 To make it easier to run this command, add it to the `docker-compose.yml` file:
@@ -181,7 +181,7 @@ load '/usr/local/lib/bats/load.bash'
 To run the test, run the following Docker command:
 
 ```shell
-docker run -it --rm -v "$(PWD):/plugin:ro" buildkite/plugin-tester
+docker run -it --rm -v "$PWD:/plugin:ro" buildkite/plugin-tester
 ```
 
 ```


### PR DESCRIPTION
Fails with `bash: PWD: command not found`.  Should either be $PWD or
$(pwd), I've opted for the former.