### PR TITLE
Update command help for agent 3.28.1

### DIFF
--- a/pages/agent/v3/help/_annotation_remove.txt
+++ b/pages/agent/v3/help/_annotation_remove.txt
@@ -1,29 +1,29 @@
 Usage:
 
-  buildkite-agent annotation remove [arguments...]
+   buildkite-agent annotation remove [arguments...]
 
 Description:
 
-  Remove an existing annotation which was previously published using the
-  buildkite-agent annotate command.
+   Remove an existing annotation which was previously published using the
+   buildkite-agent annotate command.
 
-  Or if you leave context blank, it will use the default context.
+   If you leave context blank, it will use the default context.
 
 Example:
 
-  $ buildkite-agent annotation remove
-  $ buildkite-agent annotation remove --context "remove-me"
+   $ buildkite-agent annotation remove
+   $ buildkite-agent annotation remove --context "remove-me"
 
 Options:
 
-  --context value             The context of the annotation used to differentiate this annotation from others (default: "default") [$BUILDKITE_ANNOTATION_CONTEXT]
-  --job value                 Which job should the annotation come from [$BUILDKITE_JOB_ID]
-  --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
-  --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
-  --no-http2                  Disable HTTP2 when communicating with the Agent API. [$BUILDKITE_NO_HTTP2]
-  --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
-  --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
-  --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
-  --experiment value          Enable experimental features within the buildkite-agent [$BUILDKITE_AGENT_EXPERIMENT]
-  --profile value             Enable a profiling mode, either cpu, memory, mutex or block [$BUILDKITE_AGENT_PROFILE]
-
+   --context value             The context of the annotation used to differentiate this annotation from others (default: "default") [$BUILDKITE_ANNOTATION_CONTEXT]
+   --job value                 Which job is removing the annotation [$BUILDKITE_JOB_ID]
+   --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
+   --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
+   --no-http2                  Disable HTTP2 when communicating with the Agent API. [$BUILDKITE_NO_HTTP2]
+   --debug-http                Enable HTTP debug mode, which dumps all request and response bodies to the log [$BUILDKITE_AGENT_DEBUG_HTTP]
+   --no-color                  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
+   --debug                     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
+   --experiment value          Enable experimental features within the buildkite-agent [$BUILDKITE_AGENT_EXPERIMENT]
+   --profile value             Enable a profiling mode, either cpu, memory, mutex or block [$BUILDKITE_AGENT_PROFILE]
+   

--- a/pages/agent/v3/help/_bootstrap.txt
+++ b/pages/agent/v3/help/_bootstrap.txt
@@ -62,6 +62,7 @@ Options:
    --pty                                Run jobs within a pseudo terminal [$BUILDKITE_PTY]
    --shell value                        The shell to use to interpret build commands (default: "/bin/bash -e -c") [$BUILDKITE_SHELL]
    --phases value                       The specific phases to execute. The order they're defined is irrelevant. [$BUILDKITE_BOOTSTRAP_PHASES]
+   --cancel-signal value                The signal to use for cancellation (default: "SIGTERM") [$BUILDKITE_CANCEL_SIGNAL]
    --redacted-vars value                Pattern of environment variable names containing sensitive values [$BUILDKITE_REDACTED_VARS]
    --tracing-backend value              The name of the tracing backend to use. [$BUILDKITE_TRACING_BACKEND]
    --debug                              Enable debug mode [$BUILDKITE_AGENT_DEBUG]

--- a/pages/agent/v3/help/_start.txt
+++ b/pages/agent/v3/help/_start.txt
@@ -27,7 +27,7 @@ Options:
    --shell value                          The shell command used to interpret build commands, e.g /bin/bash -e -c (default: "/bin/bash -e -c") [$BUILDKITE_SHELL]
    --tags value                           A comma-separated list of tags for the agent (e.g. "linux" or "mac,xcode=8") [$BUILDKITE_AGENT_TAGS]
    --tags-from-host                       Include tags from the host (hostname, machine-id, os) [$BUILDKITE_AGENT_TAGS_FROM_HOST]
-   --tags-from-ec2-meta-data value        Include the default set of host EC2 meta-data as tags (instance-id, instance-type, and ami-id) [$BUILDKITE_AGENT_TAGS_FROM_EC2_META_DATA]
+   --tags-from-ec2-meta-data value        Include the default set of host EC2 meta-data as tags (instance-id, instance-type, ami-id, and instance-life-cycle) [$BUILDKITE_AGENT_TAGS_FROM_EC2_META_DATA]
    --tags-from-ec2-meta-data-paths value  Include additional tags fetched from EC2 meta-data via tag & path suffix pairs, e.g "tag_name=path/to/value" [$BUILDKITE_AGENT_TAGS_FROM_EC2_META_DATA_PATHS]
    --tags-from-ec2-tags                   Include the host's EC2 tags as tags [$BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS]
    --tags-from-gcp-meta-data value        Include the default set of host Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone) [$BUILDKITE_AGENT_TAGS_FROM_GCP_META_DATA]

--- a/scripts/update-agent-help.sh
+++ b/scripts/update-agent-help.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 commands=(
   "annotate"
+  "annotation remove"
   "artifact download"
   "artifact shasum"
   "artifact upload"


### PR DESCRIPTION
Following on from #954, this updates the docs for [v3.28.1](https://github.com/buildkite/agent/releases/tag/v3.28.1) of the Agent