### PR TITLE
Managing Log Output: fix output-redactor experiment name

### DIFF
--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -115,7 +115,7 @@ Make sure to set the `-o pipefail` option in your buildscript as above, otherwis
 
 <div class="Docs__experiment">
 <p class="Docs__experiment__heading">Experimental feature</p>
-<p>This is an experimental feature, set <code>experiment="redacted-vars"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a> to use it.</p>
+<p>This is an experimental feature, set <code>experiment="output-redactor"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a> to use it.</p>
 </div>
 
 The Buildkite agent can redact strings that match the value of environment variables whose names match common patterns for passwords and other secure information before the build log is uploaded to Buildkite.


### PR DESCRIPTION
I just [noticed](https://github.com/buildkite/docs/pull/966/files#r599194738) the docs say `experiment="redacted-vars"` rather than `experiment="output-redactor"`:

![image](https://user-images.githubusercontent.com/15759/112082147-f4220880-8bd8-11eb-80b7-4c5159611388.png)

```go
	if experiments.IsEnabled("output-redactor") {
```
https://github.com/buildkite/agent/blob/decbc9df4ecad2004ad4ed0cc8af8d18582f2106/bootstrap/bootstrap.go#L1804