### PR TITLE
Add AWS Secrets manager guide

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -38,6 +38,11 @@
         <ul class="Docs__nav__sub-nav" style="margin-top: 15px;">
           <%= sidebar_link_to "Agent v2 (Deprecated)", 'agent/v2' %>
         </ul>
+        <p class="Docs__nav__section-subheading">Elastic CI Stack for AWS</p>
+        <ul class="Docs__nav__sub-nav">
+          <%= sidebar_link_to "Running Elastic CI Stack", 'agent/v3/elastic-ci-aws' %>
+          <%= sidebar_link_to "Using AWS Secrets Manager", 'agent/v3/aws/secrets_manager.md' %>
+        </ul>
         <p class="Docs__nav__section-subheading">Agent Installers</p>
         <ul class="Docs__nav__sub-nav">
           <%= sidebar_link_to "Ubuntu", 'agent/v3/ubuntu' %>
@@ -49,7 +54,6 @@
           <%= sidebar_link_to "Linux", 'agent/v3/linux' %>
           <%= sidebar_link_to "Docker", 'agent/v3/docker' %>
           <%= sidebar_link_to "AWS", 'agent/v3/aws' %>
-          <%= sidebar_link_to "Elastic CI Stack for AWS", 'agent/v3/elastic-ci-aws' %>
           <%= sidebar_link_to "Google Cloud", 'agent/v3/gcloud' %>
         </ul>
         <p class="Docs__nav__section-subheading">Command-Line Reference</p>

--- a/pages/agent/v3/aws/secrets_manager.md
+++ b/pages/agent/v3/aws/secrets_manager.md
@@ -1,0 +1,50 @@
+# Storing your Buildkite Agent token in AWS Secrets Manager
+
+If you prefer to store your Buildkite Agent token as an AWS Secrets Manager secret,
+you can configure the Elastic CI Stack’s `BuildkiteAgentTokenParameterStorePath`
+parameter to reference your secret with the special `/aws/reference/secretsmanager/your_Secrets_Manager_secret_ID` parameter path which will fetch the secret from Secrets Manager.
+
+See the AWS documentation on [Referencing AWS Secrets Manager secrets from Parameter Store parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html)
+for more details.
+
+The important points to note are:
+
+- Provide the Key ID (not the alias) used to encrypt the Secrets Manager secret to the `BuildkiteAgentTokenParameterStoreKMSKey` parameter.
+	- The CloudFormation template includes an IAM policy with `kms:Decrypt` permission for this key.
+- Use the Secret Manager secret's resource policy to grant `secretsmanager:GetSecretValue` permission to the Elastic CI Stack’s IAM role.
+	- Secret Manager captures the role's Unique ID when saving the resource policy, if you re-create the IAM role you will need to save the resource policy again to grant access.
+
+```
+{
+  "Version" : "2012-10-17",
+  "Statement" : [ {
+    "Effect" : "Allow",
+    "Principal" : {
+      "AWS" : [
+        "arn:aws:iam::[redacted]:role/buildkite-secretsmanager-test-Role”
+      ]
+    },
+    "Action" : "secretsmanager:GetSecretValue",
+    "Resource" : "*"
+  } ]
+}
+```
+
+## Multi Region Replication
+
+It is also possible to replicate your Buildkite Agent token to multiple regions using
+AWS Secret Manager’s [multi-region replication](https://docs.aws.amazon.com/secretsmanager/latest/userguide/create-manage-multi-region-secrets.html). You can then deploy an Elastic CI Stack to each region
+and use the SSM Parameter Store reference path to read the secret from the regionally replicated secret.
+
+Some additional points to keep in mind when using multi-region replication:
+
+- Ensure each region's IAM role has `ssm:GetParameter` permission for the region it will be retrieving the secret from.
+    - By default, the template will grant permission to only the region it is deployed to, limiting the role’s utility to the stack’s region. This isn’t a problem just a caveat to be aware of, don’t expect to use the same role in multiple regions.
+- Ensure each region's IAM role has `kms:Decrypt` permission for the key used to encrypt the secret in that region.
+    - I used the AWS Secrets Manager key e.g. aws/secretsmanager in Secrets Manager and then looked up the underlying CMK ID of that key alias in each region I deployed the stack template to. Provide that value for the `BuildkiteAgentTokenParameterStoreKMSKey` parameter.
+- Apply a resource policy to the primary Secrets Manager secret that grants `secretsmanager:GetSecretValue` for each region's IAM role and wait for that to be replicated.
+
+Now, changes to the agent token secret (either made by hand or using Automatic Secret Rotation) will be replicated from the primary region to each replia region.
+
+The Elastic CI Stack currently only resolves the agent token once on instance boot. Consider refreshing your
+AutoScale Group instances after rotating the secret and before revoking the old token.

--- a/pages/agent/v3/aws/secrets_manager.md
+++ b/pages/agent/v3/aws/secrets_manager.md
@@ -62,7 +62,7 @@ it will be retrieving the secret from.
     multiple regions.
 - Ensure each region’s IAM role has `kms:Decrypt` permission for the key used to
 encrypt the secret in that region.
-    - You can do this with the AWS Secrets Manager key e.g. aws/secretsmanager in Secrets
+    - You can do this with the AWS Secrets Manager key e.g. `aws/secretsmanager` in Secrets
     Manager, and looking up the underlying CMK ID of that key alias in each
     region the stack template is deployed to. Provide that value for the
     `BuildkiteAgentTokenParameterStoreKMSKey` parameter for the stack in that
@@ -72,7 +72,7 @@ encrypt the secret in that region.
 be replicated.
 
 Now, changes to the agent token secret (either made by hand or using Automatic
-Secret Rotation) will be replicated from the primary region to each replia
+Secret Rotation) will be replicated from the primary region to each replica
 region.
 
 The Elastic CI Stack will only retrieve the Buildkite Agent token once when the

