### PR TITLE
updated details on running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ To contribute, send a pull request! :heart:
 
 ```bash
 git clone https://github.com/buildkite/docs.git
+cd docs
 git submodule update --init
 ```
 
 If you have Ruby installed:
 
 ```bash
+# Navigate into the docs directory
 # Install the dependencies
 bundle
 # Run the specs
@@ -21,6 +23,8 @@ bundle exec rspec
 # Start the app on http://localhost:3000/
 bin/rails server
 ```
+
+> **Note**: The documentation uses Ruby 2.7.2. You also need Node installed. The current LTS should be ok.
 
 Or if you have Docker installed:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bundle exec rspec
 bin/rails server
 ```
 
-> **Note**: The documentation uses Ruby 2.7.2. You also need Node installed. The current LTS should be ok.
+> **Note**: The documentation uses Ruby 2.7.2. You also need Node installed. The current LTS (long term support) version should be ok.
 
 Or if you have Docker installed:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bundle exec rspec
 bin/rails server
 ```
 
-> **Note**: The documentation uses Ruby 2.7.2. You also need Node installed. The current LTS (long term support) version should be ok.
+> **Note**: Check [.ruby-version](.ruby-version) for the current required version. You also need Node installed. The current LTS (long term support) version should be ok.
 
 Or if you have Docker installed:
 


### PR DESCRIPTION
Added a little more detail, to flag Ruby versions and Node requirement.

Have also spelled out need to be in docs directory - possibly too basic for our users though?

Also: I never got it running on Windows directly, had to resort to WSL. Wondering if we should flag this? You might get another windows user in a year or two . . . 