### PR TITLE
Proof of concept of attributes as yaml

### DIFF
--- a/app/models/agent_attributes.rb
+++ b/app/models/agent_attributes.rb
@@ -1,0 +1,1 @@
+AGENT_ATTRIBUTES = YAML.load_file('data/agent_attributes.yaml').freeze

--- a/data/agent_attributes.yaml
+++ b/data/agent_attributes.yaml
@@ -1,0 +1,11 @@
+---
+- attribute: bootstrap-script
+  desc: |
+      <p>Command to invoke the bootstrap process.</p>
+      <p class="Docs__api-param-eg"><em>Default:</em> <code>"buildkite-agent bootstrap"</code></p>
+      <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BOOTSTRAP_SCRIPT_PATH</code></p>
+- attribute: build-path
+  desc: |
+      <p>Path to where the builds will run from.</p>
+      <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
+      <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BUILD_PATH</code></p>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -32,6 +32,20 @@ _Required attributes:_
   </tbody>
 </table>
 
+_ Test attributes:_
+
+<table>
+  <tbody>
+    <% AGENT_ATTRIBUTES.each do |attr| %>
+      <tr id="<%= attr['attribute'] %>">
+        <th><code><%= attr['attribute'] %></code></th>
+        <td><%= attr['desc'] %></td>
+      </tr>
+      <% end %>
+  </tbody>
+</table>
+
+
 _Optional attributes:_
 
 <table>


### PR DESCRIPTION
Following on from data as  Ruby constants in `models` this lets you source YAML files from `data` and iterate over them. 

Which would mean you don't need to add the id manually, but can generate it from the attribute name.

```html
    <tr id="build-path">
      <th><code>build-path</code></th>
      <td>
        Path to where the builds will run from.
        <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
        <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_BUILD_PATH</code></p>
      </td>
    </tr>
```

which by itself isn't worth making the change. 

But you could also change the html formatting at low effort. And include single attribute data in other places. 