### PR TITLE
Less noisy CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -17,13 +17,8 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 Rails.application.config.content_security_policy do |policy|
-  policy.default_src    :self
-  policy.font_src       :self, "https://www2.buildkiteassets.com/"
-  policy.img_src        :self, "https://buildkiteassets.com/", "https://buildkite.com/", Matomo::URL, ENV.fetch("BADGE_DOMAIN", "https://badge.buildkite.com")
-  policy.object_src     :none
-  policy.script_src     :self, Matomo::URL, Posthog::URL, "https://www.googletagmanager.com/"
-  policy.style_src      :self, :unsafe_inline
-  policy.style_src_attr :self, :unsafe_inline
+  policy.object_src :none
+  policy.script_src :self, Matomo::URL, Posthog::URL, "https://www.googletagmanager.com/"
 
   # allow AJAX queries against our search vendor
   policy.connect_src "https://#{ENV["ALGOLIA_APP_ID"]}-dsn.algolia.net", "https://#{ENV["ALGOLIA_APP_ID"]}-1.algolianet.com", "https://#{ENV["ALGOLIA_APP_ID"]}-2.algolianet.com", "https://#{ENV["ALGOLIA_APP_ID"]}-3.algolianet.com", Posthog::URL, "https://www.google-analytics.com/"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -18,14 +18,14 @@
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
-  policy.font_src    :self, 'https://www2.buildkiteassets.com/'
-  policy.img_src     :self, 'https://buildkiteassets.com/', 'https://buildkite.com/', Matomo::URL, ENV.fetch('BADGE_DOMAIN', 'https://badge.buildkite.com')
+  policy.font_src    :self, "https://www2.buildkiteassets.com/"
+  policy.img_src     :self, "https://buildkiteassets.com/", "https://buildkite.com/", Matomo::URL, ENV.fetch("BADGE_DOMAIN", "https://badge.buildkite.com")
   policy.object_src  :none
   policy.script_src  :self, Matomo::URL, Posthog::URL, "https://www.googletagmanager.com/"
   policy.style_src   :self, :unsafe_inline
 
   # allow AJAX queries against our search vendor
-  policy.connect_src "https://#{ENV['ALGOLIA_APP_ID']}-dsn.algolia.net", "https://#{ENV['ALGOLIA_APP_ID']}-1.algolianet.com", "https://#{ENV['ALGOLIA_APP_ID']}-2.algolianet.com", "https://#{ENV['ALGOLIA_APP_ID']}-3.algolianet.com", Posthog::URL, "https://www.google-analytics.com/"
+  policy.connect_src "https://#{ENV["ALGOLIA_APP_ID"]}-dsn.algolia.net", "https://#{ENV["ALGOLIA_APP_ID"]}-1.algolianet.com", "https://#{ENV["ALGOLIA_APP_ID"]}-2.algolianet.com", "https://#{ENV["ALGOLIA_APP_ID"]}-3.algolianet.com", Posthog::URL, "https://www.google-analytics.com/"
 
   # Specify URI for violation reports
   policy.report_uri "/_csp-violation-reports"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -17,12 +17,13 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 Rails.application.config.content_security_policy do |policy|
-  policy.default_src :self
-  policy.font_src    :self, "https://www2.buildkiteassets.com/"
-  policy.img_src     :self, "https://buildkiteassets.com/", "https://buildkite.com/", Matomo::URL, ENV.fetch("BADGE_DOMAIN", "https://badge.buildkite.com")
-  policy.object_src  :none
-  policy.script_src  :self, Matomo::URL, Posthog::URL, "https://www.googletagmanager.com/"
-  policy.style_src   :self, :unsafe_inline
+  policy.default_src    :self
+  policy.font_src       :self, "https://www2.buildkiteassets.com/"
+  policy.img_src        :self, "https://buildkiteassets.com/", "https://buildkite.com/", Matomo::URL, ENV.fetch("BADGE_DOMAIN", "https://badge.buildkite.com")
+  policy.object_src     :none
+  policy.script_src     :self, Matomo::URL, Posthog::URL, "https://www.googletagmanager.com/"
+  policy.style_src      :self, :unsafe_inline
+  policy.style_src_attr :self, :unsafe_inline
 
   # allow AJAX queries against our search vendor
   policy.connect_src "https://#{ENV["ALGOLIA_APP_ID"]}-dsn.algolia.net", "https://#{ENV["ALGOLIA_APP_ID"]}-1.algolianet.com", "https://#{ENV["ALGOLIA_APP_ID"]}-2.algolianet.com", "https://#{ENV["ALGOLIA_APP_ID"]}-3.algolianet.com", Posthog::URL, "https://www.google-analytics.com/"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -18,7 +18,9 @@
 
 Rails.application.config.content_security_policy do |policy|
   policy.object_src :none
-  policy.script_src :self, Matomo::URL, Posthog::URL, "https://www.googletagmanager.com/"
+
+  # algolia requires eval
+  policy.script_src :self, :unsafe_eval, Matomo::URL, Posthog::URL, "https://www.googletagmanager.com/"
 
   # allow AJAX queries against our search vendor
   policy.connect_src "https://#{ENV["ALGOLIA_APP_ID"]}-dsn.algolia.net", "https://#{ENV["ALGOLIA_APP_ID"]}-1.algolianet.com", "https://#{ENV["ALGOLIA_APP_ID"]}-2.algolianet.com", "https://#{ENV["ALGOLIA_APP_ID"]}-3.algolianet.com", Posthog::URL, "https://www.google-analytics.com/"


### PR DESCRIPTION
We're getting _lots_ of CSP reports about docs pages containing inline style attributes, like `<... style="...">`. I'm not exactly sure why. It might be because it's falling back to `default-src`, so I'm proposing removing the default here as a trial. It might also be because once you add a nonce the browser expects all things to have nonces and ignores `unsafe-inline`. Let's find out?