### PR TITLE
Mention Datadog metric unit

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -224,7 +224,7 @@ _Optional attributes:_
     <tr id="metrics-datadog">
       <th><code>metrics-datadog</code></th>
       <td>
-        Send metrics to DogStatsD for Datadog. This will generate the following metrics:<br>
+        Send metrics to DogStatsD for Datadog. This will generate the following metrics (duration measured in milliseconds):<br>
         <code>buildkite.jobs.success</code><br>
         <code>buildkite.jobs.duration.success.avg</code><br>
         <code>buildkite.jobs.duration.success.max</code><br>


### PR DESCRIPTION
These are sent in milliseconds according to the agent codebase, however without trawling through a bunch of Go this is not very clear.