### PR TITLE
Add Elastic Mac docs

### DIFF
--- a/pages/agent/v3/aws.md.erb
+++ b/pages/agent/v3/aws.md.erb
@@ -58,6 +58,12 @@ Your saved AMI can now be used to boot as many macOS instances as you require.
 To make this process repeatable, save your instance configuration in a Launch
 Template.
 
+Use of an Auto-Scaling Group and Host Resource Group to maintain capacity in the
+face of hardware failures is recommended. Load based auto-scaling of macOS
+mac1.metal instances is not recommended, the instances are slow to boot and slow
+to terminate. It is likely that your agents will overprovision in response to
+load resulting in a high minimum charge per dedicated instance.
+
 There is an excellent blog post on [running iOS agents in the cloud](https://www.starkandwayne.com/blog/buildkite-2/) that goes into more detail on preparing macOS AMIs using [Packer](https://www.packer.io/).
 
 ### Known issues

--- a/pages/agent/v3/aws.md.erb
+++ b/pages/agent/v3/aws.md.erb
@@ -38,8 +38,8 @@ To use Xcode and the iOS Simulator, you must configure auto-login of a GUI
 session, and launch the Buildkite Agent in an `aqua` session as a Launchd Agent:
 
 1. Reserve a [AWS mac1.metal](https://aws.amazon.com/ec2/instance-types/mac/)
-Dedicated Instance.
-1. Boot a macOS instance using your desired AMI on the Dedicated Instance.
+Dedicated Host.
+1. Boot a macOS instance using your desired AMI on the Dedicated Host.
 1. Configure instance VPC subnets, security groups, and key pairs so that you
 can access the instance.
 1. Using an SSH or SSM session, set a password for the ec2-user and enable
@@ -64,7 +64,7 @@ maintain capacity in the face of hardware failures is recommended, load based
 dynamic auto-scaling of macOS instances is not recommended. The instances are
 currently slow to boot and slow to terminate. Use of load based auto-scaling is
 likely to result in an overprovision of agents which carries a high minimum
-charge per dedicated instance.
+charge per dedicated host.
 
 There is an excellent blog post on [running iOS agents in the cloud](https://www.starkandwayne.com/blog/buildkite-2/) that goes into more detail on preparing macOS AMIs using [Packer](https://www.packer.io/).
 

--- a/pages/agent/v3/aws.md.erb
+++ b/pages/agent/v3/aws.md.erb
@@ -37,7 +37,6 @@ step process. You can start with one of the macOS AMIs from AWS, or with an AMI 
 To use Xcode and the iOS Simulator, you must configure auto-login of a GUI
 session, and launch the Buildkite Agent in an `aqua` session as a Launchd Agent:
 
-
 1. Reserve a [AWS mac1.metal](https://aws.amazon.com/ec2/instance-types/mac/)
 Dedicated Instance.
 1. Boot a macOS instance using your desired AMI on the Dedicated Instance.
@@ -55,14 +54,17 @@ desired agent tags.
 1. Create an AMI from your instance.
 
 Your saved AMI can now be used to boot as many macOS instances as you require.
-To make this process repeatable, save your instance configuration in a Launch
-Template.
 
-Use of an Auto-Scaling Group and Host Resource Group to maintain capacity in the
-face of hardware failures is recommended. Load based auto-scaling of macOS
-mac1.metal instances is not recommended, the instances are slow to boot and slow
-to terminate. It is likely that your agents will overprovision in response to
-load resulting in a high minimum charge per dedicated instance.
+To make this process repeatable, save your instance configuration in a Launch
+Template. To automate instance replacement, use an Auto Scaling group to boot
+Instances and a Host Resource Group to reserve Dedicated Instances.
+
+While the use of an Auto-Scaling Group and Host Resource Group to automatically
+maintain capacity in the face of hardware failures is recommended, load based
+dynamic auto-scaling of macOS instances is not recommended. The instances are
+currently slow to boot and slow to terminate. Use of load based auto-scaling is
+likely to result in an overprovision of agents which carries a high minimum
+charge per dedicated instance.
 
 There is an excellent blog post on [running iOS agents in the cloud](https://www.starkandwayne.com/blog/buildkite-2/) that goes into more detail on preparing macOS AMIs using [Packer](https://www.packer.io/).
 

--- a/pages/agent/v3/aws.md.erb
+++ b/pages/agent/v3/aws.md.erb
@@ -40,7 +40,7 @@ session, and launch the Buildkite Agent in an `aqua` session as a Launchd Agent:
 
 1. Reserve a [AWS mac1.metal](https://aws.amazon.com/ec2/instance-types/mac/)
 Dedicated Instance.
-1. Boot a macOS instance using your desired AMI on the Dedicated Instance
+1. Boot a macOS instance using your desired AMI on the Dedicated Instance.
 1. Configure instance VPC subnets, security groups, and key pairs so that you
 can access the instance.
 1. Using an SSH or SSM session, set a password for the ec2-user and enable

--- a/pages/agent/v3/aws.md.erb
+++ b/pages/agent/v3/aws.md.erb
@@ -47,7 +47,7 @@ can access the instance.
 screen sharing.
 1. Using a VNC session, enable auto-login for the ec2-user in System Preferences
 and disable the auto screen lock and screen saver.
-1. Follow the [OS X installation guide](/docs/agent/v3/osx#installation)
+1. Follow the [macOS Installation Guide](/docs/agent/v3/macos#installation)
 instructions to install the Buildkite Agent using Homebrew and configure
 starting on login.
 1. Verify that the Buildkite Agent has connected to buildkite.com with your

--- a/pages/agent/v3/aws.md.erb
+++ b/pages/agent/v3/aws.md.erb
@@ -32,7 +32,8 @@ instance operating system. For Amazon Linux 2 use the
 ## Installing the Agent on AWS mac1.metal instances
 
 Setting up a macOS AMI that starts a Buildkite Agent on launch is a multi
-step process. You can start with one of the macOS AMIs from AWS, or with an AMI you've already installed Xcode or other software on.
+step process. You can start with one of the macOS AMIs from AWS, or with an AMI
+you've already installed Xcode or other software on.
 
 To use Xcode and the iOS Simulator, you must configure auto-login of a GUI
 session, and launch the Buildkite Agent in an `aqua` session as a Launchd Agent:

--- a/pages/agent/v3/aws.md.erb
+++ b/pages/agent/v3/aws.md.erb
@@ -16,10 +16,10 @@ You can use an Elastic CI Stack deployment to test Linux or Windows projects,
 parallelize large test suites, run Docker containers or docker-compose
 integration tests, or perform any AWS ops related tasks.
 
-[Read the documentation][github] on GitHub, and launch it using the
+[Read the documentation][elastic-ci-github] on GitHub, and launch it using the
 button on your organization’s Agents page.
 
-   [github]: https://github.com/buildkite/elastic-ci-stack-for-aws
+   [elastic-ci-github]: https://github.com/buildkite/elastic-ci-stack-for-aws
    [Red Hat/CentOS installer]: /docs/agent/v3/redhat
 
 ## Installing the Agent on your own AWS instances
@@ -29,7 +29,18 @@ instance operating system. For Amazon Linux 2 use the
 [Red Hat/CentOS installer](/docs/agent/v3/redhat). For macOS, see
 [installing the agent on AWS mac1.metal instances](#installing-the-agent-on-aws-mac1-dot-metal-instances)
 
-## Installing the Agent on AWS mac1.metal instances
+## Using our experimental Elastic Mac for AWS CloudFormation template
+
+The [Elastic Mac for AWS](/docs/agent/v3/aws/autoscaling_mac_metal) is a
+CloudFormation template for an autoscaling macOS Buildkite Agent cluster.
+
+You can use an Elastic Mac deployment to build and test macOS, iOS, iPadOS,
+tvOS, and watchOS projects.
+
+[Read the documentation](/docs/agent/v3/aws/autoscaling_mac_metal) for
+instructions on preparing and deploying this template.
+
+## Installing the Agent on your own AWS mac1.metal instances
 
 Setting up a macOS AMI that starts a Buildkite Agent on launch is a multi
 step process. You can start with one of the macOS AMIs from AWS, or with an AMI

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -20,14 +20,13 @@ familiarity with the macOS GUI.
 
 ## Choose a VPC Layout
 
-Before deploying this template you must choose a VPC subnet layout for your
-instances and which VPC security groups you want them to belong to.
+Before deploying this template you must choose a VPC subnet design, and which
+VPC security groups your instances should belong to.
 
-Depending on your threat model, you may find running these instances in your AWS
-account’s default VPC’s public subnets with public IP addresses suitable.
-Otherwise, you may wish to explore options like separate Public/Private subnets
-and a NAT Gateway, and using a Bastion or VPN to access the instances over SSH
-and VNC.
+Depending on your threat model, you may find running instances in your default
+VPC’s public subnets with a public IP address suitable. Otherwise, you may wish
+to explore options like separate Public/Private subnets and a NAT Gateway, and
+using a Bastion or VPN to access the instances over SSH and VNC.
 
 You also need to define the VPC Security Groups your instance network interfaces
 should belong to. At a minimum, inbound SSH access is required to set up your
@@ -35,18 +34,27 @@ initial template AMI.
 
 ## Build an AMI
 
-Set up a password for the ec2-user so you can connect using VNC.
+Before deploying this template, you must create a template AMI that can be
+horizontally scaled across multiple instances.
 
-Using screen sharing, set up auto-login for the ec2-user. Disable auto screen
-lock.
+1. Reserve a [AWS mac1.metal](https://aws.amazon.com/ec2/instance-types/mac/)
+Dedicated Host.
+1. Boot a macOS instance using your desired AMI on the Dedicated Host.
+1. Configure instance VPC subnets, security groups, and key pairs so that you
+can access the instance.
+1. Using an SSH or SSM session:
+	1. Set a password for the ec2-user using `sudo passwd ec2-user`
+	1. Enable screen sharing using `sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -activate -configure -access -on -restart -agent -privs -all`
+1. Using a VNC session:
+	1. Sign in as the ec2-user
+	1. Enable Automatic login for the ec2-user in System Preferences > Users & Accounts > Login Options
+	1. Disable Require password in System Preferences > Security & Privacy > General
+1. Install your required Xcode version
+	1. Ensure you launch Xcode at least once so you are presented with the EULA prompt.
+1. Using the AWS Console, create an AMI from your instance.
 
-Install Xcode and Xcode Command Line Utilities. Launch them once so you are
-presented with the EULA prompt.
-
-You do not need to install the buildkite-agent, this will be done automatically
-by the Launch Template `UserData` script.
-
-Create an AMI from the instance using the AWS Console.
+You do not need to install the `buildkite-agent`, it is automatically by the
+Launch Template `UserData` script.
 
 ## Associate your AMI with a Customer managed license in AWS License Manager
 

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -176,8 +176,8 @@ are slow to boot and slow to terminate. Consider using Scheduled Scaling Rules.
 If your ASG does not launch any instances, check the ASG Activity to see what
 error is occuring.
 
-It may be that there are no mac1.metal instances available in the region or
-subnets you have chosen.
+It may be that there are no `mac1.metal` instances available in the region, or
+Availability Zones of your VPC subnets.
 
 It may be that your Launch Template’s AMI is not associated with a Customer
 Managed License in AWS License Manager.

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -43,7 +43,7 @@ by the Launch Template `UserData` script.
 
 Create an AMI from the instance using the AWS Console.
 
-## Register your AMI with an AWS License Manager License
+## Associate your AMI with a Customer managed license in AWS License Manager
 
 To launch 
 
@@ -86,15 +86,23 @@ are slow to boot and slow to terminate. Consider using Scheduled Scaling Rules.
 
 ## F.A.Q.
 
-### My ASG reports an error launching instances
+### My ASG doesn’t launch any instances
 
-Ensure you [associate your AMI]() with an AWS License Manager License
-Configuration.
+If your ASG does not launch any instances, check the ASG Activity to see what
+error is occuring.
 
-Ensure the License uses `Core` type tracking.
+It may be that there are no mac1.metal instances available in the region or
+subnets you have chosen.
 
-### My buildkite-agent doesn’t launch automatically
+It may be that your Launch Template’s AMI is not associated with a Customer
+Managed License in AWS License Manager.
 
-Ensure your AMI is configured to auto-login as the ec2-user in the GUI. The
-buildkite-agent launchd job configuration requires an `Aqua` session type to
-allow your pipelines to use Xcode and the iOS Simulator.
+Ensure you [associate your AMI](#associate-your-AMI-with-a-Customer-managed-license-in-AWS-License-Manager)
+and any new AMIs with a Customer managed license. Ensure the License
+Configuration has a License Type of `Core`.
+
+### The buildkite-agent doesn’t launch automatically when the instance starts
+
+Ensure your AMI has been [configured to auto-login as the ec2-user](#Build-an-AMI)
+in the GUI. The buildkite-agent launchd job configuration requires an `Aqua`
+session type to allow your pipelines to use Xcode and the iOS Simulator.

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -110,7 +110,7 @@ Ensure you [associate your AMI](#associate-your-AMI-with-a-Customer-managed-lice
 and any new AMIs with a Customer managed license. Ensure the License
 Configuration has a License Type of `Core`.
 
-### The buildkite-agent doesn’t launch automatically when the instance starts
+### My instances don’t start the buildkite-agent
 
 Ensure your AMI has been [configured to auto-login as the ec2-user](#Build-an-AMI)
 in the GUI. The buildkite-agent launchd job configuration requires an `Aqua`

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -1,0 +1,74 @@
+# Auto Scaling mac1.metal instances
+
+We have built a [CloudFormation template](https://github.com/buildkite/elastic-mac-for-aws)
+that configures an Auto Scaling group, Launch Template, and Host Resource Group
+suitable for maintaining a pool of mac1.metal instance based Buildkite Agents.
+
+Using an Auto Scaling Group for your instances enables automatic instance
+replacement when hardware failures occur.
+
+As you must prepare and supply your own AMI for this template, macOS support has
+not been incorporated into the Elastic CI Stack for AWS.
+
+## Choose a VPC Layout
+
+Can use the default VPC and a security group to permit inbound SSH access.
+
+Consider whether giving your mac1.metal instances a public IP address is
+appropriate.
+
+May wish to use a VPC with separate Public / Private subnets with a NAT Gateway,
+and a Bastion instance or VPN for SSH and VNC access to the mac1.metal
+instances.
+
+## Build an AMI
+
+Set up a password for the ec2-user so you can connect using VNC.
+
+Using screen sharing, set up auto-login for the ec2-user. Disable auto screen
+lock.
+
+Install Xcode and Xcode Command Line Utilities. Launch them once so you are
+presented with the EULA prompt.
+
+You do not need to install the buildkite-agent, this will be done automatically
+by the Launch Template `UserData` script.
+
+Create an AMI from the instance using the AWS Console.
+
+## Deploy the CloudFormation template
+
+Using the VPC and AMI prepared earlier, deploy this template and fill in values
+for the parameters:
+
+* ImageId
+* RootVolumeSize
+* Subnets, from your VPC set up
+* SecurityGroupIds, from your VPC set up
+* IamInstanceProfile, if using additional AWS services from your builds provide an instance profile with appropriate IAM role
+* BuildkiteAgentToken
+* BuildkiteAgentQueue
+
+Using the AWS CLI:
+
+```
+aws cloudformation deploy --stack-name buildkite-mac --region YOUR_REGION --parameters-override file:///.parameters.json
+```
+
+There are optional parameters to configure the Auto Scaling Group `MinSize` and
+`MaxSize` which default to 0 and 3 respectively.
+
+The default AWS limit for mac1.metal is 3 dedicated hosts per account region. If
+you require more than 3 instances, request an increased limit using the AWS
+Console.
+
+Once you have deployed the template, use the template Resources tab to find the
+Auto Scaling Group. Edit the Auto Scaling Group and set the Desired Capacity to
+the number of instances you require.
+
+The Auto Scaling Group will automatically provision Dedicated Hosts using the
+Host Resource Group, and boot instances on them. The Launch Template’s
+`UserData` script will install, configure, and start the Buildkite Agent.
+
+Caveat the use of dynamic scaling policies on the Auto Scaling Group, instances
+are slow to boot and slow to terminate. Consider using Scheduled Scaling Rules.

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -104,6 +104,17 @@ The default AWS Limit for mac1.metal is 3 dedicated hosts per account region. If
 you require more than 3 instances, request an increased limit using the AWS
 Console.
 
+### Using the AWS Console
+
+To deploy using the AWS Console:
+
+[![Launch AWS Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=buildkite-mac&templateURL=https://s3.amazonaws.com/buildkite-serverless-apps-us-east-1/elastic-mac/template/latest.yml)
+
+Ensure you have selected the same region as your VPC and AMI resources, give
+your stack a unique name, and fill in the required parameters.
+
+### Using the AWS CLI
+
 To deploy using the AWS CLI, save your parameters in a `.parameters.json` file
 and run the following commands:
 
@@ -145,15 +156,15 @@ $ aws cloudformation deploy --stack-name buildkite-mac --region YOUR_REGION --te
 See the [AWS CloudFormation Deploy CLI documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/deploy/index.html)
 for more details.
 
+## Starting your Buildkite Agents
 
-
-Once you have deployed the template, use the template Resources tab to find the
-Auto Scaling Group. Edit the Auto Scaling Group and set the Desired Capacity to
-the number of instances you require.
+Once you have successfully deployed the template, use the template Resources tab
+to find the Auto Scaling Group. Edit the Auto Scaling Group and set the Desired
+Capacity to the number of instances you require.
 
 The Auto Scaling Group will automatically provision Dedicated Hosts using the
-Host Resource Group, and boot instances on them. The Launch Template’s
-`UserData` script will install, configure, and start the Buildkite Agent.
+Host Resource Group and boot instances on them. The Launch Template’s `UserData`
+script will install, configure, and start the Buildkite Agent.
 
 Caveat the use of dynamic scaling policies on the Auto Scaling Group, instances
 are slow to boot and slow to terminate. Consider using Scheduled Scaling Rules.

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -177,12 +177,11 @@ If your ASG does not launch any instances, check the ASG Activity to see what
 error is occuring.
 
 It may be that there are no `mac1.metal` instances available in the region, or
-Availability Zones of your VPC subnets.
+Availability Zones of your VPC subnets. This error is likely transient, wait for
+some more ASG scale out attempts to see if the error persists.
 
 It may be that your Launch Template’s AMI is not associated with a Customer
-Managed License in AWS License Manager.
-
-Ensure you [associate your AMI](#associate-your-AMI-with-a-Customer-managed-license-in-AWS-License-Manager)
+Managed License in AWS License Manager. Ensure you [associate your AMI](#associate-your-AMI-with-a-Customer-managed-license-in-AWS-License-Manager)
 and any new AMIs with a Customer managed license. Ensure the License
 Configuration has a License Type of `Core`.
 

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -3,6 +3,7 @@
 We have built a [CloudFormation template](https://github.com/buildkite/elastic-mac-for-aws)
 that configures an Auto Scaling group, Launch Template, and Host Resource Group
 suitable for maintaining a pool of mac1.metal instance based Buildkite Agents.
+This can be used to build Xcode Project based software projects using Buildkite.
 
 Using an Auto Scaling Group for your instances enables automatic instance
 replacement when hardware failures occur.

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -36,9 +36,13 @@ VPC’s public subnets with a public IP address suitable. Otherwise, you may wis
 to explore options like separate Public/Private subnets and a NAT Gateway, and
 using a Bastion or VPN to access the instances over SSH and VNC.
 
-You also need to define the VPC Security Groups your instance network interfaces
-should belong to. At a minimum, inbound SSH access is required to set up your
-initial template AMI.
+In supported regions, `mac1.metal` dedicated hosts may not be availabile in
+every Availability Zone. Consider using a subnet in every Availability Zone to
+maximise the pool of instances available to boot from.
+
+You also need to configure or define the VPC Security Groups your instance
+network interfaces should belong to. At a minimum, inbound SSH access is
+required to set up your initial template AMI.
 
 ## Build an AMI
 

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -14,14 +14,14 @@ not been incorporated into the Elastic CI Stack for AWS.
 
 ## Choose a VPC Layout
 
-Can use the default VPC and a security group to permit inbound SSH access.
+Before deploying this template you must choose a VPC subnet layout for your
+instances and which VPC security groups you want them to belong to.
 
-Consider whether giving your mac1.metal instances a public IP address is
-appropriate.
-
-May wish to use a VPC with separate Public / Private subnets with a NAT Gateway,
-and a Bastion instance or VPN for SSH and VNC access to the mac1.metal
-instances.
+Depending on your threat model, you may find running these instances in you AWS
+account’s default VPC public subnets with public IP addresses suitable.
+Otherwise, you may wish to explore options like separate Public/Private subnets
+and a NAT Gateway, and using a Bastion or VPN to access the instances over SSH
+and VNC.
 
 ## Build an AMI
 

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -5,12 +5,17 @@ that configures an Auto Scaling group, Launch Template, and Host Resource Group
 suitable for maintaining a pool of mac1.metal instance based Buildkite Agents.
 This can be used to build Xcode Project based software projects using Buildkite.
 
-Using an Auto Scaling Group for your instances enables automatic instance
-replacement when hardware failures occur, freeing you from the responsibility to
-reprovision instances.
-
 As you must prepare and supply your own AMI for this template, macOS support has
 not been incorporated into the Elastic CI Stack for AWS.
+
+Using an Auto Scaling Group for your instances enables automatic instance
+replacement when hardware failures occur, freeing you from the responsibility to
+manually reprovision instances.
+
+## Prerequisites
+
+Familiarity with AWS VPCs, and EC2 AMIs is required. You should also have
+familiarity with the macOS GUI.
 
 ## Choose a VPC Layout
 
@@ -37,6 +42,10 @@ You do not need to install the buildkite-agent, this will be done automatically
 by the Launch Template `UserData` script.
 
 Create an AMI from the instance using the AWS Console.
+
+## Register your AMI with an AWS License Manager License
+
+To launch 
 
 ## Deploy the CloudFormation template
 
@@ -74,3 +83,18 @@ Host Resource Group, and boot instances on them. The Launch Template’s
 
 Caveat the use of dynamic scaling policies on the Auto Scaling Group, instances
 are slow to boot and slow to terminate. Consider using Scheduled Scaling Rules.
+
+## F.A.Q.
+
+### My ASG reports an error launching instances
+
+Ensure you [associate your AMI]() with an AWS License Manager License
+Configuration.
+
+Ensure the License uses `Core` type tracking.
+
+### My buildkite-agent doesn’t launch automatically
+
+Ensure your AMI is configured to auto-login as the ec2-user in the GUI. The
+buildkite-agent launchd job configuration requires an `Aqua` session type to
+allow your pipelines to use Xcode and the iOS Simulator.

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -2,15 +2,16 @@
 
 We have built a [CloudFormation template](https://github.com/buildkite/elastic-mac-for-aws)
 that configures an Auto Scaling group, Launch Template, and Host Resource Group
-suitable for maintaining a pool of mac1.metal instance based Buildkite Agents.
-This can be used to build Xcode Project based software projects using Buildkite.
+suitable for maintaining a pool of EC2 mac1.metal instance based Buildkite
+Agents. These agents can be used to run Buildkite Pipelines that build Xcode
+based software projects for macOS, iOS, iPadOS, tvOS, and watchOS.
 
 As you must prepare and supply your own AMI for this template, macOS support has
-not been incorporated into the Elastic CI Stack for AWS.
+**not** been incorporated into the Elastic CI Stack for AWS.
 
 Using an Auto Scaling Group for your instances enables automatic instance
 replacement when hardware failures occur, freeing you from the responsibility to
-manually reprovision instances.
+monitor and manually reprovision instances.
 
 ## Prerequisites
 
@@ -22,11 +23,15 @@ familiarity with the macOS GUI.
 Before deploying this template you must choose a VPC subnet layout for your
 instances and which VPC security groups you want them to belong to.
 
-Depending on your threat model, you may find running these instances in you AWS
-account’s default VPC public subnets with public IP addresses suitable.
+Depending on your threat model, you may find running these instances in your AWS
+account’s default VPC’s public subnets with public IP addresses suitable.
 Otherwise, you may wish to explore options like separate Public/Private subnets
 and a NAT Gateway, and using a Bastion or VPN to access the instances over SSH
 and VNC.
+
+You also need to define the VPC Security Groups your instance network interfaces
+should belong to. At a minimum, inbound SSH access is required to set up your
+initial template AMI.
 
 ## Build an AMI
 

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -78,8 +78,8 @@ Available AMIs, select your macOS AMIs and then click Associate.
 
 ## Deploy the CloudFormation template
 
-Using the VPC and AMI prepared earlier, deploy this template and fill in values
-for the parameters:
+Using the VPC and AMI prepared earlier, provide values for the following
+required parameters:
 
 * ImageId
 * RootVolumeSize
@@ -89,18 +89,57 @@ for the parameters:
 * BuildkiteAgentToken
 * BuildkiteAgentQueue
 
-Using the AWS CLI:
+There are also optional parameters to configure the Auto Scaling Group:
 
-```
-aws cloudformation deploy --stack-name buildkite-mac --region YOUR_REGION --parameters-override file:///.parameters.json
-```
+* MinSize, defaults to 0
+* MaxSize, defaults to 3
 
-There are optional parameters to configure the Auto Scaling Group `MinSize` and
-`MaxSize` which default to 0 and 3 respectively.
-
-The default AWS limit for mac1.metal is 3 dedicated hosts per account region. If
+The default AWS Limit for mac1.metal is 3 dedicated hosts per account region. If
 you require more than 3 instances, request an increased limit using the AWS
 Console.
+
+To deploy using the AWS CLI, save your parameters in a `.parameters.json` file
+and run the following commands:
+
+```
+$ cat .parameters.json
+> [
+	{
+		"ParameterKey": "ImageId",
+		"ParameterValue": "ami-0c3a7d0c15048b6b5"
+	},
+	{
+		"ParameterKey": "RootVolumeSize",
+		"ParameterValue": "250"
+	},
+	{
+		"ParameterKey": "Subnets",
+		"ParameterValue": "subnet-f3e72abb,subnet-f23fe294"
+	},
+	{
+		"ParameterKey": "SecurityGroupIds",
+		"ParameterValue": "sg-a09db9d7"
+	},
+	{
+		"ParameterKey": "BuildkiteAgentQueue",
+		"ParameterValue": "mac"
+	},
+	{
+		"ParameterKey": "BuildkiteAgentToken",
+		"ParameterValue": "[redacted]"
+	}
+]
+
+$ make
+> sed "s/%v/v0.0.1-9-g1790b0d/" <template.yml >build/template.yml
+
+$ aws cloudformation deploy --stack-name buildkite-mac --region YOUR_REGION --template-file build/template.yml --parameters-override file:///$PWD/.parameters.json
+```
+
+See the [AWS CloudFormation Deploy CLI documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/deploy/index.html)
+for more details.
+
+
 
 Once you have deployed the template, use the template Resources tab to find the
 Auto Scaling Group. Edit the Auto Scaling Group and set the Desired Capacity to

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -73,7 +73,7 @@ Launch Template `UserData` script.
 To launch an instances using a Host Resource Group, the instance AMI must be
 associated with a Customer managed license in AWS License Manager.
 
-Using the AWS Console, open the AWS License Manager dashboard and naviate to
+Using the AWS Console, open the AWS License Manager dashboard and navigate to
 Customer managed licenses. Create a new Customer managed license, enter a
 descriptive name and select a License Type of `Cores`.
 
@@ -83,18 +83,19 @@ Available AMIs, select your macOS AMIs and then click Associate.
 
 ## Deploy the CloudFormation template
 
-Using the VPC and AMI prepared earlier, provide values for the following
+Using the VPC and AMI prepared earlier, prepare values for the following
 required parameters:
 
-* ImageId
+* ImageId, from your API set up
 * RootVolumeSize
 * Subnets, from your VPC set up
 * SecurityGroupIds, from your VPC set up
-* IamInstanceProfile, if using additional AWS services from your builds provide an instance profile with appropriate IAM role
-* BuildkiteAgentToken
-* BuildkiteAgentQueue
+* IamInstanceProfile, if accessing AWS services from your builds, provide an Instance Profile ARN with an appropriate IAM role attached
+* BuildkiteAgentToken, an Agent Token from http://buildkite.com/organizations/-/agents for your Buildkite Organization
+* BuildkiteAgentQueue, the Buildkite Queue your Pipeline Steps target
 
-There are also optional parameters to configure the Auto Scaling Group:
+There are also optional parameters to configure the size of the Auto Scaling
+Group:
 
 * MinSize, defaults to 0
 * MaxSize, defaults to 3

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -9,14 +9,21 @@ based software projects for macOS, iOS, iPadOS, tvOS, and watchOS.
 As you must prepare and supply your own AMI for this template, macOS support has
 **not** been incorporated into the Elastic CI Stack for AWS.
 
-Using an Auto Scaling Group for your instances enables automatic instance
-replacement when hardware failures occur, freeing you from the responsibility to
-monitor and manually reprovision instances.
+Using an Auto Scaling Group for your instances ensures booting your macOS
+Buildkite Agents is repeatable, and provides automatic instance replacement when
+hardware failures occur.
 
 ## Prerequisites
 
 Familiarity with AWS VPCs, and EC2 AMIs is required. You should also have
 familiarity with the macOS GUI.
+
+See [Amazon EC2 Mac instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-mac-instances.html#mac-instance-considerations)
+for more details on AWS EC2 mac1.metal instances.
+
+You must also choose an AWS Region to create your resources in. `mac1.metal`
+instances are not available in all AWS Regions or in all Availability Zones
+within those regions.
 
 ## Choose a VPC Layout
 

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -6,7 +6,8 @@ suitable for maintaining a pool of mac1.metal instance based Buildkite Agents.
 This can be used to build Xcode Project based software projects using Buildkite.
 
 Using an Auto Scaling Group for your instances enables automatic instance
-replacement when hardware failures occur.
+replacement when hardware failures occur, freeing you from the responsibility to
+reprovision instances.
 
 As you must prepare and supply your own AMI for this template, macOS support has
 not been incorporated into the Elastic CI Stack for AWS.

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -18,12 +18,13 @@ hardware failures occur.
 Familiarity with AWS VPCs, and EC2 AMIs is required. You should also have
 familiarity with the macOS GUI.
 
-See [Amazon EC2 Mac instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-mac-instances.html#mac-instance-considerations)
-for more details on AWS EC2 mac1.metal instances.
+You must choose an AWS Region with `mac1.metal` instances available. See
+[Amazon EC2 Mac Instances](https://aws.amazon.com/ec2/instance-types/mac/) and
+[Amazon EC2 Dedicated Hosts Pricing](https://aws.amazon.com/ec2/dedicated-hosts/pricing/)
+for details on which regions have `mac1.metal` hosts available.
 
-You must also choose an AWS Region to create your resources in. `mac1.metal`
-instances are not available in all AWS Regions or in all Availability Zones
-within those regions.
+See also the [Amazon EC2 Mac instances User Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-mac-instances.html)
+for more details on AWS EC2 Mac instances.
 
 ## Choose a VPC Layout
 

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -45,7 +45,16 @@ Create an AMI from the instance using the AWS Console.
 
 ## Associate your AMI with a Customer managed license in AWS License Manager
 
-To launch 
+To launch an instances using a Host Resource Group, the instance AMI must be
+associated with a Customer managed license in AWS License Manager.
+
+Using the AWS Console, open the AWS License Manager dashboard and naviate to
+Customer managed licenses. Create a new Customer managed license, enter a
+descriptive name and select a License Type of `Cores`.
+
+Once your Customer managed license has been saved, open the detail view for your
+license. Open the Associated AMIs tab and choose Associate AMI. From the list of
+Available AMIs, select your macOS AMIs and then click Associate.
 
 ## Deploy the CloudFormation template
 

--- a/pages/agent/v3/aws/autoscaling_mac_metal.md
+++ b/pages/agent/v3/aws/autoscaling_mac_metal.md
@@ -61,7 +61,7 @@ can access the instance.
 	1. Sign in as the ec2-user
 	1. Enable Automatic login for the ec2-user in System Preferences > Users & Accounts > Login Options
 	1. Disable Require password in System Preferences > Security & Privacy > General
-1. Install your required Xcode version
+1. Install your required version of Xcode
 	1. Ensure you launch Xcode at least once so you are presented with the EULA prompt.
 1. Using the AWS Console, create an AMI from your instance.
 

--- a/pages/agent/v3/aws/secrets_manager.md
+++ b/pages/agent/v3/aws/secrets_manager.md
@@ -37,8 +37,8 @@ To ensure your Elastic CI Stack instance IAM role has access to the secret:
     "Effect" : "Allow",
     "Principal" : {
       "AWS" : [
-        "arn\:aws\:iam::[redacted]:role/buildkite-secretsmanager-AutoscalingLambdaExecutionRole",
-        "arn\:aws\:iam::[redacted]:role/buildkite-secretsmanager-Role"
+        "arn\:aws\:iam::[redacted]:role/buildkite-stack-AutoscalingLambdaExecutionRole",
+        "arn\:aws\:iam::[redacted]:role/buildkite-stack-Role"
       ]
     },
     "Action" : "secretsmanager:GetSecretValue",


### PR DESCRIPTION
These docs provide instructions for deploying [Elastic Mac for AWS](https://github.com/buildkite/elastic-mac-for-aws) and depend on open sourcing that repository.

I haven’t added this new guide to the sidebar because I wasn’t sure how you’d like to structure it. This new guide is AWS specific, but not Elastic CI Stack for AWS specific. I was wondering if we wanted a new per-platform e.g. AWS and GCP sidebar header after the Agent Installers?

This is ready for _review_ but not ready for merge pending tidying up the surrounding bits before we hit open source.