--- a/pages/agent/v3/aws/secrets_manager.md
+++ b/pages/agent/v3/aws/secrets_manager.md
@@ -14,8 +14,8 @@ To store your Buildkite Agent token as an AWS Secrets
 Manager secret, configure the Elastic CI Stack’s
 `BuildkiteAgentTokenParameterStorePath` parameter to reference your secret with
 the special parameter path `/aws/reference/secretsmanager/your_Secrets_Manager_secret_ID`.
-Reads from this parameter path will transparently fetch the token from AWS Secrets
-Manager.
+Parameter Store will transparently fetch the token from AWS Secrets
+Manager when this parameter is read.
 
 See the AWS documentation on [Referencing AWS Secrets Manager secrets from Parameter Store parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html)
 for more details.

--- a/pages/agent/v3/aws/secrets_manager.md
+++ b/pages/agent/v3/aws/secrets_manager.md
@@ -21,7 +21,7 @@ The important points to note are:
     "Effect" : "Allow",
     "Principal" : {
       "AWS" : [
-        "arn:aws:iam::[redacted]:role/buildkite-secretsmanager-test-Role”
+        "arn\:aws\:iam::[redacted]:role/buildkite-secretsmanager-test-Role”
       ]
     },
     "Action" : "secretsmanager:GetSecretValue",

--- a/pages/agent/v3/aws/secrets_manager.md
+++ b/pages/agent/v3/aws/secrets_manager.md
@@ -36,7 +36,7 @@ To ensure your Elastic CI Stack instance IAM role has access to the secret:
     "Effect" : "Allow",
     "Principal" : {
       "AWS" : [
-        "arn\:aws\:iam\:\:[redacted]:role/buildkite-secretsmanager-test-Role",
+        "arn\:aws\:iam::[redacted]:role/buildkite-secretsmanager-test-Role",
       ]
     },
     "Action" : "secretsmanager:GetSecretValue",

--- a/pages/agent/v3/aws/secrets_manager.md
+++ b/pages/agent/v3/aws/secrets_manager.md
@@ -13,8 +13,8 @@ regions in your account.
 To store your Buildkite Agent token as an AWS Secrets
 Manager secret, configure the Elastic CI Stack’s
 `BuildkiteAgentTokenParameterStorePath` parameter to reference your secret with
-the special `/aws/reference/secretsmanager/your_Secrets_Manager_secret_ID`
-parameter path which will transparently fetch the secret from AWS Secrets
+the special parameter path `/aws/reference/secretsmanager/your_Secrets_Manager_secret_ID`.
+Reads from this parameter path will transparently fetch the token from AWS Secrets
 Manager.
 
 See the AWS documentation on [Referencing AWS Secrets Manager secrets from Parameter Store parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html)

--- a/pages/agent/v3/aws/secrets_manager.md
+++ b/pages/agent/v3/aws/secrets_manager.md
@@ -2,17 +2,16 @@
 
 The Elastic CI Stack for AWS supports reading a Buildkite Agent token from
 the AWS Systems Manager Parameter Store. The token can be stored in a plaintext
-parameter, or encrypted with a KMS Key for access control purposes. It is also
-possible to store your Buildkite Agent token using AWS Secrets Manager should
-you need to make use of the advanced functionality it offers over the Parameter
+parameter, or encrypted with a KMS Key for access control purposes. You can also store your Buildkite Agent token using AWS Secrets Manager if
+you need the advanced functionality it offers over the Parameter
 Store.
 
