### PR TITLE
Proof of concept: Hide the response

### DIFF
--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -20,6 +20,7 @@ class Page::Renderer
     doc = add_table_of_contents(doc)
     doc = fix_curl_highlighting(doc)
     doc = add_code_filenames(doc)
+    doc = hide_code(doc)
     doc.to_html.html_safe
   end
 
@@ -144,6 +145,22 @@ class Page::Renderer
       node.remove
     end
     
+    doc
+  end
+
+  def hide_code(doc)
+    doc.search('./p').each do |node|
+      next unless node.text.starts_with?('{: code="hidden"')
+
+      details = Nokogiri::XML::Node.new "details", doc
+      summary = Nokogiri::XML::Node.new "summary", doc
+      summary.content = "Show response body"
+      details.add_child(summary)
+      node.previous_element.add_previous_sibling(details)
+      node.previous_element.parent = details
+      node.remove
+    end
+
     doc
   end
 

--- a/pages/apis/rest_api/pipelines.md.erb
+++ b/pages/apis/rest_api/pipelines.md.erb
@@ -219,7 +219,6 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines" \
 ```
 
 
-
 ```json
 {
   "id": "14e9501c-69fe-4cda-ae07-daea9ca3afd3",
@@ -329,6 +328,7 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines" \
   "visibility": "private"
 }
 ```
+{: code="hidden"}
 
 The resulting pipeline:
 


### PR DESCRIPTION
Use the `details` tag to hide and expand code sections:

## Hidden

![image](https://user-images.githubusercontent.com/95874/115707283-db8b4680-a36e-11eb-85c6-f7a1428b73b6.png)

## Expanded

![image](https://user-images.githubusercontent.com/95874/115707336-f1007080-a36e-11eb-8ec8-624467a53b63.png)

## Caveats:

- Currently is either/or with  `code-filename`
- Hardcoded summary