### PR TITLE
Update suggested manifest for deploying the agent to GKE

### DIFF
--- a/pages/agent/v3/gcloud.md.erb
+++ b/pages/agent/v3/gcloud.md.erb
@@ -63,35 +63,38 @@ Create a [deployment](https://kubernetes.io/docs/user-guide/deployments/#creatin
 
 ```shell
 $ cat | kubectl apply -f -
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
- name: buildkite-agent
+  name: buildkite-agent
 spec:
- replicas: 1
- template:
-   metadata:
-     labels:
-       app: buildkite-agent
-   spec:
-     containers:
-       - name: buildkite-agent
-         image: buildkite/agent
-         imagePullPolicy: Always
-         securityContext:
-           privileged: true
-         env:
-           - name: BUILDKITE_AGENT_TOKEN
-             valueFrom:
-              secretKeyRef:
-                name: buildkite-agent
-                key: token
-         volumeMounts:
-           - name: docker-socket
-             mountPath: /var/run/docker.sock
-     volumes:
-       - name: docker-socket
-         hostPath: {path: /var/run/docker.sock}
+  replicas: 1
+  selector:
+    matchLabels:
+      app: buildkite-agent
+  template:
+    metadata:
+      labels:
+        app: buildkite-agent
+    spec:
+      containers:
+        - name: buildkite-agent
+          image: buildkite/agent
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          env:
+            - name: BUILDKITE_AGENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: buildkite-agent
+                  key: token
+          volumeMounts:
+            - name: docker-socket
+              mountPath: /var/run/docker.sock
+      volumes:
+        - name: docker-socket
+          hostPath: {path: /var/run/docker.sock}
 # (press Control-D)
 
 deployment "buildkite-agent" created


### PR DESCRIPTION
Our GKE docs suggest a kubernetes Deployment with type "extensions/v1beta1/Deployment", however Deployments moved to "apps/v1/Deployment" sometime ago and the old namespace is [unavailable from kuberentes 1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) (released mid 2019).

Our GKE docs in general are a bit dated and need an overhaul, but this is a worthwhile quick-fix that'll save customers hitting a confusing error.

I've also added matchLabels, because I think Deployment's are supposed to have them.

This diff is mostly whitespace - I recommend viewing [with whitespace changes hidden](https://github.com/buildkite/docs/pull/973/files?diff=split&w=1).