### PR TITLE
Remove 'experiment' from output redactor docs

### DIFF
--- a/pages/agent/v3.md.erb
+++ b/pages/agent/v3.md.erb
@@ -74,11 +74,6 @@ Please note that there is every chance we will remove or change these experiment
 
 The Buildkite agent can redact strings that match the value of environment variables whose names match common patterns for passwords and other secure information before the build log is uploaded to Buildkite.
 
-<div class="Docs__wip-note">
-  <p class="Docs__wip-heading">Experimental feature</p>
-  <p>To use it, set <code>experiment="output-redactor"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.</p>
-</div>
-
 See [redacted-vars](/docs/pipelines/managing-log-output#redacted-environment-variables) for more information.
 
 ### Git mirrors

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -364,7 +364,7 @@ _Optional attributes:_
       <th><code>redacted-vars</code></th>
       <td>
         A list of environment variable name patterns whose values should be <a href="/docs/pipelines/managing-log-output#redacted-environment-variables">redacted</a> before being printed to the build log. To disable redaction, set this to an empty string.
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>"*_PASSWORD", "*_SECRET", "*_TOKEN"</code></p>
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>*_PASSWORD,*_SECRET,*_TOKEN,*_ACCESS_KEY,*_SECRET_KEY</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_REDACTED_VARS</code></p>
       </td>
     </tr>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -364,10 +364,6 @@ _Optional attributes:_
       <th><code>redacted-vars</code></th>
       <td>
         Strings matching the values of environment variables whose names match these patterns are <a href="/docs/pipelines/managing-log-output#redacted-environment-variables">redacted</a> before being printed to the build log. 
-        <div class="Docs__wip-note">
-          <p class="Docs__wip-heading">Experimental feature</p>
-          <p>To use it, set <code>experiment="output-redactor"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.</p>
-        </div>
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"*_PASSWORD", "*_SECRET", "*_TOKEN"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_REDACTED_VARS</code></p>
       </td>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -363,7 +363,7 @@ _Optional attributes:_
     <tr id="redacted-vars">
       <th><code>redacted-vars</code></th>
       <td>
-        Strings matching the values of environment variables whose names match these patterns are <a href="/docs/pipelines/managing-log-output#redacted-environment-variables">redacted</a> before being printed to the build log. 
+        A list of environment variable name patterns whose values should be <a href="/docs/pipelines/managing-log-output#redacted-environment-variables">redacted</a> before being printed to the build log. To disable redaction, set this to an empty string.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"*_PASSWORD", "*_SECRET", "*_TOKEN"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_REDACTED_VARS</code></p>
       </td>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -364,6 +364,7 @@ _Optional attributes:_
       <th><code>redacted-vars</code></th>
       <td>
         A list of environment variable name patterns whose values should be <a href="/docs/pipelines/managing-log-output#redacted-environment-variables">redacted</a> before being printed to the build log. To disable redaction, set this to an empty string.
+        <p><em>Introduced in:</em> <a href="https://github.com/buildkite/agent/releases/tag/v3.31.0">v3.31</a></p>
         <p class="Docs__api-param-eg"><em>Default:</em> <code>*_PASSWORD,*_SECRET,*_TOKEN,*_ACCESS_KEY,*_SECRET_KEY</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_REDACTED_VARS</code></p>
       </td>

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -113,9 +113,9 @@ Make sure to set the `-o pipefail` option in your buildscript as above, otherwis
 
 ## Redacted environment variables
 
-The Buildkite agent can redact strings that match the value of environment variables whose names match common patterns for passwords and other secure information before the build log is uploaded to Buildkite.
+The Buildkite agent can redact the values of environment variables whose names match common patterns for passwords, and other secure information, before the build log is uploaded to Buildkite.
 
-The default environment variable name patterns are `*_PASSWORD`, `*_SECRET` and `*_TOKEN`. You can replace the default patterns by [setting the environment variable](/docs/agent/v3/configuration#redacted-vars) `BUILDKITE_REDACTED_VARS` **on your agent**.
+The default environment variable name patterns are `*_PASSWORD`, `*_SECRET` and `*_TOKEN`. You can replace the default patterns by [setting redacted-vars](/docs/agent/v3/configuration#redacted-vars) **on your agent**.
 
 For example, if you have environment variable `MY_SECRET="topsecret"`and you run a command that outputs `This is topsecret info`, the log output will actually be `This is [REDACTED] info`.
 

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -113,11 +113,6 @@ Make sure to set the `-o pipefail` option in your buildscript as above, otherwis
 
 ## Redacted environment variables
 
-<div class="Docs__wip-note">
-<p class="Docs__wip-heading">Experimental feature</p>
-<p>This is an experimental feature, set <code>experiment="output-redactor"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a> to use it.</p>
-</div>
-
 The Buildkite agent can redact strings that match the value of environment variables whose names match common patterns for passwords and other secure information before the build log is uploaded to Buildkite.
 
 The default environment variable name patterns are `*_PASSWORD`, `*_SECRET` and `*_TOKEN`. You can replace the default patterns by [setting the environment variable](/docs/agent/v3/configuration#redacted-vars) `BUILDKITE_REDACTED_VARS` **on your agent**.


### PR DESCRIPTION
This will land as default feature in v3.31 so we can remove the experimental caveats from these docs.

@plaindocs should we note the agent minimum version required for the feature anywhere?