### PR TITLE
update keyservers

### DIFF
--- a/pages/agent/v2/debian.md.erb
+++ b/pages/agent/v2/debian.md.erb
@@ -30,7 +30,7 @@ sudo apt-get install -y apt-transport-https dirmngr
 Now you can add our signed apt repository:
 
 ```shell
-sudo apt-key adv --keyserver ipv4.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+sudo apt-key adv --keyserver keys.openpgp.org --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 echo "deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
 ```
 

--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -25,7 +25,7 @@ sudo apt-get install -y apt-transport-https dirmngr
 Now you can add our signed apt repository. The default version of the agent is `stable`, but you can get the beta version by using `unstable` instead of `stable` in the following command, or the agent built from the `main` branch of the repository by using `experimental` instead of `stable`.
 
 ```shell
-sudo apt-key adv --keyserver ipv4.pool.sks-keyservers.net --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+sudo apt-key adv --keyserver keys.openpgp.org --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
 echo "deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
 ```
 


### PR DESCRIPTION
sks-keyservers.net is dead, long live keys.openpgp.org

https://sks-keyservers.net/
![image](https://user-images.githubusercontent.com/16850/123706332-db427800-d803-11eb-86b4-9450cf49a79c.png)
