### PR TITLE
Add documentation for the `buildkite-agent annotation remove` command.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -171,6 +171,7 @@
                   <ul class="Docs__nav__sub-nav">
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "start", 'agent/v3/cli-start' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "annotate", 'agent/v3/cli-annotate' %></li>
+                    <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "annotation", 'agent/v3/cli-annotation' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "artifact", 'agent/v3/cli-artifact' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "meta-data", 'agent/v3/cli-meta-data' %></li>
                     <li class="Docs__nav__sub-nav__item"><%= sidebar_link_to "pipeline", 'agent/v3/cli-pipeline' %></li>

--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -18,6 +18,10 @@ Options for the `annotate` command can be found in the `buildkite-agent` cli hel
 <%= render 'agent/v3/help/annotate.txt' %>
 ```
 
+## Removing an annotation
+
+Annotations can be removed using [the `buildkite-agent annotation remove` command](/docs/agent/v3/cli-annotation).
+
 ## Annotation styles
 
 You can change the visual style of annotations using the `--style` option.

--- a/pages/agent/v3/cli_annotation.md.erb
+++ b/pages/agent/v3/cli_annotation.md.erb
@@ -6,7 +6,7 @@ Annotations are added using [the `buildkite-agent annotate` command](cli-annotat
 
 <section class="Docs__note">
   <h3>Newly-added Feature</h3>
-  <p>This feature was introduced in <a href="https://github.com/buildkite/agent/releases/tag/v3.28.0">v3.28.0</a> of the agent.</p>
+  <p>This feature was introduced in <a href="https://github.com/buildkite/agent/releases/tag/v3.28.1">v3.28.1</a> of the agent.</p>
 </section>
 
 {:toc}

--- a/pages/agent/v3/cli_annotation.md.erb
+++ b/pages/agent/v3/cli_annotation.md.erb
@@ -1,0 +1,22 @@
+# buildkite-agent annotation
+
+The Buildkite Agent’s `annotation` command allows manipulating existing build annotations.
+
+Annotations are added using [the `buildkite-agent annotate` command](cli-annotate).
+
+<section class="Docs__note">
+  <h3>Newly-added Feature</h3>
+  <p>This feature was introduced in <a href="https://github.com/buildkite/agent/releases/tag/v3.28.0">v3.28.0</a> of the agent.</p>
+</section>
+
+{:toc}
+
+## Removing an annotation
+
+The `buildkite-agent annotation remove` command removes an existing annotation associated with the current build.
+
+Options for the `annotation remove` command can be found in the `buildkite-agent` cli help:
+
+```
+<%= render 'agent/v3/help/annotation_remove.txt' %>
+```

--- a/pages/agent/v3/help/_annotation_remove.txt
+++ b/pages/agent/v3/help/_annotation_remove.txt
@@ -1,0 +1,29 @@
+Usage:
+
+  buildkite-agent annotation remove [arguments...]
+
+Description:
+
+  Remove an existing annotation which was previously published using the
+  buildkite-agent annotate command.
+
+  Or if you leave context blank, it will use the default context.
+
+Example:
+
+  $ buildkite-agent annotation remove
+  $ buildkite-agent annotation remove --context "remove-me"
+
+Options:
+
+  --context value             The context of the annotation used to differentiate this annotation from others (default: "default") [$BUILDKITE_ANNOTATION_CONTEXT]
+  --job value                 Which job should the annotation come from [$BUILDKITE_JOB_ID]
+  --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
+  --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
+  --no-http2                  Disable HTTP2 when communicating with the Agent API. [$BUILDKITE_NO_HTTP2]
+  --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
+  --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+  --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
+  --experiment value          Enable experimental features within the buildkite-agent [$BUILDKITE_AGENT_EXPERIMENT]
+  --profile value             Enable a profiling mode, either cpu, memory, mutex or block [$BUILDKITE_AGENT_PROFILE]
+


### PR DESCRIPTION
Note that the referenced v3.28.0 agent version doesn't exist yet, so this shouldn't be merged until we've made a call on releasing that version.

Context: buildkite/agent#1364, buildkite/buildkite#5948.