### PR TITLE
Add build.state to conditional list

### DIFF
--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -210,6 +210,11 @@ The below variables are supported by the `if` attribute:
 		<td>The source of the event that created the build<br><em>Available sources:</em> <code>ui</code>, <code>api</code>, <code>webhook</code>, <code>trigger_job</code>, <code>schedule</code></td>
 	</tr>
 	<tr>
+		<td><code>build.state</code></td>
+		<td><code>String</code></td>
+		<td>The state the current build is in<br><em>Available states:</em> <code> scheduled</code>, <code> running</code>, <code> passed</code>, <code> failed</code>, <code> blocked</code>, <code> canceling</code>, <code> canceled</code>, <code> skipped</code>, <code> not_run</code>, <code> finished</code></td>
+	</tr>
+	<tr>
 		<td><code>build.tag</code></td>
 		<td><code>String</code>, <code>null</code></td>
 		<td>The tag associated with the commit the current build is based on</td>


### PR DESCRIPTION
It looks like `build.state` has been around a while as a conditional, no idea how I managed to leave it off the list 😅 😬

This PR adds the state conditional to the 'Supported Variables' section of the Using Conditionals page. It is already used in examples on the Notifications page.

![image](https://user-images.githubusercontent.com/2074469/115184408-1f890c00-a121-11eb-86e7-52edd4e70987.png)
