### PR TITLE
Rename and link buildkite-metrics to buildkite-agent-metrics

### DIFF
--- a/pages/tutorials/parallel_builds.md.erb
+++ b/pages/tutorials/parallel_builds.md.erb
@@ -95,6 +95,6 @@ In addition to the [Elastic CI Stack for AWS](/docs/quickstart/elastic-ci-stack-
 * [Pipelines REST API](/docs/apis/rest-api/pipelines) and [Agents API](/docs/apis/rest-api/agents) you’re able to fetch each pipeline’s job count, and information about each agent.
 * [Agent priorities](/docs/agent/v3/prioritization) allow you to define which agents are assigned work first, such as high performance ephemeral agents.
 * [Agent queues](/docs/agent/v3/queues) allow you to divide your agent pools into separate groups for scaling and performance purposes.
-* [buildkite-metrics](https://github.com/buildkite/buildkite-metrics) tool allow you to collect your organization’s Buildkite metrics and report them to AWS CloudWatch and StatsD.
+* [buildkite-agent-metrics](https://github.com/buildkite/buildkite-agent-metrics) tool allow you to collect your organization’s Buildkite metrics and report them to AWS CloudWatch and StatsD.
 
 Using these tools you can automate your build infrastructure, scale your agents based on demand, and massively reduce build times using job parallelism.


### PR DESCRIPTION
This was renamed and the repository moved. GitHub does redirect but it’s better to link to our actual repository.