### PR TITLE
Fix errors in linter

### DIFF
--- a/.alexrc.yml
+++ b/.alexrc.yml
@@ -19,4 +19,4 @@ allow:
   - executes
   - executed
   - invalid
-pronfanitySureness: 2
+profanitySureness: 2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The source files for the [Buildkite Documentation](https://buildkite.com/docs).
 
-To contribute simply send a pull request! :heart:
+To contribute, send a pull request! :heart:
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {},
   "scripts": {
-    "lint": "npx alex@9 --diff pages/**/*.erb pages/**/*.txt"
+    "lint": "npx alex@9 --diff \"pages/**/*.erb\" \"pages/**/*.txt\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {},
   "scripts": {
-    "lint": "npx alex@9 --diff \"pages/**/*.erb\" \"pages/**/*.txt\""
+    "lint": "npx alex@9 -q --diff \"pages/**/*.erb\" \"pages/**/*.txt\""
   }
 }

--- a/pages/agent/v2/aws.md.erb
+++ b/pages/agent/v2/aws.md.erb
@@ -5,7 +5,7 @@
   <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/aws">see the latest version of this document</a>.
 </section>
 
-The Buildkite Agent can be run easily on AWS using our Elastic CI Stack for AWS.
+The Buildkite Agent can be run on AWS using our Elastic CI Stack for AWS.
 
 {:toc}
 
@@ -21,7 +21,7 @@ that gives you an autoscaling Buildkite Agent cluster in your own AWS. The
 stack includes Docker, S3 and Cloudwatch integration, and is suitable for
 parallelizing large legacy test suites, testing any Linux-based project that can run within Docker, and performing AWS ops related tasks.
 
-[Read the documentation][github] on GitHub, and launch it easily using the
+[Read the documentation][github] on GitHub, and launch it using the
 button on your organization’s Agents page.
 
    [github]: https://github.com/buildkite/elastic-ci-stack-for-aws

--- a/pages/agent/v2/cli_artifact.md.erb
+++ b/pages/agent/v2/cli_artifact.md.erb
@@ -103,7 +103,7 @@ buildkite-agent artifact upload test.log
 
 Keep in mind while you’re writing your path pattern:
 
-- patterns must match whole path strings, not just substrings
+- patterns must match whole path strings, not only substrings
 - there are two wildcards available that match non-separator characters (on Linux `/` is a separator character, and on Windows `\` is a separator character):
   + `*` to match a sequence of characters
   + `?` to match a single character
@@ -193,7 +193,7 @@ buildkite-agent artifact download "*.png" images/
 
 Artifact downloads support pattern-matching using the `*` character.
 
-Unlike artifact upload glob patterns, these operate over the entire path and not just between separator characters. For example, a download path pattern of `log/*` matches all files under the log directory and all subdirectories.
+Unlike artifact upload glob patterns, these operate over the entire path and not only between separator characters. For example, a download path pattern of `log/*` matches all files under the log directory and all subdirectories.
 
 There is no need to escape characters such as `?`, `[` and `]`.
 

--- a/pages/agent/v2/docker.md.erb
+++ b/pages/agent/v2/docker.md.erb
@@ -30,7 +30,7 @@ docker run -e BUILDKITE_AGENT_TOKEN="INSERT-YOUR-AGENT-TOKEN-HERE" buildkite/age
 
 ## Running on startup
 
-By default Docker [starts containers on restart](https://docs.docker.com/articles/host_integration/) so there's no need for upstart or similar. Simply start your container with `-d` to daemonize it and it will be restarted on system boot with the same environment variables and arguments.
+By default Docker [starts containers on restart](https://docs.docker.com/articles/host_integration/) so there's no need for upstart or similar. Start your container with `-d` to daemonize it and it will be restarted on system boot with the same environment variables and arguments.
 
 ## SSH Keys, Configuration and Customization
 

--- a/pages/agent/v2/freebsd.md.erb
+++ b/pages/agent/v2/freebsd.md.erb
@@ -66,4 +66,4 @@ The configuration file is located at `~/.buildkite-agent/buildkite-agent.cfg`. S
 
 ## Upgrading
 
-Simply rerun the install script.
+Rerun the install script.

--- a/pages/agent/v2/github_ssh_keys.md.erb
+++ b/pages/agent/v2/github_ssh_keys.md.erb
@@ -8,7 +8,7 @@
 The Buildkite Agent clones your source code directly from GitHub or GitHub Enterprise. The easiest way to provide it with access is by creating a “Buildkite Agent” machine user in your organization, and adding it to a team that has access to the relevant repositories.
 
 <div class="Docs__note">
-<p>If you’re running a build agent on a local development machine which already has access to GitHub then you can skip this setup and simply start running builds.</p>
+<p>If you’re running a build agent on a local development machine which already has access to GitHub then you can skip this setup and start running builds.</p>
 </div>
 
 {:toc}

--- a/pages/agent/v2/installation.md.erb
+++ b/pages/agent/v2/installation.md.erb
@@ -22,7 +22,7 @@ Alternatively you can install it manually using the instructions below.
 
 If you need to install the agent on a system not listed above you'll need to perform a manual installation using one of the binaries from [buildkite-agent’s releases page](https://github.com/buildkite/agent/releases).
 
-Once you have a binary you simply create a bin and builds directory in `~/.buildkite-agent` and copy the binary and `bootstrap.sh` file into place:
+Once you have a binary, create `bin` and `builds` directories in `~/.buildkite-agent` and copy the binary and `bootstrap.sh` file into place:
 
 ```bash
 mkdir ~/.buildkite-agent ~/.buildkite-agent/bin ~/.buildkite-agent/builds

--- a/pages/agent/v2/linux.md.erb
+++ b/pages/agent/v2/linux.md.erb
@@ -49,4 +49,4 @@ The configuration file is located at `~/.buildkite-agent/buildkite-agent.cfg`. S
 
 ## Upgrading
 
-Simply rerun the install script.
+Rerun the install script.

--- a/pages/agent/v2/osx.md.erb
+++ b/pages/agent/v2/osx.md.erb
@@ -90,4 +90,4 @@ If you installed the agent using Homebrew you can use the standard brew upgrade 
 brew update && brew upgrade buildkite-agent
 ```
 
-If you installed the buildkite-agent using the [Linux install script](linux) then you should simply run the installer script again and it will update your agent.
+If you installed the buildkite-agent using the [Linux install script](linux) then you should run the installer script again and it will update your agent.

--- a/pages/agent/v2/queues.md.erb
+++ b/pages/agent/v2/queues.md.erb
@@ -25,7 +25,7 @@ An agent’s queue is configured in the [agent’s meta-data](agent-meta-data), 
 
 ## Targeting a queue
 
-Just as you would target agents using normal [agent meta-data](agent-meta-data), you can target specific queues using `queue=name` in your build pipeline query rules.
+You can target specific queues using `queue=name` in your build pipeline query rules, in the same way as you would target agents using normal [agent meta-data](agent-meta-data)
 
 For example, the following build step matches only agents running the `deploy` queue (and ignores the agents running the `default` queue):
 

--- a/pages/agent/v2/upgrading_to_v2.md.erb
+++ b/pages/agent/v2/upgrading_to_v2.md.erb
@@ -51,7 +51,7 @@ All agents prior to v2 (including the old Buildbox Ruby agents) are deprecated a
 
 To upgrade, install the new 2.0 agent using the [standard installation methods](/docs/agent/v2/installation) and migrate each pipeline to target the new agents.
 
-To make installation easy we’ve created packages for each of the major operating systems.
+To make installation easier we’ve created packages for each of the major operating systems.
 
 ## Upgrading a 1.0 beta agent
 

--- a/pages/agent/v2/upgrading_to_v2.md.erb
+++ b/pages/agent/v2/upgrading_to_v2.md.erb
@@ -49,7 +49,7 @@ Once you have the new agent running, update your pipeline’s build pipeline ste
 
 All agents prior to v2 (including the old Buildbox Ruby agents) are deprecated and will stop executing new jobs on December 12th 2015.
 
-To upgrade you simply install the a new 2.0 agent using the [standard installation methods](/docs/agent/v2/installation) and migrate each pipeline to target the new agents.
+To upgrade, install the new 2.0 agent using the [standard installation methods](/docs/agent/v2/installation) and migrate each pipeline to target the new agents.
 
 To make installation easy we’ve created packages for each of the major operating systems.
 
@@ -67,4 +67,4 @@ To upgrade a _Red Hat / CentOS_ 1.0 beta agent:
 
 Note that when you install the agent on a new machine using the Debian / rpm packages the agent will be installed and run as the unprivileged `buildkite-agent` user, unlike some beta builds which ran as root.
 
-If you didn't install the agent using the above packages then simply update the agent like you did originally and you should get the latest stable version.
+If you didn't install the agent using the above packages then update the agent like you did originally and you should get the latest stable version.

--- a/pages/agent/v2/upgrading_to_v3.md.erb
+++ b/pages/agent/v2/upgrading_to_v3.md.erb
@@ -28,7 +28,7 @@ You can test your updated agents in parallel to your existing agents by using ag
 
 Added:
 
-* [Plugins](/docs/plugins) for easily sharing functionality between pipelines and customizing how agents behave
+* [Plugins](/docs/plugins) for sharing functionality between pipelines and customizing how agents behave
 * [Variable interpolation](/docs/agent/v3/cli-pipeline) in `pipeline.yml`
 * [Build annotations](/docs/agent/v3/cli-annotate)
 * [pre-exit hook](/docs/agent/v3/hooks#available-hooks)

--- a/pages/agent/v3/aws.md.erb
+++ b/pages/agent/v3/aws.md.erb
@@ -1,6 +1,6 @@
 # Running Buildkite Agent on AWS
 
-The Buildkite Agent can be run easily on AWS using our Elastic CI Stack for AWS.
+The Buildkite Agent can be run on AWS using our Elastic CI Stack for AWS.
 
 {:toc}
 
@@ -16,7 +16,7 @@ that gives you an autoscaling Buildkite Agent cluster in your own AWS. The
 stack includes Docker, S3 and Cloudwatch integration, and is suitable for
 parallelizing large legacy test suites, testing any Linux-based project that can run within Docker, and performing AWS ops related tasks.
 
-[Read the documentation][github] on GitHub, and launch it easily using the
+[Read the documentation][github] on GitHub, and launch it using the
 button on your organization’s Agents page.
 
    [github]: https://github.com/buildkite/elastic-ci-stack-for-aws

--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -67,6 +67,8 @@ buildkite-agent artifact upload test.log
 
 Keep in mind while you’re writing your path pattern:
 
+<!--alex ignore just-->
+
 - patterns must match whole path strings, not just substrings
 - there are two wildcards available that match non-separator characters (on Linux `/` is a separator character, and on Windows `\` is a separator character):
   + `*` to match a sequence of characters
@@ -81,9 +83,7 @@ Keep in mind while you’re writing your path pattern:
 
 Use this command in your build scripts to download artifacts.
 
-
 <%= render 'agent/v3/help/artifact_download' %>
-
 
 ### Artifact download examples
 
@@ -122,6 +122,8 @@ buildkite-agent artifact download "*.png" images/
 ### Artifact download pattern syntax
 
 Artifact downloads support pattern-matching using the `*` character.
+
+<!--alex ignore just-->
 
 Unlike artifact upload glob patterns, these operate over the entire path and not just between separator characters. For example, a download path pattern of `log/*` matches all files under the log directory and all subdirectories.
 

--- a/pages/agent/v3/cli_step.md.erb
+++ b/pages/agent/v3/cli_step.md.erb
@@ -18,7 +18,7 @@ Use this command in your build scripts to get the value of a particular attribut
 
 ## Getting the outcome of a step
 
-If you're just interested in whether a step passed or failed, perhaps to use conditional logic inside your build script, you can use the same approach as above in [Getting a Step](#getting-a-step).
+If you're only interested in whether a step passed or failed, perhaps to use conditional logic inside your build script, you can use the same approach as above in [Getting a Step](#getting-a-step).
 
 For example, the following pipeline has one step that fails (`one`), and another that passes (`two`). After the `wait`, the next two steps print the `outcome` attribute of steps `one` and `two`, and the last step [annotates the build](/docs/agent/v3/cli-annotate#creating-an-annotation) if step `one` fails. Note that `step get` needs the `key` of the step to identify it, not the `label`.
 

--- a/pages/agent/v3/freebsd.md.erb
+++ b/pages/agent/v3/freebsd.md.erb
@@ -61,4 +61,4 @@ The configuration file is located at `~/.buildkite-agent/buildkite-agent.cfg`. S
 
 ## Upgrading
 
-Simply rerun the install script.
+Rerun the install script.

--- a/pages/agent/v3/github_ssh_keys.md.erb
+++ b/pages/agent/v3/github_ssh_keys.md.erb
@@ -3,7 +3,7 @@
 The Buildkite Agent clones your source code directly from GitHub or GitHub Enterprise. The easiest way to provide it with access is by creating a “Buildkite Agent” machine user in your organization, and adding it to a team that has access to the relevant repositories.
 
 <div class="Docs__note">
-<p>If you’re running a build agent on a local development machine which already has access to GitHub then you can skip this setup and simply start running builds.</p>
+<p>If you’re running a build agent on a local development machine which already has access to GitHub then you can skip this setup and start running builds.</p>
 </div>
 
 {:toc}

--- a/pages/agent/v3/installation.md.erb
+++ b/pages/agent/v3/installation.md.erb
@@ -11,7 +11,7 @@ Alternatively you can install it manually using the instructions below.
 
 If you need to install the agent on a system not listed above you'll need to perform a manual installation using one of the binaries from [buildkite-agent’s releases page](https://github.com/buildkite/agent/releases).
 
-Once you have a binary you simply create a bin and builds directory in `~/.buildkite-agent` and copy the binary and `bootstrap.sh` file into place:
+Once you have a binary, create `bin` and `builds` directories in `~/.buildkite-agent` and copy the binary and `bootstrap.sh` file into place:
 
 ```bash
 mkdir ~/.buildkite-agent ~/.buildkite-agent/bin ~/.buildkite-agent/builds

--- a/pages/agent/v3/linux.md.erb
+++ b/pages/agent/v3/linux.md.erb
@@ -44,4 +44,4 @@ The configuration file is located at `~/.buildkite-agent/buildkite-agent.cfg`. S
 
 ## Upgrading
 
-Simply rerun the install script.
+Rerun the install script.

--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -119,4 +119,4 @@ If you installed the agent using Homebrew you can use the standard brew upgrade 
 brew update && brew upgrade buildkite-agent
 ```
 
-If you installed the buildkite-agent using the [Linux install script](linux) then you should simply run the installer script again and it will update your agent.
+If you installed the buildkite-agent using the [Linux install script](linux) then you should run the installer script again and it will update your agent.

--- a/pages/agent/v3/tokens.md.erb
+++ b/pages/agent/v3/tokens.md.erb
@@ -36,6 +36,8 @@ mutation {
 }
 ```
 
+<!--alex ignore clearly-->
+
 The token description should clearly identify the environment the token is intended to be used for, and is shown on your [Agents page](https://buildkite.com/organizations/-/agents) (for example, `Read-only token for static site generator`).  
 
 It is possible to create multiple agent tokens using the GraphQL API. These tokens will show up on the [Agents page](https://buildkite.com/organizations/-/agents) in the UI, but can only be managed (created or revoked) via the API.    

--- a/pages/apis/webhooks/integrations.md.erb
+++ b/pages/apis/webhooks/integrations.md.erb
@@ -29,6 +29,6 @@ To use Buildkite webhooks with Zapier create a new Zap and select Webhook.
 
 ## Webtask
 
-[Webtask](https://webtask.io/) makes it easy to write Node.js powered backend code without having to run a server, and it supports cron (scheduled runs) and secure token storage (for things like API keys). You can use our LIFX webtask example to get started with processing webhooks using Webtask:
+[Webtask](https://webtask.io/) allows you to write Node.js powered backend code without having to run a server, and it supports cron (scheduled runs) and secure token storage (for things like API keys). You can use our LIFX webtask example to get started with processing webhooks using Webtask:
 
 <a class="Docs__example-repo" href="https://github.com/buildkite/lifx-buildkite-build-light-webtask">:node: Webtask.io webhook example application <span class="repo">github.com/buildkite/lifx-buildkite-build-light-webtask</span></a>

--- a/pages/deployments.md.erb
+++ b/pages/deployments.md.erb
@@ -19,13 +19,13 @@ steps:
 
   - label: "🚀"
     command: "scripts/deploy"
-    if: build.branch == 'master'
+    if: build.branch == 'main'
     concurrency: 1
     concurrency_group: "my-app-deploy"
 ```
 {: codeblock-file="pipeline.yml"}
 
-This pipeline uses a [conditional](/docs/pipelines/conditionals) to only run on commits to the master branch, and sets a [concurrency limit](/docs/pipelines/controlling-concurrency) of 1 to ensure that only one deployment happens at a time.
+This pipeline uses a [conditional](/docs/pipelines/conditionals) to only run on commits to the main branch, and sets a [concurrency limit](/docs/pipelines/controlling-concurrency) of 1 to ensure that only one deployment happens at a time.
 
 <%= image "deploy-step.png", width: 1482/2, height: 730/2, alt: "Screenshot of a deploy step output" %>
 
@@ -68,13 +68,13 @@ steps:
 
   - label: "🚀"
     trigger: "my-app-deploy"
-    if: build.branch == 'master'
+    if: build.branch == 'main'
     build:
       commit: "$BUILDKITE_COMMIT"
 ```
 {: codeblock-file="pipeline.yml"}
 
-Once the tests run successfully, if the commit is on the master branch then continuous deployment is done by triggering a build on the deployment pipeline.
+Once the tests run successfully, if the commit is on the main branch then continuous deployment is done by triggering a build on the deployment pipeline.
 
 The deployment pipeline (with slug `my-app-deployment`) could be configured to upload the following `.buildkite/deploy.pipeline.yml` file:
 
@@ -82,7 +82,7 @@ The deployment pipeline (with slug `my-app-deployment`) could be configured to u
 steps:
   - label: "🚀"
     command: "scripts/deploy"
-    if: build.branch == 'master'
+    if: build.branch == 'main'
     concurrency: 1
     concurrency_group: "my-app-deploy"
 ```
@@ -110,7 +110,7 @@ steps:
 
   - label: "🚀"
     command: "scripts/deploy"
-    if: build.branch == 'master'
+    if: build.branch == 'main'
     concurrency_group: "my-app-deploy"
     concurrency: 1
 ```

--- a/pages/pipelines.md.erb
+++ b/pages/pipelines.md.erb
@@ -8,7 +8,7 @@ Pipelines are the top level containers for modelling and defining your workflows
 
 A pipeline is a template of the steps you want to run. There are many types of steps, some run scripts, some define conditional logic, and others wait for user input. When you run a pipeline, a build is created. Each of the steps in the pipeline end up as jobs in the build, which then get distributed to available agents.
 
-## Is this just for running tests and deploying code?
+## Is this only for running tests and deploying code?
 
 Not at all! You can do all kinds of exciting things with pipelines, like generating static sites, running data imports, provisioning servers, and automating app store submissions. You can even use pipelines to [create other pipelines](/docs/pipelines/uploading-pipelines) 😱
 


### PR DESCRIPTION
Pronfanity has been there forever I think. Who lints the linters?

More importantly, the missing quotes around the regex do affect things badly, and leaves us an extra 25 "simply" type things to fix up. 

When we're done we can add the `--diff` back, so it only runs on changed files.