### PR TITLE
Proof of concept: API docs using redocly

### DIFF
--- a/app/controllers/redoc_controller.rb
+++ b/app/controllers/redoc_controller.rb
@@ -1,0 +1,7 @@
+
+class RedocController < ApplicationController
+    def index
+    end
+   end
+   
+   

--- a/app/views/redoc/index.html.erb
+++ b/app/views/redoc/index.html.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>ReDoc</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='http://petstore.swagger.io/v2/swagger.json'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,8 @@ Rails.application.routes.draw do
   # Quick Reference JSON
   get "/docs/quick-reference/pipelines", to: "quick_reference#pipelines", as: :pipelines_quick_reference
 
+  get "/docs/redoc", to: "redoc#index", as: :redoc
+
   # Homepage
   get "/docs" => "pages#index", as: :home_page
 


### PR DESCRIPTION
Unformatted, and fetches `swagger.json` remotely.

![image](https://user-images.githubusercontent.com/95874/117160126-25d5e400-adc1-11eb-953f-81cd9fed5d64.png)
![image](https://user-images.githubusercontent.com/95874/117160202-35552d00-adc1-11eb-9256-229d27ad0af4.png)

* https://github.com/Redocly/redoc