-For example, AWS Secrets Manager can be configured to automatically rotate and
+For example, AWS Secrets Manager can automatically rotate and
 revoke secrets using Lambda functions, and replicate secrets across multiple
 regions in your account.
 
-If you would prefer to store your Buildkite Agent token as an AWS Secrets
-Manager secret, you can configure the Elastic CI Stack’s
+To store your Buildkite Agent token as an AWS Secrets
+Manager secret, configure the Elastic CI Stack’s
 `BuildkiteAgentTokenParameterStorePath` parameter to reference your secret with
 the special `/aws/reference/secretsmanager/your_Secrets_Manager_secret_ID`
 parameter path which will transparently fetch the secret from AWS Secrets
@@ -30,14 +29,14 @@ To ensure your Elastic CI Stack instance IAM role has access to the secret:
   policy, if you re-create the IAM role you will need to save the resource
   policy again to grant access.
 
-```
+```json
 {
   "Version" : "2012-10-17",
   "Statement" : [ {
     "Effect" : "Allow",
     "Principal" : {
       "AWS" : [
-        "arn\:aws\:iam::[redacted]:role/buildkite-secretsmanager-test-Role”
+        "arn\:aws\:iam":":[redacted]:role/buildkite-secretsmanager-test-Role",
       ]
     },
     "Action" : "secretsmanager:GetSecretValue",
@@ -63,9 +62,9 @@ it will be retrieving the secret from.
     multiple regions.
 - Ensure each region’s IAM role has `kms:Decrypt` permission for the key used to
 encrypt the secret in that region.
-    - I used the AWS Secrets Manager key e.g. aws/secretsmanager in Secrets
-    Manager and then looked up the underlying CMK ID of that key alias in each
-    region I deployed the stack template to. Provide that value for the
+    - You can do this with the AWS Secrets Manager key e.g. aws/secretsmanager in Secrets
+    Manager, and looking up the underlying CMK ID of that key alias in each
+    region the stack template is deployed to. Provide that value for the
     `BuildkiteAgentTokenParameterStoreKMSKey` parameter for the stack in that
     region.
 - Apply a resource policy to the primary Secrets Manager secret that grants

--- a/pages/agent/v3/aws/secrets_manager.md
+++ b/pages/agent/v3/aws/secrets_manager.md
@@ -36,7 +36,7 @@ To ensure your Elastic CI Stack instance IAM role has access to the secret:
     "Effect" : "Allow",
     "Principal" : {
       "AWS" : [
-        "arn\:aws\:iam":":[redacted]:role/buildkite-secretsmanager-test-Role",
+        "arn\:aws\:iam\:\:[redacted]:role/buildkite-secretsmanager-test-Role",
       ]
     },
     "Action" : "secretsmanager:GetSecretValue",

--- a/pages/agent/v3/aws/secrets_manager.md
+++ b/pages/agent/v3/aws/secrets_manager.md
@@ -1,18 +1,34 @@
 # Storing your Buildkite Agent token in AWS Secrets Manager
 
-If you prefer to store your Buildkite Agent token as an AWS Secrets Manager secret,
-you can configure the Elastic CI Stack’s `BuildkiteAgentTokenParameterStorePath`
-parameter to reference your secret with the special `/aws/reference/secretsmanager/your_Secrets_Manager_secret_ID` parameter path which will fetch the secret from Secrets Manager.
+The Elastic CI Stack for AWS supports reading a Buildkite Agent token from
+the AWS Systems Manager Parameter Store. The token can be stored in a plaintext
+parameter, or encrypted with a KMS Key for access control purposes. It is also
+possible to store your Buildkite Agent token using AWS Secrets Manager should
+you need to make use of the advanced functionality it offers over the Parameter
+Store.
+
+For example, AWS Secrets Manager can be configured to automatically rotate and
+revoke secrets using Lambda functions, and replicate secrets across multiple
+regions in your account.
+
+If you would prefer to store your Buildkite Agent token as an AWS Secrets
+Manager secret, you can configure the Elastic CI Stack’s
+`BuildkiteAgentTokenParameterStorePath` parameter to reference your secret with
+the special `/aws/reference/secretsmanager/your_Secrets_Manager_secret_ID`
+parameter path which will transparently fetch the secret from AWS Secrets
+Manager.
 
 See the AWS documentation on [Referencing AWS Secrets Manager secrets from Parameter Store parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html)
 for more details.
 
-The important points to note are:
+To ensure your Elastic CI Stack instance IAM role has access to the secret:
 
 - Provide the Key ID (not the alias) used to encrypt the Secrets Manager secret to the `BuildkiteAgentTokenParameterStoreKMSKey` parameter.
 	- The CloudFormation template includes an IAM policy with `kms:Decrypt` permission for this key.
-- Use the Secret Manager secret's resource policy to grant `secretsmanager:GetSecretValue` permission to the Elastic CI Stack’s IAM role.
-	- Secret Manager captures the role's Unique ID when saving the resource policy, if you re-create the IAM role you will need to save the resource policy again to grant access.
+- Use the Secret Manager secret’s resource policy to grant `secretsmanager:GetSecretValue` permission to the Elastic CI Stack’s IAM role.
+	- Secret Manager will capture the role’s Unique ID when saving the resource
+  policy, if you re-create the IAM role you will need to save the resource
+  policy again to grant access.
 
 ```
 {
@@ -32,19 +48,34 @@ The important points to note are:
 
 ## Multi Region Replication
 
-It is also possible to replicate your Buildkite Agent token to multiple regions using
-AWS Secret Manager’s [multi-region replication](https://docs.aws.amazon.com/secretsmanager/latest/userguide/create-manage-multi-region-secrets.html). You can then deploy an Elastic CI Stack to each region
-and use the SSM Parameter Store reference path to read the secret from the regionally replicated secret.
+It is also possible to replicate your Buildkite Agent token to multiple regions
+using AWS Secret Manager’s [multi-region replication](https://docs.aws.amazon.com/secretsmanager/latest/userguide/create-manage-multi-region-secrets.html). You
+can then deploy an Elastic CI Stack to each region and use the Parameter Store
+reference path to read the secret from the regionally replicated secret.
 
 Some additional points to keep in mind when using multi-region replication:
 
-- Ensure each region's IAM role has `ssm:GetParameter` permission for the region it will be retrieving the secret from.
-    - By default, the template will grant permission to only the region it is deployed to, limiting the role’s utility to the stack’s region. This isn’t a problem just a caveat to be aware of, don’t expect to use the same role in multiple regions.
-- Ensure each region's IAM role has `kms:Decrypt` permission for the key used to encrypt the secret in that region.
-    - I used the AWS Secrets Manager key e.g. aws/secretsmanager in Secrets Manager and then looked up the underlying CMK ID of that key alias in each region I deployed the stack template to. Provide that value for the `BuildkiteAgentTokenParameterStoreKMSKey` parameter.
-- Apply a resource policy to the primary Secrets Manager secret that grants `secretsmanager:GetSecretValue` for each region's IAM role and wait for that to be replicated.
+- Ensure each region’s IAM role has `ssm:GetParameter` permission for the region
+it will be retrieving the secret from.
+    - By default, the template will grant permission to only the region it is
+    deployed to, limiting the role’s utility to the stack’s region. This isn’t a
+    problem just a caveat to be aware of. Don’t expect to use the same role in
+    multiple regions.
+- Ensure each region’s IAM role has `kms:Decrypt` permission for the key used to
+encrypt the secret in that region.
+    - I used the AWS Secrets Manager key e.g. aws/secretsmanager in Secrets
+    Manager and then looked up the underlying CMK ID of that key alias in each
+    region I deployed the stack template to. Provide that value for the
+    `BuildkiteAgentTokenParameterStoreKMSKey` parameter for the stack in that
+    region.
+- Apply a resource policy to the primary Secrets Manager secret that grants
+`secretsmanager:GetSecretValue` for each region’s IAM role and wait for that to
+be replicated.
 
-Now, changes to the agent token secret (either made by hand or using Automatic Secret Rotation) will be replicated from the primary region to each replia region.
+Now, changes to the agent token secret (either made by hand or using Automatic
+Secret Rotation) will be replicated from the primary region to each replia
+region.
 
-The Elastic CI Stack currently only resolves the agent token once on instance boot. Consider refreshing your
-AutoScale Group instances after rotating the secret and before revoking the old token.
+The Elastic CI Stack will only retrieve the Buildkite Agent token once when the
+instance boots. You should [refresh your Auto Scaling Group instances](https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
+after rotating and replicating the secret, and before revoking the old token.

--- a/vale/vocab.txt
+++ b/vale/vocab.txt
@@ -93,6 +93,7 @@ Pagerduty
 Phabricator
 phabricator
 php
+plaintext
 plist
 png
 pngs


### PR DESCRIPTION
This adds a guide for using AWS Secrets Manager to store (and potentially multi-region replicate) your Buildkite Agent token.

I put this in an Agent > v3 > AWS but haven’t linked to it or inserted it into the sidebar hierarchy yet and thought I’d leave that up to the fine docs folks to find a home for it that fits in with how you want to structure things for the Elastic CI Stack(s) going forward 😊

Moved from https://github.com/buildkite/elastic-ci-stack-for-aws/pull/855