### PR TITLE
301 redirect paths with trailing slashes

### DIFF
--- a/config/initializers/trailing_slash_middleware.rb
+++ b/config/initializers/trailing_slash_middleware.rb
@@ -1,0 +1,25 @@
+# Removes trailing slashes from URLs, making sure we don't serve up two
+# different URLs with the same content, and confuse spiders as to which is the
+# canonical URL.
+class TrailingSlashMiddlware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    req = Rack::Request.new(env)
+
+    if req.path_info != "/" && req.path_info.end_with?("/")
+      req.path_info = req.path_info.delete_suffix("/")
+      [
+        301,
+        { "Location" => req.url, "Content-Type" => "text/plain" },
+        ["Moved permanently to #{req.url}"]
+      ]
+    else
+      @app.call(env)
+    end
+  end
+end
+
+Rails.application.config.middleware.use TrailingSlashMiddlware

--- a/spec/requests/remove_trailing_slashes_middleware_spec.rb
+++ b/spec/requests/remove_trailing_slashes_middleware_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "Remove trailing slashes middleware" do
+  it "should 301 redirect to non-slash" do
+    get "/docs/agent/v3/"
+
+    expect(response.status).to eql(301)
+    expect(response.body).to eql("Moved permanently to http://www.example.com/docs/agent/v3")
+    expect(response.headers["Location"]).to eql("http://www.example.com/docs/agent/v3")
+  end
+
+  it "should preserve params" do
+    get "/docs/agent/v3/?moo=cow"
+
+    expect(response.status).to eql(301)
+    expect(response.body).to eql("Moved permanently to http://www.example.com/docs/agent/v3?moo=cow")
+    expect(response.headers["Location"]).to eql("http://www.example.com/docs/agent/v3?moo=cow")
+  end
+
+  it "should not redirect non-slash paths" do
+    get "/docs/agent/v3"
+
+    expect(response.status).to eql(200)
+  end
+end


### PR DESCRIPTION
In our ahrefs.com SEO site audit report it shows that we're internally linking to both https://buildkite.com/docs/pipelines and https://buildkite.com/docs/pipelines/ but don't set any canonical URL, so we're leaving up to search engines to figure out what the right URL is.

https://help.ahrefs.com/en/articles/2596742-duplicate-pages-without-canonical-error-in-site-audit

This adds a 301 redirect rule to ensure we only have a single URL for a unique page on the docs.