### PR TITLE
Update agent OS support policy

### DIFF
--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -1,6 +1,6 @@
 # Installing Buildkite Agent on Debian
 
-The Buildkite Agent can be installed on Debian versions 7.x and above using our signed apt repository.
+The Buildkite Agent is supported on Debian versions 8 and above using our signed apt repository.
 
 {:toc}
 
@@ -44,27 +44,13 @@ sudo sed -i "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" /etc/buildkite-agent/buildkit
 And then start the agent:
 
 ```shell
-# For Debian 8.x and above (systemd)
 sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent
-
-# For Debian 7.x (using upstart)
-sudo service buildkite-agent start
-
-# For Debian 7.x (using sysvinit)
-sudo /etc/init.d/buildkite-agent start
 ```
 
 You can view the logs at:
 
 ```shell
-# For Debian 8.x and above (systemd)
 sudo journalctl -f -u buildkite-agent
-
-# For Debian 7.x (using upstart)
-sudo tail -f /var/log/upstart/buildkite-agent.log
-
-# For Debian 7.x (using sysvinit)
-sudo tail -f /var/log/buildkite-agent.log
 ```
 
 ## SSH Key Configuration
@@ -85,8 +71,6 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 
 You can run as many parallel agents on the one machine as you wish by duplicating the systemd/upstart service configuration file, for example:
 
-### For Debian 8.x and above (systemd)
-
 ```shell
 # Disable the default unit
 sudo systemctl stop buildkite-agent && sudo systemctl disable buildkite-agent
@@ -103,14 +87,6 @@ sudo journalctl -f -u "buildkite-agent@*"
 
 # Or one-by-one
 sudo journalctl -f -u buildkite-agent@2
-```
-
-### For Debian 7.x (using upstart)
-
-```shell
-sudo cp /etc/init/buildkite-agent.conf /etc/init/buildkite-agent-2.conf
-sudo service buildkite-agent-2 start
-sudo tail -f /var/log/upstart/buildkite-agent-2.log
 ```
 
 ## Upgrading

--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -1,6 +1,6 @@
 # Installing Buildkite Agent on macOS
 
-The Buildkite Agent can be installed on macOS 10.9 or higher using Homebrew or our installer script, and supports pre-release versions of both OS X and Xcode.
+The Buildkite Agent is supported on macOS 10.11 or newer using Homebrew or our installer script, and supports pre-release versions of both macOS and Xcode.
 
 {:toc}
 

--- a/pages/agent/v3/osx.md.erb
+++ b/pages/agent/v3/osx.md.erb
@@ -1,6 +1,6 @@
 # Installing Buildkite Agent on macOS
 
-The Buildkite Agent is supported on macOS 10.11 or newer using Homebrew or our installer script, and supports pre-release versions of both macOS and Xcode.
+The Buildkite Agent is supported on macOS 10.12 or newer using Homebrew or our installer script, and supports pre-release versions of both macOS and Xcode.
 
 {:toc}
 

--- a/pages/agent/v3/redhat.md.erb
+++ b/pages/agent/v3/redhat.md.erb
@@ -1,6 +1,6 @@
 # Installing Buildkite Agent on Red Hat Enterprise Linux, CentOS and Amazon Linux
 
-The Buildkite Agent is supported on Red Hat Enterprise Linux 7, CentOS 7 and newer, and Amazon Linux 2
+The Buildkite Agent is supported on Red Hat Enterprise Linux 7 and newer, CentOS 7 and newer, and Amazon Linux 2
 using our yum repository.
 
 {:toc}

--- a/pages/agent/v3/redhat.md.erb
+++ b/pages/agent/v3/redhat.md.erb
@@ -1,6 +1,7 @@
-# Installing Buildkite Agent on Red Hat, CentOS and Amazon Linux
+# Installing Buildkite Agent on Red Hat Enterprise Linux, CentOS and Amazon Linux
 
-The Buildkite Agent can be installed on Red Hat, CentOS and Amazon Linux using our yum repository.
+The Buildkite Agent is supported on Red Hat Enterprise Linux 7, CentOS 7 and newer, and Amazon Linux 2
+using our yum repository.
 
 {:toc}
 
@@ -41,13 +42,8 @@ sudo sed -i "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" /etc/buildkite-agent/buildkit
 And then start the agent, and tail the logs:
 
 ```shell
-# For distributions with systemctl
 sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent
 sudo tail -f /var/log/messages
-
-# For distributions without systemctl (such as Amazon Linux)
-sudo service buildkite-agent start
-sudo tail -f /var/log/buildkite-agent.log
 ```
 
 ## SSH Key Configuration
