### PR TITLE
Fix typo of meta endpoint

### DIFF
--- a/pages/apis/rest_api/meta.md.erb
+++ b/pages/apis/rest_api/meta.md.erb
@@ -11,12 +11,12 @@ It does not require authentication.
 Returns IP addresses:
 
 ```bash
-curl "https://api.buildkite.com/v2/user"
+curl "https://api.buildkite.com/v2/meta"
 ```
 
 ```json
 {
-  "webhook_ips":["54.165.103.71"]
+  "webhook_ips": ["100.24.182.113", "35.172.45.249", "54.165.103.71", "54.85.125.32"]
 }
 ```
 


### PR DESCRIPTION
The path should be `/meta`