### PR TITLE
adding in missing documentation for using a key as part of a block step

### DIFF
--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -79,6 +79,13 @@ _Optional attributes:_
       <em>Example:</em> <code>"test-suite"</code>
     </td>
    </tr>
+  <tr>
+    <td><code>key</code></td>
+    <td>
+	A unique string to identify the block step.
+      <em>Example:</em> <code>"test-suite"</code>
+    </td>
+   </tr>
    <tr>
     <td><code>allow_dependency_failure</code></td>
     <td>


### PR DESCRIPTION
While setting up dependencies for steps, I found this article which describes an undocumented feature of the block step.

https://forum.buildkite.community/t/step-dependencies-and-block/862

I added in a basic row to call this out