### PR TITLE
Mobile experience improvements (and other Google lighthouse fixups)

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -3,11 +3,13 @@ $color-green: rgb(3, 165, 98);
 
 .Docs__page-container {
   padding-top: 20px;
+  @media (max-width: $Docs__bp_stacked) { padding: 0; }
 }
 
 .Docs__page-container__inner {
   display: flex;
-  @media (max-width: $Docs__bp_stacked) { display: block; }
+  margin-top: 75px;
+  @media (max-width: $Docs__bp_stacked) { display: block; margin-top: 0; }
 }
 
 .Docs__header {
@@ -20,6 +22,22 @@ $color-green: rgb(3, 165, 98);
   margin-top: .8em;
   @media (max-width: $Docs__bp_stacked) { margin-left: -20px; margin-right: -20px; margin-bottom: 40px; padding-right: 0; }
   position: relative;
+}
+
+.Docs__nav__sections {
+  @media (max-width: $Docs__bp_stacked) {
+    margin-top: 40px;
+    &::before {
+      content: "Menu";
+      display: block;
+      color: #767676;
+      text-transform: uppercase;
+      font-size: 11px;
+      font-weight: 600;
+      margin-left: 20px;
+      margin-bottom: 15px;
+    }
+  }
 }
 
 .Docs__nav__section-container {
@@ -36,6 +54,7 @@ $color-green: rgb(3, 165, 98);
       color: $color-green;
       &::after {opacity: 1.0;}
     }
+
     &::after {
       content: '';
       display: block;
@@ -43,7 +62,7 @@ $color-green: rgb(3, 165, 98);
       height: 8px;
       border-right: 1px solid #aaa;
       border-bottom: 1px solid #aaa;
-      right: 0;
+      right: 20px;
       top: 4px;
       position: absolute;
       transform: rotate(45deg);
@@ -75,11 +94,7 @@ $color-green: rgb(3, 165, 98);
   color: black;
 
   @media (max-width: $Docs__bp_stacked) {
-    font-size: 1.4rem;
-    margin: 0;
     padding-left: 20px;
-    padding-top: 15px;
-    padding-bottom: 15px;
   }
 
   &:first-of-type { margin-top: 0; }

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -20,23 +20,16 @@ $color-green: rgb(3, 165, 98);
   flex: 2;
   padding-right: 20px;
   margin-top: .8em;
-  @media (max-width: $Docs__bp_stacked) { margin-left: -20px; margin-right: -20px; margin-bottom: 40px; padding-right: 0; }
+  @media (max-width: $Docs__bp_stacked) {
+    margin: 0 -20px 40px -20px;
+    padding-right: 0;
+  }
   position: relative;
 }
 
 .Docs__nav__sections {
   @media (max-width: $Docs__bp_stacked) {
-    margin-top: 40px;
-    &::before {
-      content: "Menu";
-      display: block;
-      color: #767676;
-      text-transform: uppercase;
-      font-size: 11px;
-      font-weight: 600;
-      margin-left: 20px;
-      margin-bottom: 15px;
-    }
+    margin-top: 30px;
   }
 }
 
@@ -44,15 +37,21 @@ $color-green: rgb(3, 165, 98);
   margin-bottom: 20px;
   width: 100%;
 
