### PR TITLE
Fixing minor typo in docs

### DIFF
--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -43,7 +43,7 @@ steps:
 
 We use CommonMark with GitHub Flavored Markdown extensions to provide consistent, unambiguous Markdown syntax.
 
-GitHub [kindly provide a guide](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) to this syntax.
+GitHub [kindly provides a guide](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) to this syntax.
 
 Annotations do not support GitHub-style syntax highlighting, task lists, user mentions, or automatic links for references to issues, pull requests or commits.
 


### PR DESCRIPTION
I believe the sense of the documentation could be improved by this PR.

I know there is debate whether to use singular or plural verbs when referring to a company's actions, but according to the sources cited [here](https://www.grammarphobia.com/blog/2018/01/it-or-they.html), British English allows either singular or plural and American English uses singular verbs "unless you wish to emphasize the individuals who make up the organization; in that case, use the plural" (quoted [here](https://www.grammarphobia.com/blog/2018/01/it-or-they.html)).