### PR TITLE
Update Algolia config to match new sidebar structure

### DIFF
--- a/config/algolia.json
+++ b/config/algolia.json
@@ -8,7 +8,7 @@
   ],
   "selectors": {
     "lvl0": {
-      "selector": ".Docs__nav__section-heading:not(.Docs__nav__section-heading--link)",
+      "selector": ".Docs__nav__section-container.current > .Docs__nav__section-heading",
       "global": true,
       "default_value": "Documentation"
     },
@@ -22,6 +22,7 @@
   },
   "selectors_exclude": [
     ".Docs__toc",
-    ".Docs__note--footer-typo"
+    ".Docs__note--footer-typo",
+    ".HomepageCategory"
   ]
 }


### PR DESCRIPTION
When I pushed [the update to the sidebar](https://github.com/buildkite/docs/pull/999) last week, the changes in markup broke our Algolia config, and gave us useless categories that look like this:

![image](https://user-images.githubusercontent.com/2824446/115650239-32435100-a36c-11eb-8b0f-e30405ccd8ab.png)

This PR updates the selector that Algolia uses to determine the `lvl0` (ie, root category) for a given record, to match the current markup. Algolia should then update and go back to normal the next time its scraper runs (which happens ["every 24 hours"](https://docsearch.algolia.com/docs/scraper)).

I've also manually excluded the content categories that live on the new docs landing page, so they won't be indexed for search.