### PR TITLE
Add styling for Experimental/WIP feature callouts

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -272,7 +272,7 @@ a.Docs__example-repo {
     font-weight: bold;
     color: orange;
     &:before {
-      content: '🚧 ';
+      content: '🛠 ';
     }
   }
 }

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -266,7 +266,7 @@ a.Docs__example-repo {
   border-left-color: orange;
   margin-top: 2rem;
   margin-bottom: 2rem;
-  h1 {
+  .Docs__wip-heading {
     font: inherit;
     color: inherit;
     font-weight: bold;

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -113,8 +113,8 @@ Make sure to set the `-o pipefail` option in your buildscript as above, otherwis
 
 ## Redacted environment variables
 
-<div class="Docs__experiment">
-<p class="Docs__experiment__heading">Experimental feature</p>
+<div class="Docs__wip-note">
+<p class="Docs__wip-heading">Experimental feature</p>
 <p>This is an experimental feature, set <code>experiment="output-redactor"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a> to use it.</p>
 </div>
 


### PR DESCRIPTION
The requirement here was a style to flag when a given feature was experimental/WIP.

Turns out there was an existing style there for pretty much exactly this use case — it wasn't in use anywhere, so I've refactored it very slightly to avoid a dependence on its headings being H1's, and have updated the existing example page ("Managing Log Output") to use this class instead.

<img width="770" alt="image" src="https://user-images.githubusercontent.com/2824446/113805627-2ec49d00-97a4-11eb-8493-b1f6750df133.png">