@@ -91,14 +87,6 @@ sudo journalctl -f -u "buildkite-agent@*"
 
 # Or one-by-one
 sudo journalctl -f -u buildkite-agent@2
-```
-
-For older systems without `systemd` (such as Amazon Linux) you instead use:
-
-```shell
-sudo cp /etc/init.d/buildkite-agent /etc/init.d/buildkite-agent-2
-sudo chkconfig --add buildkite-agent-2
-sudo service buildkite-agent-2 start
 ```
 
 ## Upgrading

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -1,6 +1,6 @@
 # Installing Buildkite Agent on Ubuntu
 
-The Buildkite Agent can be installed on Ubuntu versions 14.04 and above using our signed apt repository.
+The Buildkite Agent is supported on Ubuntu versions 18.04 and above using our signed apt repository.
 
 {:toc}
 

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -28,21 +28,13 @@ sudo sed -i "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" /etc/buildkite-agent/buildkit
 And then start the agent:
 
 ```shell
-# Ubuntu 15.04+ (systemd)
 sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent
-
-# Older Ubuntu (upstart)
-sudo service buildkite-agent start
 ```
 
 You can view the logs at:
 
 ```shell
-# Ubuntu 15.04+ (systemd)
 journalctl -f -u buildkite-agent
-
-# Older Ubuntu (upstart)
-tail -f /var/log/upstart/buildkite-agent.log
 ```
 
 ## SSH Key Configuration
@@ -64,8 +56,6 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 You can run as many parallel agents on the one machine as you wish by duplicating the upstart service configuration file, for example:
 
 ```shell
-# For Ubuntu 15.04 and above (using systemd)
-
 # Disable the default unit
 sudo systemctl stop buildkite-agent && sudo systemctl disable buildkite-agent
 
@@ -81,11 +71,6 @@ sudo journalctl -f -u "buildkite-agent@*"
 
 # Or one-by-one
 sudo journalctl -f -u buildkite-agent@2
-
-# For older Ubuntu (using upstart)
-sudo cp /etc/init/buildkite-agent.conf /etc/init/buildkite-agent-2.conf
-sudo service buildkite-agent-2 start
-sudo tail -f /var/log/upstart/buildkite-agent-2.log
 ```
 
 ## Upgrading

--- a/pages/agent/v3/windows.md.erb
+++ b/pages/agent/v3/windows.md.erb
@@ -1,6 +1,6 @@
 # Installing Buildkite Agent on Windows
 
-The Buildkite Agent is supported on Windows Server 2012 and newer.
+The Buildkite Agent is supported on Windows 8, Windows Server 2012, and newer.
 
 {:toc}
 

--- a/pages/agent/v3/windows.md.erb
+++ b/pages/agent/v3/windows.md.erb
@@ -1,6 +1,6 @@
 # Installing Buildkite Agent on Windows
 
-The Buildkite Agent can be installed on both 64bit and 32bit editions of Windows XP and later.
+The Buildkite Agent is supported on Windows Server 2016 and newer.
 
 {:toc}
 
@@ -8,7 +8,7 @@ The Buildkite Agent can be installed on both 64bit and 32bit editions of Windows
 
 You'll need to run the automated installer within Powershell with Administrative Privileges.
 
-To start a Powershell session as an Administrator (in Windows 8):
+To start a Powershell session as an Administrator:
 
 1. Open the Start menu and type "powershell"
 2. Highlight "Windows Powershell" in the results

--- a/pages/agent/v3/windows.md.erb
+++ b/pages/agent/v3/windows.md.erb
@@ -1,6 +1,6 @@
 # Installing Buildkite Agent on Windows
 
-The Buildkite Agent is supported on Windows Server 2016 and newer.
+The Buildkite Agent is supported on Windows Server 2012 and newer.
 
 {:toc}
 


### PR DESCRIPTION
This changes the docs for each operating system (I only changed the agent v3 docs and didn’t touch the v2 ones) to steer folks towards which operating systems we support rather than the oldest operating system the agent can be installed on.

This doesn’t practically change where the agent can be installed, e.g. it probably still works on Windows XP we’re just saying that if it _happens to_ we can’t guarantee support when it goes wrong as we have to focus our efforts.

For Debian, Red Hat, and Ubuntu we can also drop the docs for using Upstart, as presently in service and supported versions of these all use systemd 🎉