+  &.Docs__nav__section-container.expanded .Docs__nav__section-heading::after {
+    opacity: 1;
+  }
+
   .Docs__nav__section-heading { 
     cursor: pointer;
     position: relative;
     user-select: none;
 
-    &:hover {
-      transition: all 0.1s;
-      color: $color-green;
-      &::after {opacity: 1.0;}
+    @media (hover: hover) {
+      &:hover {
+        transition: transform 0.1s;
+        color: $color-green;
+        &::after { opacity: 1; }
+      }
     }
 
     &::after {
@@ -62,12 +61,12 @@ $color-green: rgb(3, 165, 98);
       height: 8px;
       border-right: 1px solid #aaa;
       border-bottom: 1px solid #aaa;
-      right: 20px;
+      right: 25px;
       top: 4px;
       position: absolute;
       transform: rotate(45deg);
       transform-origin: 75% 75%;
-      transition: all 0.2s;
+      transition: transform 0.2s;
       opacity: 0;
     }
   }
@@ -197,6 +196,7 @@ $color-green: rgb(3, 165, 98);
   transition: background-color 300ms;
 
   @media (max-width: $Docs__bp_stacked) {
+    margin-top: 10px;
     margin-left: 20px;
   }
 

--- a/app/assets/stylesheets/public/_site_header.scss
+++ b/app/assets/stylesheets/public/_site_header.scss
@@ -41,7 +41,7 @@ $SiteHeader__bp_wrap_search: 600px;
 .SiteHeader__mark {
   margin-right: .5em;
   svg {
-    width: 30px;
+    width: 28px;
     height: auto;
     margin-top: .55em;
   }

--- a/app/assets/stylesheets/public/_site_header.scss
+++ b/app/assets/stylesheets/public/_site_header.scss
@@ -1,6 +1,6 @@
 $SiteHeaderLogoHeight: 36px;
 $SiteHeader__bp_small_screen_nav: 850px;
-$SiteHeader__bp_wrap_search: 550px;
+$SiteHeader__bp_wrap_search: 400px;
 
 .SiteHeader {
   position: absolute;
@@ -55,11 +55,10 @@ $SiteHeader__bp_wrap_search: 550px;
   line-height: $SiteHeaderLogoHeight;
   display: inline-block;
   margin-right: 1em;
+  margin-bottom: 1em;
 }
 
 .SiteHeader__search {
-  flex: 0 0 300px;
-  align-self: flex-end;
   @media (max-width: $SiteHeader__bp_wrap_search) {
     flex: 1 1 300px;
   }

--- a/app/assets/stylesheets/public/_site_header.scss
+++ b/app/assets/stylesheets/public/_site_header.scss
@@ -1,6 +1,5 @@
 $SiteHeaderLogoHeight: 36px;
-$SiteHeader__bp_small_screen_nav: 850px;
-$SiteHeader__bp_wrap_search: 400px;
+$SiteHeader__bp_wrap_search: 600px;
 
 .SiteHeader {
   position: absolute;
@@ -11,21 +10,18 @@ $SiteHeader__bp_wrap_search: 400px;
   padding-bottom: 20px;
   line-height: $SiteHeaderLogoHeight;
   z-index: 5;
+
+  @media (max-width: $SiteHeader__bp_wrap_search) {
+    position: relative;
+    padding-bottom: 0;
+  }
 }
 
 .SiteHeader__inner {
   display: flex;
-  align-items: stretch;
-  justify-content: space-between;
   @media (max-width: $SiteHeader__bp_wrap_search) {
-    flex-wrap: wrap;
+    flex-direction: column;
   }
-}
-
-.SiteHeader_minimal__inner {
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
 }
 
 .SiteHeader__docslink {
@@ -40,9 +36,14 @@ $SiteHeader__bp_wrap_search: 400px;
   &:hover, &:focus, &:active {
     color: #14CC80;
   }
+}
 
-  > .SiteHeader__mark {
-    margin-right: .5em;
+.SiteHeader__mark {
+  margin-right: .5em;
+  svg {
+    width: 30px;
+    height: auto;
+    margin-top: .55em;
   }
 }
 
@@ -55,12 +56,13 @@ $SiteHeader__bp_wrap_search: 400px;
   line-height: $SiteHeaderLogoHeight;
   display: inline-block;
   margin-right: 1em;
-  margin-bottom: 1em;
+  margin-bottom: .5em;
 }
 
 .SiteHeader__search {
+  margin-left: auto;
   @media (max-width: $SiteHeader__bp_wrap_search) {
-    flex: 1 1 300px;
+    width: 100%;
   }
 }
 
@@ -85,47 +87,4 @@ $SiteHeader__bp_wrap_search: 400px;
   &:-moz-placeholder { color: rgba(#555, .35); }
   &::-moz-placeholder { color: rgba(#555, .35); }
   &:-ms-input-placeholder { color: rgba(#555, .35); }
-}
-
-$SiteHeader__logo-width: 173px;
-$SiteHeader__logo-height: 33px;
-
-.SiteHeader__logo {
-  position: relative;
-  width: $SiteHeader__logo-width * .95;
-  height: $SiteHeader__logo-height * .95;
-  left: 4px;
-  top: 3px;
-  @media (max-width: $SiteHeader__bp_small_screen_nav) {
-    left: 0px;
-    top: 1px;
-  }
-}
-
-.SiteHeader__mark {
-  > svg {
-    width: 30px;
-    height: auto;
-    margin-top: .55em;
-  }
-}
-
-.SiteHeader__nav {
-  flex: 1;
-  margin-left: 30px;
-}
-
-.SiteHeader__small_nav_toggle {
-  display: none;
-  @media (max-width: $SiteHeader__bp_small_screen_nav) {
-    display: block;
-    position: absolute;
-    text-align: center;
-    padding: 0;
-    width: 40px;
-    height: 40px;
-    .fa { line-height: 42px; }
-    top: 15px;
-    right: 15px;
-  }
 }

--- a/app/assets/stylesheets/public/utils/_standard_top_section.scss
+++ b/app/assets/stylesheets/public/utils/_standard_top_section.scss
@@ -3,12 +3,3 @@
   padding-bottom: 40px;
   color: inherit;
 }
-
-.StandardTopSection--empty {
-  @extend .StandardTopSection;
-  padding-bottom: 16px;
-
-  @media (max-width: 600px) {
-    padding-bottom: 10px;
-  }
-}

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -261,7 +261,7 @@
       }
       
       let sectionHeaders = document.getElementsByClassName('Docs__nav__section-heading');
-      for(let sectionHeader of sectionHeaders){
+      for (let sectionHeader of sectionHeaders) {
         sectionHeader.onclick = function() {
           let parent = sectionHeader.parentElement;
           let alreadyExpanded = parent.classList.contains('expanded'); // Track whether section is already expanded, in which case we want to hide it
@@ -275,9 +275,12 @@
         }
       };
 
-      // hide agent v2 section if we're not browsing it 
-      if (window.location.pathname.indexOf('v2') == -1) {
-        
-      }
+      // don't auto-expand nav on small screens
+      if (window.matchMedia && window.matchMedia('(max-width: 600px)').matches) {
+        let expandedSectionContainers = document.querySelectorAll('.Docs__nav__section-container.expanded');
+        for (let expandedSectionContainer of expandedSectionContainers) {
+          expandedSectionContainer.classList.remove('expanded');
+        }
+      }      
   })();
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,12 +54,12 @@
               <svg
                   width="<%= local_assigns.fetch(:width) { 42 } %>"
                   height="<%= local_assigns.fetch(:height) { 28 } %>"
-                  viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title>Buildkite Mark</title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
+                  viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title>Buildkite</title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
             </span>
             Docs
           <% end %>
         </h1>
-        <p class="OffScreen SiteHeader__tagline">Powerful build automation and continous deployment.</p>
+        <p class="OffScreen SiteHeader__tagline">Lightning fast testing and delivery for all your software projects.</p>
         <p class="OffScreen SiteHeader__skip-nav"><a href="#main">Skip to main content</a></p>
         <div class="SiteHeader__search">
           <input id="search" placeholder="Search" />
@@ -67,8 +67,6 @@
       </div>
     </header>
     <main id="main" role="main">
-      <div class="StandardTopSection--empty"></div>
-
       <div class="Docs__page-container StandardWhiteContentPage">
         <div class="Docs__page-container__inner PageContainer">
           <%= render 'layouts/sidebar' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,9 +54,9 @@
               <svg
                   width="<%= local_assigns.fetch(:width) { 42 } %>"
                   height="<%= local_assigns.fetch(:height) { 28 } %>"
-                  viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title>Buildkite</title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
+                  viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title></title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
             </span>
-            Docs
+            Buildkite Docs
           <% end %>
         </h1>
         <p class="OffScreen SiteHeader__tagline">Lightning fast testing and delivery for all your software projects.</p>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -56,7 +56,7 @@
       <svg
           width="84"
           height="56"
-          viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title>Buildkite Mark</title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
+          viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title>Buildkite</title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
       <h1>Buildkite Docs</h1>
       <p class="OffScreen SiteHeader__tagline">Lightning fast testing and delivery for all your software projects.</p>
       <p class="OffScreen SiteHeader__skip-nav"><a href="#main">Skip to main content</a></p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -10,7 +10,7 @@
   <div class="grid-row">
     <div class="HomepageCategory">
       <h2>
-        <%= image_tag("icons/rocketship.svg") %>
+        <%= image_tag("icons/rocketship.svg", alt: "") %>
         <a href="/docs/tutorials/getting-started">Getting started</a>
       </h2>
       <span>For when you're new to Buildkite</span>
@@ -22,7 +22,7 @@
     </div>
     <div class="HomepageCategory">
       <h2>
-        <%= image_tag("icons/repository.svg") %>
+        <%= image_tag("icons/repository.svg", alt: "") %>
         <a href="/docs/integrations/source-control">Source control</a>
       </h2>
       <span>Trigger builds from wherever your code is stored</span>
@@ -35,11 +35,11 @@
       </ul>
     </div>
     <div class="HomepageCategory" style="text-align: center; padding-top: 40px;">
-      <%= image_tag("home/docs-rocket.jpg", class: "HomepageCategory__icon") %>
+      <%= image_tag("home/docs-rocket.jpg", class: "HomepageCategory__icon", alt: "") %>
     </div>
     <div class="HomepageCategory">
       <h2>
-        <%= image_tag("icons/agents_install.svg") %>
+        <%= image_tag("icons/agents_install.svg", alt: "") %>
         <a href="/docs/agent/v3#installation">Installing Buildkite agents</a>
       </h2>
       <span>Install agents on your infrastructure</span>
@@ -55,7 +55,7 @@
     </div>
     <div class="HomepageCategory">
     <h2>
-      <%= image_tag("icons/agents.svg") %>
+      <%= image_tag("icons/agents.svg", alt: "") %>
       <a href="/docs/agent/v3">Running Buildkite agents</a>
     </h2>
     <span>Configuring your Buildkite agents</span>
@@ -70,7 +70,7 @@
   </div>
     <div class="HomepageCategory">
       <h2>
-      <%= image_tag("icons/pipeline.svg") %>
+      <%= image_tag("icons/pipeline.svg", alt: "") %>
         <a href="/docs/pipelines">Configuring pipelines</a>
       </h2>
       <span>Common tasks and workflows</span>
@@ -85,7 +85,7 @@
     </div>
     <div class="HomepageCategory">
       <h2>
-        <%= image_tag("icons/deploy.svg") %>
+        <%= image_tag("icons/deploy.svg", alt: "") %>
         <a href="/docs/deployments">Deployments</a>
       </h2>
       <span>Publish to other systems</span>
@@ -97,7 +97,7 @@
     </div>
     <div class="HomepageCategory">
       <h2>
-        <%= image_tag("icons/integration.svg") %>
+        <%= image_tag("icons/integration.svg", alt: "") %>
         <a href="/docs/apis">APIs and integrations</a>
       </h2>
       <span>Write your own customizations</span>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -544,7 +544,7 @@ _Optional attributes:_
         Do not automatically verify SSH fingerprints for first-time checkouts.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_AUTOMATIC_SSH_FINGERPRINT_VERIFICATION</code></p>
-        <p class="Docs__api-param-eg"><a href="#no-ssh-keyscan"><em>Use instead:</em> <code>no-ssh-keyscan</code><a/></p>
+        <p class="Docs__api-param-eg"><a href="#no-ssh-keyscan"><em>Use instead:</em> <code>no-ssh-keyscan</code></a></p>
       </td>
     </tr>
   </tbody>

--- a/public/404.html
+++ b/public/404.html
@@ -150,27 +150,6 @@
         margin-left: 30px
       }
 
-      .SiteHeader__small_nav_toggle {
-        display: none
-      }
-
-      @media (max-width: 850px) {
-        .SiteHeader__small_nav_toggle {
-            display: block;
-            position: absolute;
-            text-align: center;
-            padding: 0;
-            width: 40px;
-            height: 40px;
-            top: 15px;
-            right: 15px
-        }
-
-        .SiteHeader__small_nav_toggle .fa {
-            line-height: 42px
-        }
-      }
-
       .OffScreen {
           overflow: hidden;
           text-indent: -1000px;
@@ -357,11 +336,10 @@
             <svg
               width="42"
               height="28"
-              viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title>Buildkite Mark</title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
+              viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title>Buildkite</title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
           </a>
         </p>
-        <p class="OffScreen SiteHeader__tagline">Powerful build automation and continous deployment.</p>
-        <p class="OffScreen SiteHeader__skip-nav"><a href="#main">Skip to main content</a></p>
+        <p class="OffScreen SiteHeader__tagline">Lightning fast testing and delivery for all your software projects.</p>
       </div>
     </header>
     <main id="main" role="main">      


### PR DESCRIPTION
This PR cleans up a number of warnings from Google Lighthouse that I spotted when viewing the Google crawler warnings for our site via Google Search Console.

The biggest change is that it improves the navigation on mobile, so it isn't as large and expanded by default… which means people can get to the documentation they're reading much faster (especially when navigating between pages, which would involving scrolling past the navigation each time).

| Before | After |
| -- | -- |
| <img width="855" alt="image" src="https://user-images.githubusercontent.com/153/120432020-a6860100-c3bc-11eb-8232-76bc16851caa.png"> | <img width="855" alt="image" src="https://user-images.githubusercontent.com/153/120432037-aab21e80-c3bc-11eb-8e06-e75c3476a52c.png"> |

It also makes sure the up arrow is available visible in the nav when it's expanded, showing you can collapse it and hinting that the menu is exapando/collapsable for non-hover devices too (like touch screens).

<img width="278" alt="image" src="https://user-images.githubusercontent.com/153/120432295-14322d00-c3bd-11eb-9a65-e7aea4cabe08.png">

It also adds the word "Buildkite" back into the top nav, so "Buildkite Docs" instead of just "Docs"