### PR TITLE
Fix Deprecation warnings

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -54,11 +54,11 @@ class Page
     end
 
     def render(partial)
-      PagesController.render(partial: partial)
+      PagesController.render(partial: partial, formats: [:md])
     end
 
     def render_markdown(markdown_path, *args)
-      Page::Renderer.render(render(markdown_path + '.md', *args)).html_safe
+      Page::Renderer.render(render(markdown_path)).html_safe
     end
 
     def responsive_image_tag(image, width, height, image_tag_options={}, &block)

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,3 +1,5 @@
-Bugsnag.configure do |config|
-  config.api_key = ENV["BUGSNAG_API_KEY"]
+if ENV["BUGSNAG_API_KEY"].present?
+  Bugsnag.configure do |config|
+    config.api_key = ENV["BUGSNAG_API_KEY"]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,6 +121,9 @@ Rails.application.routes.draw do
   # All other standard docs pages
   get "/docs/*path" => "pages#show", as: :docs_page
 
+  # Less noise in the log please
+  post "/_csp-violation-reports", to: proc { [201, {}, ['']] }
+
   # Take us straight to the docs when running standalone
   root to: redirect("/docs")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,7 @@ Rails.application.routes.draw do
   # All other standard docs pages
   get "/docs/*path" => "pages#show", as: :docs_page
 
-  # Less noise in the log please
+  # Content Security Policy violations are sent here, and in production the path is handled by buildkite/buildkite. This is a stub response so CSP violations in development don't generate extra noise in the development log
   post "/_csp-violation-reports", to: proc { [201, {}, ['']] }
 
   # Take us straight to the docs when running standalone

--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -14,7 +14,7 @@ There is no limit to the amount of annotations you can create. All annotations c
 
 Options for the `annotate` command can be found in the `buildkite-agent` cli help:
 
-<%= render 'agent/v3/help/annotate.md' %>
+<%= render 'agent/v3/help/annotate' %>
 
 ## Removing an annotation
 

--- a/pages/agent/v3/cli_annotation.md.erb
+++ b/pages/agent/v3/cli_annotation.md.erb
@@ -18,5 +18,5 @@ The `buildkite-agent annotation remove` command removes an existing annotation a
 Options for the `annotation remove` command can be found in the `buildkite-agent` cli help:
 
 
-<%= render 'agent/v3/help/annotation_remove.md' %>
+<%= render 'agent/v3/help/annotation_remove' %>
 

--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -13,7 +13,7 @@ You can use this command in your build scripts to store artifacts in the Buildki
 You can also configure the agent to automatically upload artifacts based on a file pattern (see the [Using Build Artifacts guide](/docs/builds/artifacts) for details).
 
 
-<%= render 'agent/v3/help/artifact_upload.md' %>
+<%= render 'agent/v3/help/artifact_upload' %>
 
 
 ### Artifact upload examples
@@ -82,7 +82,7 @@ Keep in mind while you’re writing your path pattern:
 Use this command in your build scripts to download artifacts.
 
 
-<%= render 'agent/v3/help/artifact_download.md' %>
+<%= render 'agent/v3/help/artifact_download' %>
 
 
 ### Artifact download examples
@@ -140,7 +140,7 @@ If you want to download an artifact from outside a build use our [Artifact Downl
 Use this command in your build scripts to verify downloaded artifacts against the original SHA-1 of the file.
 
 
-<%= render 'agent/v3/help/artifact_shasum.md' %>
+<%= render 'agent/v3/help/artifact_shasum' %>
 
 
 ## Using your private AWS S3 bucket

--- a/pages/agent/v3/cli_bootstrap.md.erb
+++ b/pages/agent/v3/cli_bootstrap.md.erb
@@ -8,5 +8,5 @@ your agent.
 ## Running the bootstrap
 
 
-<%= render 'agent/v3/help/bootstrap.md' %>
+<%= render 'agent/v3/help/bootstrap' %>
 ```

--- a/pages/agent/v3/cli_meta_data.md.erb
+++ b/pages/agent/v3/cli_meta_data.md.erb
@@ -10,7 +10,7 @@ See the [Using Build Meta-data](/docs/pipelines/build-meta-data) guide for a ste
 
 Use this command in your build scripts to save string data in the Buildkite meta-data store.
 
-<%= render 'agent/v3/help/meta_data_set.md' %>
+<%= render 'agent/v3/help/meta_data_set' %>
 
 Meta-data values are restricted to a maximum of 100 kilobytes. Keys and values larger than 1 kilobyte are discouraged. Please use [artifacts](https://buildkite.com/docs/agent/v3/cli-artifact) for large data which needs to uploaded and downloaded.
 
@@ -18,12 +18,12 @@ Meta-data values are restricted to a maximum of 100 kilobytes. Keys and values l
 
 Use this command in your build scripts to get a previously saved value from the Buildkite meta-data store.
 
-<%= render 'agent/v3/help/meta_data_get.md' %>
+<%= render 'agent/v3/help/meta_data_get' %>
 
 ## Checking if data exists
 
-<%= render 'agent/v3/help/meta_data_exists.md' %>
+<%= render 'agent/v3/help/meta_data_exists' %>
 
 ## Listing keys
 
-<%= render 'agent/v3/help/meta_data_keys.md' %>
+<%= render 'agent/v3/help/meta_data_keys' %>

--- a/pages/agent/v3/cli_pipeline.md.erb
+++ b/pages/agent/v3/cli_pipeline.md.erb
@@ -8,7 +8,7 @@ See the [Defining Your Pipeline Steps](/docs/pipelines/defining-steps) guide for
 
 ## Uploading pipelines
 
-<%= render 'agent/v3/help/pipeline_upload.md' %>
+<%= render 'agent/v3/help/pipeline_upload' %>
 
 ## Pipeline format
 

--- a/pages/agent/v3/cli_start.md.erb
+++ b/pages/agent/v3/cli_start.md.erb
@@ -6,7 +6,7 @@ The Buildkite Agent’s `start` command is used to manually start an agent and r
 
 ## Starting an Agent
 
-<%= render 'agent/v3/help/start.md' %>
+<%= render 'agent/v3/help/start' %>
 
 ## Setting Tags
 

--- a/pages/agent/v3/cli_step.md.erb
+++ b/pages/agent/v3/cli_step.md.erb
@@ -8,10 +8,10 @@ The Buildkite Agent’s `step` command provides the ability to retrieve and  upd
 
 Use this command in your build scripts to update an attribute of a step. 
 
-<%= render 'agent/v3/help/step_update.md' %>
+<%= render 'agent/v3/help/step_update' %>
 
 ## Getting a step
 
 Use this command in your build scripts to get the value of a particular attribute from a step. 
 
-<%= render 'agent/v3/help/step_get.md' %>
+<%= render 'agent/v3/help/step_get' %>


### PR DESCRIPTION
The rails development log was full of junk, so @yob and I paired on trimming it.

If anyone knows *exactly* what is going on with the arguments in `app/models/page.rb` might be good to know, otherwise it seems to work and tests pass :-p.

* Stop Bugsnag complaining about an api key `config/initializers/bugsnag.rb`
* Stop Rails 6 complaining about `.` in render in `app/models/page.rb` and update docs to match in `pages/*`
* Stop CSP noise in `config/routes.rb`