### PR TITLE
Adding an example using depends_on with block steps

### DIFF
--- a/pages/pipelines/dependencies.md.erb
+++ b/pages/pipelines/dependencies.md.erb
@@ -88,6 +88,23 @@ steps:
 
 Even though the second command step in the above example is after a wait step, the empty dependency directs it not to wait until after the `wait` step is complete. Both commands steps will be available to run immediately at the start of the build.
 
+Explicit dependencies on block steps can be added without setting additional input values. You can use this to define a "Deploy" button, for example.
+
+```yml
+steps:
+  - command: "build.sh"
+    key: "built"
+  - block: "Deploy"
+    key: "blocked-deploy"
+    depends_on:
+      - "built"
+  - command: "release.sh"
+    depends_on:
+      - "built"
+      - "blocked-deploy"
+```
+{: codeblock-file="pipeline.yml"}
+
 ## Order of operations
 
 There are three step attributes that can each affect when a step is able to run:


### PR DESCRIPTION
Adding an example of using block _without_ input fields to set subsequent dependencies