### PR TITLE
Update GHEnterprise Firewalled Installation IP

### DIFF
--- a/pages/integrations/github_enterprise.md.erb
+++ b/pages/integrations/github_enterprise.md.erb
@@ -68,7 +68,7 @@ Buildkite will recognize that it's hosted on your GitHub Enterprise Server, and 
 
 If your GitHub Enterprise is behind a firewall you’ll need to allow Buildkite’s IP address so we can perform OAuth authentications using GitHub Enterprise API to update your pull request statuses.
 
-All Buildkite network traffic to your GitHub Enterprise Server will come from a set list of IP addresses. As the IP addresses are subject to change, it is best to retrieve them directly from the [Meta API endpoint](/docs/apis/rest-api/meta#get-meta-information). Please configure your network to allow traffic from all IP addressres returned by the endpoint.
+All Buildkite network traffic to your GitHub Enterprise Server will come from a set list of IP addresses. As the IP addresses are subject to change, it is best to retrieve them directly from the [Meta API endpoint](/docs/apis/rest-api/meta#get-meta-information). Please configure your network to allow traffic from all IP addresses returned by the endpoint.
 
 For additional security you can create a proxy which allows only the API endpoints we require:
 

--- a/pages/integrations/github_enterprise.md.erb
+++ b/pages/integrations/github_enterprise.md.erb
@@ -68,7 +68,14 @@ Buildkite will recognize that it's hosted on your GitHub Enterprise Server, and 
 
 If your GitHub Enterprise is behind a firewall you’ll need to allow Buildkite’s IP address so we can perform OAuth authentications use GitHub Enterprise API to update your pull request statuses.
 
-All Buildkite network traffic to your GitHub Enterprise Server will come from the following IP address: `54.165.103.71`. Please configure your network to allow traffic from this IP address.
+All Buildkite network traffic to your GitHub Enterprise Server will come from the following IP addresses:
+
+* `100.24.182.113`
+* `35.172.45.249`
+* `54.165.103.71`
+* `54.85.125.32`
+
+This list can be retrieved from the [Meta API](/docs/api/rest-api/meta#get-meta-information). Please configure your network to allow traffic from this IP address.
 
 For additional security you can create a proxy which allows only the API endpoints we require:
 

--- a/pages/integrations/github_enterprise.md.erb
+++ b/pages/integrations/github_enterprise.md.erb
@@ -66,16 +66,9 @@ Buildkite will recognize that it's hosted on your GitHub Enterprise Server, and 
 
 ## Firewalled installs
 
-If your GitHub Enterprise is behind a firewall you’ll need to allow Buildkite’s IP address so we can perform OAuth authentications use GitHub Enterprise API to update your pull request statuses.
+If your GitHub Enterprise is behind a firewall you’ll need to allow Buildkite’s IP address so we can perform OAuth authentications using GitHub Enterprise API to update your pull request statuses.
 
-All Buildkite network traffic to your GitHub Enterprise Server will come from the following IP addresses:
-
-* `100.24.182.113`
-* `35.172.45.249`
-* `54.165.103.71`
-* `54.85.125.32`
-
-This list can be retrieved from the [Meta API](/docs/api/rest-api/meta#get-meta-information). Please configure your network to allow traffic from this IP address.
+All Buildkite network traffic to your GitHub Enterprise Server will come from a set list of IP addresses. As the IP addresses are subject to change, it is best to retrieve them directly from the [Meta API endpoint](/docs/apis/rest-api/meta#get-meta-information). Please configure your network to allow traffic from all IP addressres returned by the endpoint.
 
 For additional security you can create a proxy which allows only the API endpoints we require:
 


### PR DESCRIPTION
The docs for GitHub Enterprise Firewalled Installations referenced one
specific IP address, which I think is the old egress IP address from
before [the new IPs](https://buildkite.com/changelog/118-new-outbound-ip-addresses) were
allocated.

This PR adds the new (current) IPs, as well as a reference to where one
can find the updated list (the meta API)