### PR TITLE
Document the new archive pipeline endpoint

### DIFF
--- a/pages/apis/rest_api/pipelines.md.erb
+++ b/pages/apis/rest_api/pipelines.md.erb
@@ -738,6 +738,88 @@ Error responses:
   <p>To update a pipeline's teams, please use the <a href="/docs/apis/graphql-api">GraphQL API</a>.</p>
 </div>
 
+## Archive a pipeline
+
+Archived pipelines are read-only, and are hidden from Pipeline pages by default. Builds, build logs, and artifacts are preserved.
+
+```bash
+curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{slug}/archive"
+```
+
+```json
+{
+  "id": "14e9501c-69fe-4cda-ae07-daea9ca3afd3",
+  "graphql_id": "UGlwZWxpbmUtLS1lOTM4ZGQxYy03MDgwLTQ4ZmQtOGQyMC0yNmQ4M2E0ZjNkNDg=",
+  "url": "https://api.buildkite.com/v2/organizations/acme-inc/pipelines/my-pipeline",
+  "web_url": "https://buildkite.com/acme-inc/my-pipeline",
+  "name": "My Pipeline",
+  "description": null,
+  "slug": "my-pipeline",
+  "repository": "git@github.com:acme-inc/new-repo.git",
+  "branch_configuration": "master",
+  "default_branch": "master"
+  "provider": {
+    "id": "github",
+    "webhook_url": "https://webhook.buildkite.com/deliver/xxx",
+    "settings": {
+      "publish_commit_status": true,
+      "build_pull_requests": true,
+      "build_pull_request_forks": false,
+      "build_tags": false,
+      "publish_commit_status_per_step": false,
+      "repository": "acme-inc/new-repo",
+      "trigger_mode": "code"
+    }
+  },
+  "skip_queued_branch_builds": false,
+  "skip_queued_branch_builds_filter": null,
+  "cancel_running_branch_builds": false,
+  "cancel_running_branch_builds_filter": null,
+  "builds_url": "https://api.buildkite.com/v2/organizations/acme-inc/pipelines/my-pipeline/builds",
+  "badge_url": "https://badge.buildkite.com/58b3da999635d0ad2daae5f784e56d264343eb02526f129bfb.svg",
+  "created_at": "2015-03-01 06:44:40 UTC",
+  "archived_at": "2021-06-01 08:23:35 UTC",
+  "configuration": "steps:\n  - command: \"new.sh\"\n    agents:\n    - \"something=true\"",
+  "steps": [
+    {
+      "type": "script",
+      "name": null,
+      "command": "new.sh",
+      "artifact_paths": null,
+      "branch_configuration": null,
+      "env": {},
+      "timeout_in_minutes": null,
+      "agent_query_rules": [
+        "myqueue=true"
+      ],
+      "concurrency": null,
+      "parallelism": null
+    }
+  ],
+  "env": {
+  },
+  "scheduled_builds_count": 0,
+  "running_builds_count": 0,
+  "scheduled_jobs_count": 0,
+  "running_jobs_count": 0,
+  "waiting_jobs_count": 0,
+  "visibility": "private"
+}
+```
+
+Required scope: `write_pipelines`
+
+Success response: `200 OK`
+
+Error responses:
+
+<table>
+<tbody>
+  <tr><th><code>403 Forbidden</code></th><td><code>{ "message": "Forbidden" }</code></td></tr>
+  <tr><th><code>422 Unprocessable Entity</code></th><td><code>{ "message": "Pipeline could not be archived." }</code></td></tr>
+</tbody>
+</table>
+
 ## Delete a pipeline
 
 ```bash
@@ -790,7 +872,7 @@ Properties available for all providers:
       The conditions under which this pipeline will trigger a build. See the <a href="/docs/pipelines/conditionals">Using Conditionals</a> guide for more information.
       <p class="Docs__api-param-eg"><em>Example:</em> <code>"build.pull_request.base_branch =~ /master/"</code></p>
     </td>
-  </tr>    
+  </tr>
 </tbody>
 </table>
 
@@ -875,7 +957,7 @@ Additional properties available for GitHub:
       <td>
         What type of event to trigger builds on. <code>Code</code> will create builds when code is pushed to GitHub. <code>Deployment</code> will create builds when a deployment is created with the <a href="https://developer.github.com/v3/repos/deployments/">GitHub Deployments API</a>. <code>Fork</code> will create builds when the GitHub repository is forked. <code>None</code> will not create any builds based on GitHub activity.
         <p class="Docs__api-param-eg"><em>Values:</em> <code>code</code>, <code>deployment</code>, <code>fork</code>, <code>none</code></p></td>
-    </tr>    
+    </tr>
     <tr>
       <th><code>build_pull_request_forks</code></th>
       <td>


### PR DESCRIPTION
I've just added a [new REST endpoint](https://github.com/buildkite/buildkite/pull/6615) for archiving a pipeline, so here's the documentation for it