### PR TITLE
Differentiate agent lifecycle vs job lifecycle hooks

### DIFF
--- a/pages/agent/v2/_apt_locations.md.erb
+++ b/pages/agent/v2/_apt_locations.md.erb
@@ -1,5 +1,5 @@
 * Configuration: `/etc/buildkite-agent/buildkite-agent.cfg`
-* Hooks: `/etc/buildkite-agent/hooks/`
+* Agent Hooks: `/etc/buildkite-agent/hooks/`
 * Builds: `/var/lib/buildkite-agent/builds/`
 * Logs, depending on your system:
   - `journalctl -f -u buildkite-agent` (systemd)

--- a/pages/agent/v2/cli_artifact.md.erb
+++ b/pages/agent/v2/cli_artifact.md.erb
@@ -248,7 +248,7 @@ Options:
 
 ## Using your own private AWS S3 bucket
 
-You can use the `buildkite-agent artifact` command to store artifacts in your own private Amazon S3 bucket. To do so, you’ll need to export the following environment variables using an [environment agent hook](/docs/agent/v2/hooks) (this can not be set via the Buildkite web interface, API, or during pipeline upload):
+You can use the `buildkite-agent artifact` command to store artifacts in your own private Amazon S3 bucket. To do so, you’ll need to export the following environment variables using an [environment hook](/docs/agent/v2/hooks) (this can not be set via the Buildkite web interface, API, or during pipeline upload):
 
 ```bash
 export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID"

--- a/pages/agent/v2/freebsd.md.erb
+++ b/pages/agent/v2/freebsd.md.erb
@@ -56,7 +56,7 @@ See the [Agent SSH Keys](/docs/agent/v2/ssh-keys) documentation for more details
 ## File Locations
 
 * Configuration: `~/.buildkite-agent/buildkite-agent.cfg`
-* Hooks: `~/.buildkite-agent/hooks`
+* Agent Hooks: `~/.buildkite-agent/hooks`
 * Builds: `~/.buildkite-agent/builds`
 * SSH keys: `~/.ssh`
 

--- a/pages/agent/v2/linux.md.erb
+++ b/pages/agent/v2/linux.md.erb
@@ -39,7 +39,7 @@ See the [Agent SSH Keys](/docs/agent/v2/ssh-keys) documentation for more details
 ## File Locations
 
 * Configuration: `~/.buildkite-agent/buildkite-agent.cfg`
-* Hooks: `~/.buildkite-agent/hooks`
+* Agent Hooks: `~/.buildkite-agent/hooks`
 * Builds: `~/.buildkite-agent/builds`
 * SSH keys: `~/.ssh`
 

--- a/pages/agent/v2/osx.md.erb
+++ b/pages/agent/v2/osx.md.erb
@@ -41,14 +41,14 @@ See the [Agent SSH Keys](/docs/agent/v2/ssh-keys) documentation for more details
 Homebrew install file locations:
 
 * Configuration: `/usr/local/etc/buildkite-agent/buildkite-agent.cfg`
-* Hooks: `/usr/local/etc/buildkite-agent/hooks`
+* Agent Hooks: `/usr/local/etc/buildkite-agent/hooks`
 * Builds: `/usr/local/var/buildkite-agent/builds`
 * Log: `/usr/local/var/log/buildkite-agent.log`
 
 Linux installer script file locations:
 
 * Configuration: `~/.buildkite-agent/buildkite-agent.cfg`
-* Hooks: `~/.buildkite-agent/hooks`
+* Agent Hooks: `~/.buildkite-agent/hooks`
 * Builds: `~/.buildkite-agent/builds`
 
 ## Configuration

--- a/pages/agent/v2/redhat.md.erb
+++ b/pages/agent/v2/redhat.md.erb
@@ -58,7 +58,7 @@ See the [Agent SSH Keys](/docs/agent/v2/ssh-keys) documentation for more details
 ## File Locations
 
 * Configuration: `/etc/buildkite-agent/buildkite-agent.cfg`
-* Hooks: `/etc/buildkite-agent/hooks/`
+* Agent Hooks: `/etc/buildkite-agent/hooks/`
 * Builds: `/var/buildkite-agent/builds/`
 * Logs, depending on your system:
   - `journalctl -f -u buildkite-agent` (systemd)

--- a/pages/agent/v3/_apt_locations.md.erb
+++ b/pages/agent/v3/_apt_locations.md.erb
@@ -1,5 +1,5 @@
 * Configuration: `/etc/buildkite-agent/buildkite-agent.cfg`
-* Hooks: `/etc/buildkite-agent/hooks/`
+* Agent Hooks: `/etc/buildkite-agent/hooks/`
 * Builds: `/var/lib/buildkite-agent/builds/`
 * Logs, depending on your system:
   - `journalctl -f -u buildkite-agent` (systemd)

--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -149,14 +149,17 @@ Use this command in your build scripts to verify downloaded artifacts against th
 
 You can use the `buildkite-agent artifact` command to store artifacts in your private Amazon S3 bucket. To do so, you’ll need to export some artifact environment variables.
 
-You can set these environment variables from a variety of places, but we recommend storing your exports in an [environment agent hook](/docs/agent/v3/hooks) as a best practice:
+You can set these environment variables from a variety of places. Exporting them
+from an [environment hook](/docs/agent/v3/hooks#job-lifecycle-hooks) defined in
+your [agent `hooks-path` directory](/docs/agent/v3/hooks#hook-locations-agent-hooks)
+ensures they are applied to all jobs:
 
 ```bash
 export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID"
 export BUILDKITE_S3_DEFAULT_REGION="eu-central-1" # default: us-east-1
 ```
 
-You will need to make sure your agent instances have the following IAM policy to read and write objects in the bucket, for example:
+You will also need to make sure your agent instances have the following IAM policy to read and write objects in the bucket, for example:
 
 ```json
 {

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -206,7 +206,7 @@ _Optional attributes:_
     <tr id="hooks-path">
       <th><code>hooks-path</code></th>
       <td>
-        The directory to use for agent hooks. See <a href="/docs/agent/v3/hooks#hook-locations-agent-hooks">hook locations</a> for details.
+        A directory containing <a href="/docs/agent/v3/hooks#hook-locations-agent-hooks">agent hooks</a>.
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_HOOKS_PATH</code></p>
       </td>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -206,7 +206,7 @@ _Optional attributes:_
     <tr id="hooks-path">
       <th><code>hooks-path</code></th>
       <td>
-        Directory where the global hooks are found.
+        The directory to use for agent hooks. See <a href="/docs/agent/v3/hooks#hook-locations-agent-hooks">hook locations</a> for details.
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_HOOKS_PATH</code></p>
       </td>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -206,7 +206,7 @@ _Optional attributes:_
     <tr id="hooks-path">
       <th><code>hooks-path</code></th>
       <td>
-        Directory where the global hook scripts are found.
+        Directory where the global hooks are found.
         <p class="Docs__api-param-eg"><em>Default:</em> (depends on platform)</p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_HOOKS_PATH</code></p>
       </td>
@@ -555,4 +555,4 @@ Most configuration options can be specified as environment variables when starti
 BUILDKITE_AGENT_TAGS="queue=deploy,host=$(hostname)" buildkite-agent start
 ```
 
-These variables cannot be modified through the Buildkite web interface, API or via pipeline upload for security reasons. You may be able to modify some of the options, such as `BUILDKITE_GIT_CLONE_FLAGS`, from within [hook scripts](/docs/agent/v3/hooks).
+These variables cannot be modified through the Buildkite web interface, API or via pipeline upload for security reasons. You may be able to modify some of the options, such as `BUILDKITE_GIT_CLONE_FLAGS`, from within [hooks](/docs/agent/v3/hooks).

--- a/pages/agent/v3/docker.md.erb
+++ b/pages/agent/v3/docker.md.erb
@@ -35,7 +35,7 @@ The default tag (i.e. `buildkite/agent:latest`) will always point to the latest 
 ## Default file locations
 
 * Configuration: `/buildkite/buildkite-agent.cfg`
-* Hooks: `/buildkite/hooks`
+* Agent Hooks: `/buildkite/hooks`
 * Builds: `/buildkite/builds`
 * Agent user home: `/root`
 
@@ -151,7 +151,8 @@ If you're using Docker with Docker images hosted on Docker Hub, note that as of 
 
 ## Authenticating private git repositories
 
-To configure a [git-credentials file](https://git-scm.com/docs/git-credential-store#_storage_format) located at `/buildkite-secrets/git-credentials`, you could use the following `environment` [agent hook](/docs/agent/hooks) mounted to `/buildkite/hooks/environment`:
+To configure a [git-credentials file](https://git-scm.com/docs/git-credential-store#_storage_format) located at `/buildkite-secrets/git-credentials`, you could use the following
+[`environment` hook](/docs/agent/hooks#job-lifecycle-hooks) mounted to `/buildkite/hooks/environment`:
 
 ```bash
 #!/bin/bash
@@ -164,7 +165,9 @@ git config --global credential.helper "store --file=/buildkite-secrets/git-crede
 # export FOO=bar
 ```
 
-To configure a private SSH key located at `/buildkite-secrets/id_rsa_buildkite_git` you could use the following `environment` [agent hook](/docs/agent/hooks) mounted to `/buildkite/hooks/environment`:
+To configure a private SSH key located at `/buildkite-secrets/id_rsa_buildkite_git`
+you could use the following [`environment` hook](/docs/agent/hooks#job-lifecycle-hooks)
+mounted to `/buildkite/hooks/environment`:
 
 ```bash
 #!/bin/bash

--- a/pages/agent/v3/freebsd.md.erb
+++ b/pages/agent/v3/freebsd.md.erb
@@ -51,7 +51,7 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 ## File Locations
 
 * Configuration: `~/.buildkite-agent/buildkite-agent.cfg`
-* Hooks: `~/.buildkite-agent/hooks`
+* Agent Hooks: `~/.buildkite-agent/hooks`
 * Builds: `~/.buildkite-agent/builds`
 * SSH keys: `~/.ssh`
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -119,11 +119,12 @@ they are run as part of each job:
 
 ## Creating Lifecycle hooks
 
-Lifecycle hooks are executed and can be written in any programming language of
-your choice. See the specific lifecycle hook documentation for details on the
-interface between them and the Buildkite Agent.
+Lifecycle hooks can be written in the programming language of your choice and
+are executed by the Buildkite Agent. See the documentation for each lifecycle
+hook for details on the interface between the Buildkite Agent and the
+Lifecycle hook.
 
-Lifecycle hooks can only be defined in the [global hooks](#agent-hook-locations)
+Lifecycle hooks can only be defined in the [global hooks](#agent-hook-locations-global-hooks)
 directory.
 
 ## Creating Job hooks

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -30,7 +30,7 @@ environment variables are carried to the job’s subsequent phases and hooks. Fo
 example, the `environment` hook can modify or export new environment variables
 for the job’s subsequent phases and hooks.
 
-## Available Lifecycle hooks
+## Lifecycle hooks
 
 <table>
   <thead>
@@ -60,7 +60,7 @@ for the job’s subsequent phases and hooks.
   </tbody>
 </table>
 
-## Available Job hooks
+## Job hooks
 
 The following is a complete list of available job hooks, and the order in which
 they are run as part of each job:
@@ -191,9 +191,8 @@ platform’s installation documentation.
 To get started with global hooks copy the relevant example script and remove the
 `.sample` file extension.
 
-See the lists of [lifecycle hooks](#available-lifecycle-hooks) and
-[job hooks](#available-job-hooks) for the hook types that can be included in the
-global hooks directory.
+See [lifecycle hooks](#lifecycle-hooks) and [job hooks](#job-hooks) for the hook
+types that can be defined in the global hooks directory.
 
 ### Repository hooks
 
@@ -205,8 +204,8 @@ To get started, create a shell script in `.buildkite/hooks` named
 `post-checkout`. It will be sourced and run after your repository has been
 checked out as part of every job for any pipeline that uses this repository.
 
-You can include any of the [available job hooks](#available-job-hooks) whose
-`Order` includes *Repository*.
+You can define any of the [job hooks](#job-hooks) whose `Order` includes
+*Repository*.
 
 ### Plugin hooks
 
@@ -214,5 +213,4 @@ Plugin hooks allow plugins you’ve defined in your Pipeline Steps to override
 default behavior.
 
 See the [plugin documentation](/docs/plugins) for how to implement plugin hooks
-and [available job hooks](#available-job-hooks) for the list of hook types that
-a plugin can include.
+and [job hooks](#job-hooks) for the list of hook types that a plugin can define.

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -1,40 +1,89 @@
 # Buildkite Agent Hooks
 
-Every agent installer comes with a hooks directory which can be used to override and extend the built-in agent behavior. For example, you could create an agent `checkout` hook which speeds up a fresh `git clone` on a new build machine, an agent `environment` hook which exports secret API keys as environment variables, or a repository `pre-command` hook which sets up repository-specific environment variables.
+Every agent installer comes with a hooks directory which can be used to override
+and extend the built-in agent behavior. For example, you could create an agent
+`checkout` hook which speeds up a fresh `git clone` on a new build machine, an
+agent `environment` hook which exports secret API keys as environment
+variables, or a repository `pre-command` hook which sets up repository-specific
+environment variables.
 
 {:toc}
 
 ## Types of hooks
 
-There are three types of hooks:
+There are two types of hook:
 
-* Agent hooks - these exist on the agent’s machine, and are run for every job on any pipeline.
-* Repository hooks - these exist in your pipeline repository’s `.buildkite/hooks` directory.
-* Plugin hooks - these are provided by any [plugins](/docs/plugins) you've defined in your `pipeline.yml`.
+* Agent hooks
+* Step hooks
+
+Agent hooks are executed as part of the agent lifecycle. For example, the
+`pre-bootstrap` hook is executed before starting the per-job bootstrap process.
+
+Step hooks are sourced as part of each Buildkite Job. Step hooks are run in a
+per-job shell environment, and environment variables are carried between the
+phases and hooks for a given step. For example, the `environment` hook can
+modify or export new environment variables for the subsequent job phases and
+hooks.
+
+## Hook locations
+
+There are three hook locations:
+
+* Agent hooks - these exist on the agent’s machine and can define both agent and step hooks. Step hooks are run for every job on any pipeline.
+* Repository hooks - these exist in your pipeline repository’s `.buildkite/hooks` directory and can define step hooks.
+* Plugin hooks - these are provided by any [plugins](/docs/plugins) you've defined in your `pipeline.yml` and can define step hooks.
 
 ### Agent hooks
 
-Each agent installer comes with a hooks directory containing a set of sample hooks. You can find the location of your agent hooks directory in your platform’s installation documentation.
+Each agent installer comes with a hooks directory containing a set of sample
+hooks. You can find the location of your agent hooks directory in your
+platform’s installation documentation.
 
-To get started with agent hooks copy the relevant example script and remove the `.sample` file extension.
+To get started with agent hooks copy the relevant example script and remove the
+`.sample` file extension.
 
 ### Repository hooks
 
-Repository hooks allow you to execute repository-specific scripts. Repository hooks live alongside your repository’s source code under the directory `.buildkite/hooks`.
+Repository hooks allow you to execute repository-specific scripts. Repository
+hooks live alongside your repository’s source code under the directory
+`.buildkite/hooks`.
 
-To get started, create a shell script in `.buildkite/hooks` named `post-checkout`.
-It will be sourced and run every build, after the Agent checks your repository out.
-You can also use one of the other available *Repository* hooks, according to when you want your custom script to run.
+To get started, create a shell script in `.buildkite/hooks` named
+`post-checkout`. It will be sourced and run every build, after the Agent checks
+your repository out. You can also use one of the other available *Repository*
+hooks, according to when you want your custom script to run.
 
 ### Plugin hooks
 
-Plugin hooks allow plugins you’ve defined in your Pipeline to override default behavior.
+Plugin hooks allow plugins you’ve defined in your Pipeline to override default
+behavior.
 
 See the [plugin documentation](/docs/plugins) for how to implement plugin hooks.
 
-## Available hooks
+## Available Agent Hooks
 
-The following is a complete list of available hooks, and the order in which they are called:
+<table>
+  <thead>
+    <tr>
+        <th>Hook</th>
+        <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="white-space: nowrap"><code>pre-bootstrap</code></td>
+      <td>Runs before a step’s job is started. Useful for <a href="/docs/agent/v3/securing#strict-checks-using-agent-hooks">adding strict checks</a> before jobs are permitted to run.</td></tr>
+    <tr>
+      <td style="white-space: nowrap"><code>agent-shutdown</code></td>
+      <td>Runs when each agent shuts down. Useful for performing cleanup tasks
+      for the entire agent, outside of the job lifecycle.</td></tr>
+  </tbody>
+</table>
+
+## Available Step Hooks
+
+The following is a complete list of available step hooks, and the order in which
+they are run as part of each job:
 
 <table>
   <thead>
@@ -48,7 +97,7 @@ The following is a complete list of available hooks, and the order in which they
     <tr>
       <td style="white-space: nowrap"><code>environment</code></td>
       <td style="white-space: nowrap">Agent, Plugin</td>
-      <td>Runs before all other hooks. Useful for <a href="/docs/pipelines/secrets#storing-secrets-in-environment-hooks">exposing secret keys</a> and <a href="/docs/agent/v3/securing#strict-checks-using-agent-hooks">adding strict checks</a>.</td></tr>
+      <td>Runs before all other hooks. Useful for <a href="/docs/pipelines/secrets#storing-secrets-in-environment-hooks">exposing secret keys</a>.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>pre-checkout</code></td>
       <td style="white-space: nowrap">Agent, Plugin</td>
@@ -85,27 +134,31 @@ The following is a complete list of available hooks, and the order in which they
       <td style="white-space: nowrap"><code>pre-exit</code></td>
       <td style="white-space: nowrap">Agent, Repository, Plugin</td>
       <td>Runs before the job finishes. Useful for performing cleanup tasks.</td></tr>
-    <tr>
-      <td style="white-space: nowrap"><code>agent-shutdown</code></td>
-      <td style="white-space: nowrap">Agent</td>
-      <td>Runs when each agent shuts down, and prints output only to the agent log. Useful for performing cleanup tasks for the entire agent, outside of the job lifecycle.</td></tr>
   </tbody>
 </table>
 
-## Creating hook scripts
+## Creating agent hooks
 
-Hooks are shell scripts you can use to run commands and export environment variables.
-Hooks have access to all the standard [Buildkite environment variables](/docs/pipelines/environment-variables).
+Agent hooks are executed and can be written in any programming language.
 
-Hooks are copied to `$TMPDIR` directory and *sourced* by the default shell on the Agent that is running the build, which has a few implications:
+## Creating step hooks
+
+Step hooks are shell scripts you can use to run commands and export environment
+variables. Hooks have access to all the standard [Buildkite environment variables](/docs/pipelines/environment-variables).
+
+Step hooks are copied to `$TMPDIR` directory and *sourced* by the default shell
+on the Agent that is running the build, which has a few implications:
 
 * `$BASH_SOURCE` contains the location the hook is sourced from
 * `$0` contains the location of the copy of the script that is running from `$TMPDIR`
 * the shebang line of the hook script has no effect
 
-To write hooks in another programming language, you need to call them from within the shell script, and explicitly pass any Buildkite environment variables you need to the script when you call it.
+To write step hooks in another programming language, you need to call them from
+within the shell script, and explicitly pass any Buildkite environment variables
+you need to the script when you call it.
 
-The following is an example of a custom `environment` hook which exports a GitHub API key for the pipeline’s release build step:
+The following is an example of a custom `environment` hook which exports a
+GitHub API key for the pipeline’s release build step:
 
 ```bash
 set -eu
@@ -114,7 +167,7 @@ echo '--- \:house_with_garden\: Setting up the environment'
 export GITHUB_RELEASE_ACCESS_KEY='xxx'
 ```
 
-## Hooks on Windows
+## Step hooks on Windows
 
 Agents running Windows require hook files to have either:
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -134,7 +134,7 @@ they are run as part of each job:
 
 ### Creating job lifecycle hooks
 
-Job lifecyle hooks run for every job an agent accepts. They are shell
+Job lifecycle hooks run for every job an agent accepts. They are shell
 scripts you can use to run commands and export environment variables. These
 hooks have access to all the standard [Buildkite environment variables](/docs/pipelines/environment-variables).
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -1,12 +1,13 @@
 # Buildkite Agent Hooks
 
-Agent hooks can be used to extend or override built-in behaviours of the
-Buildkite Agent. Hooks can be configured on your agent hosts, in your
-repository, or from Pipeline Plug-ins. For example, you could create a global
-`checkout` hook which speeds up a fresh `git clone` on a new build machine, a
-repository `pre-command` hook which sets up repository-specific environment
-variables, or a plug-in `environment` hook which exports secret API keys as
-environment variables.
+Agent hooks can be used to extend or override the built-in behaviours of the
+Buildkite Agent.
+
+Hooks can be configured on your agent hosts, in your repository, or from
+Pipeline Plugins. For example, you could create a global `checkout` hook which
+speeds up a fresh `git clone` on a new build machine, a repository `pre-command`
+hook which sets up repository-specific environment variables, or a plug-in
+`environment` hook which exports secret API keys as environment variables.
 
 {:toc}
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -65,6 +65,16 @@ covers hooks for both the Agent and Bootstrap processes.
   </tbody>
 </table>
 
+### Creating lifecycle hooks
+
+Lifecycle hooks can be written in the programming language of your choice and
+are executed by the Buildkite Agent. See the documentation for each lifecycle
+hook for details on the interface between the Buildkite Agent and the
+Lifecycle hook.
+
+Lifecycle hooks can only be defined in the [global hooks](#agent-hook-locations-global-hooks)
+directory.
+
 ## Job hooks
 
 The following is a complete list of available job hooks, and the order in which
@@ -122,17 +132,7 @@ they are run as part of each job:
   </tbody>
 </table>
 
-## Creating Lifecycle hooks
-
-Lifecycle hooks can be written in the programming language of your choice and
-are executed by the Buildkite Agent. See the documentation for each lifecycle
-hook for details on the interface between the Buildkite Agent and the
-Lifecycle hook.
-
-Lifecycle hooks can only be defined in the [global hooks](#agent-hook-locations-global-hooks)
-directory.
-
-## Creating Job hooks
+### Creating job hooks
 
 Job hooks are shell scripts you can use to run commands and export environment
 variables. Job hooks have access to all the standard

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -19,27 +19,28 @@ There are two categories of hook:
 * Lifecycle hooks
 * Job hooks
 
-Lifecycle hooks are **executed** as part of the agent lifecycle. For example,
-the `pre-bootstrap` hook is executed before starting the per-job bootstrap
-process, and the `agent-shutdown` hook is executed before the agent process
-terminates.
+Lifecycle hooks are **executed** by the Buildkite Agent as part of the agent
+lifecycle. For example, the `pre-bootstrap` hook is executed before starting a
+per-job bootstrap process, and the `agent-shutdown` hook is executed before the
+agent process terminates.
 
-Job hooks are **sourced** as part a job’s phases. Job hooks are run in a per-job
-shell environment, and any exported environment variables are carried to the
-job’s subsequent phases and hooks. For example, the `environment` hook can
-modify or export new environment variables for the job’s subsequent phases and
-hooks.
+Job hooks are **sourced** by the Buildkite Bootstrap in the different job
+phases. They are run in a per-job shell environment, and any exported
+environment variables are carried to the job’s subsequent phases and hooks. For
+example, the `environment` hook can modify or export new environment variables
+for the job’s subsequent phases and hooks.
 
 ## Agent Hook Locations
 
-There are three locations that agent hooks are found:
+Agent hooks can be defined in three locations:
 
 * Global hooks - these exist on the agent file system in a directory created by
 your agent installer. The global hooks directory can define both Lifecycle and
 Job hooks. Global job hooks are run for every job the agent receives, from any
 pipeline.
 * Repository hooks - these exist in your pipeline repository’s
-`.buildkite/hooks` directory and can define job hooks.
+`.buildkite/hooks` directory and can define job hooks. Repository hooks are run
+for every pipeline that uses the repository.
 * Plugin hooks - these are provided by any [plugins](/docs/plugins) you’ve
 defined in your `pipeline.yml` and can define job hooks.
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -101,43 +101,43 @@ they are run as part of each job:
   <tbody>
     <tr>
       <td style="white-space: nowrap"><code>environment</code></td>
-      <td style="white-space: nowrap">Agent, Plugin</td>
+      <td style="white-space: nowrap">Global, Plugin</td>
       <td>Runs before all other hooks. Useful for <a href="/docs/pipelines/secrets#storing-secrets-in-environment-hooks">exposing secret keys</a>.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>pre-checkout</code></td>
-      <td style="white-space: nowrap">Agent, Plugin</td>
+      <td style="white-space: nowrap">Global, Plugin</td>
       <td>Runs before checkout.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>checkout</code></td>
-      <td style="white-space: nowrap">Plugin, Agent</td>
+      <td style="white-space: nowrap">Plugin, Global</td>
       <td>Overrides the default <code>git checkout</code> behavior.<br><em>Note:</em> As of Agent v3.15.0, if multiple checkout hooks are found, only the first will be run.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>post-checkout</code></td>
-      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td style="white-space: nowrap">Global, Repository, Plugin</td>
       <td>Runs after checkout.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>pre-command</code></td>
-      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td style="white-space: nowrap">Global, Repository, Plugin</td>
       <td>Runs before the build command.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>command</code></td>
-      <td style="white-space: nowrap">Plugin, Repository, Agent</td>
+      <td style="white-space: nowrap">Plugin, Repository, Global</td>
       <td>Overrides the default command running behavior. If multiple command hooks are found, only the first will be run.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>post-command</code></td>
-      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td style="white-space: nowrap">Global, Repository, Plugin</td>
       <td>Runs after the command.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>pre-artifact</code></td>
-      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td style="white-space: nowrap">Global, Repository, Plugin</td>
       <td>Runs before artifacts are uploaded, if an artifact upload pattern was defined for the job.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>post-artifact</code></td>
-      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td style="white-space: nowrap">Global, Repository, Plugin</td>
       <td>Runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>pre-exit</code></td>
-      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
+      <td style="white-space: nowrap">Global, Repository, Plugin</td>
       <td>Runs before the job finishes. Useful for performing cleanup tasks.</td></tr>
   </tbody>
 </table>

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -10,10 +10,6 @@ which speeds up a fresh `git clone` on a new build machine, a repository
 plugin `environment` hook which exports secret API keys as environment
 variables.
 
-{:toc}
-
-## Categories of hooks
-
 There are two categories of hook:
 
 * Lifecycle hooks
@@ -29,6 +25,8 @@ phases. They are run in a per-job shell environment, and any exported
 environment variables are carried to the job’s subsequent phases and hooks. For
 example, the `environment` hook can modify or export new environment variables
 for the job’s subsequent phases and hooks.
+
+{:toc}
 
 ## Lifecycle hooks
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -178,13 +178,14 @@ Agent hooks can be defined in three locations:
 
 * Global hooks - these exist on the agent file system in a directory created by
 your agent installer. The global hooks directory can define both Lifecycle and
-Job hooks. Global job hooks are run for every job the agent receives, from any
-pipeline.
+Job hooks. The agent will run the global job hooks for every job it receives,
+from any pipeline.
 * Repository hooks - these exist in your pipeline repository’s
-`.buildkite/hooks` directory and can define job hooks. Repository hooks are run
-for every pipeline that uses the repository.
+`.buildkite/hooks` directory and can define job hooks. The agent will run the
+repository hooks for every pipeline that uses the repository that defines them.
 * Plugin hooks - these are provided by any [plugins](/docs/plugins) you’ve
-defined in your `pipeline.yml` and can define job hooks.
+defined in your `pipeline.yml` and can define job hooks. The agent will run any
+plugin hooks defined by the step’s [plugins](plugins) for every job it receives.
 
 ### Global hooks
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -1,13 +1,14 @@
 # Buildkite Agent Hooks
 
 Agent hooks can be used to extend or override the built-in behaviours of the
-Buildkite Agent.
+Buildkite Agent and Bootstrap binaries.
 
-Hooks can be configured on your agent hosts, in your repository, or from
-Pipeline Plugins. For example, you could create a global `checkout` hook which
-speeds up a fresh `git clone` on a new build machine, a repository `pre-command`
-hook which sets up repository-specific environment variables, or a plug-in
-`environment` hook which exports secret API keys as environment variables.
+Hooks can be configured globally on your agent hosts, in your repository, or
+from [Plugins](/docs/plugins). For example, you could create a global `checkout` hook
+which speeds up a fresh `git clone` on a new build machine, a repository
+`pre-command` hook which sets up repository-specific environment variables, or a
+plugin `environment` hook which exports secret API keys as environment
+variables.
 
 {:toc}
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -4,7 +4,7 @@ Agent hooks can be used to extend or override built-in behaviours of the
 Buildkite Agent. Hooks can be configured on your agent hosts, in your
 repository, or from Pipeline Plug-ins. For example, you could create a global
 `checkout` hook which speeds up a fresh `git clone` on a new build machine, a
-repository `pre-command` hook which sets up repository-specific environment\
+repository `pre-command` hook which sets up repository-specific environment
 variables, or a plug-in `environment` hook which exports secret API keys as
 environment variables.
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -1,38 +1,39 @@
 # Buildkite Agent Hooks
 
-Agent hooks extend or override the built-in behaviours of the
-Buildkite Agent and Bootstrap binaries.
+Hooks extend or override the built-in behaviours of the Buildkite Agent and
+Bootstrap binaries.
 
 Hooks can be defined in three locations: agent-wide, your pipeline’s repository,
-or specific [plugins](/docs/plugins). For example, you could create an agent
-level `checkout` hook which speeds up a fresh `git clone` on a new build
+or in [plugins](/docs/plugins) applied to steps. For example, you could define
+an agent wide `checkout` hook which speeds up a fresh `git clone` on a new build
 machine, a repository `pre-command` hook which sets up repository-specific
 environment variables, or a plugin `environment` hook which fetches API keys
-from a secret management service.
+from a secrets storage service.
 
 There are two categories of hook:
 
-* Lifecycle hooks
-* Job hooks
+* Agent Lifecycle
+* Job Lifecycle
 
-Lifecycle hooks are **executed** by the Buildkite Agent as part of the agent
-lifecycle. For example, the `pre-bootstrap` hook is executed before starting a
-job’s bootstrap process, and the `agent-shutdown` hook is executed before the
-agent process terminates.
+Agent lifecycle hooks are **executed** by the Buildkite Agent as part of the
+agent’s lifecycle. For example, the `pre-bootstrap` hook is executed before
+starting a job’s bootstrap process, and the `agent-shutdown` hook is executed
+before the agent process terminates.
 
-Job hooks are **sourced** by the Buildkite Bootstrap in the different job
-phases. They are run in a per-job shell environment, and any exported
+Job lifecycle hooks are **sourced** by the Buildkite Bootstrap in the different
+job phases. They are run in a per-job shell environment, and any exported
 environment variables are carried to the job’s subsequent phases and hooks. For
 example, the `environment` hook can modify or export new environment variables
-for the job’s subsequent phases and hooks.
+for the job’s subsequent checkout and command phases.
 
-In July 2021 we changed how we refer to Agent Hooks to differentiate between the
-agent configuration for the location that hooks are defined in, and the hooks
-feature which covers hooks for both the Agent and Bootstrap processes.
+In August 2021 we changed how we refer to Agent Hooks to differentiate between
+the hooks feature for both the Agent and Bootstrap processes, and the agent
+[`hooks-path` configuration](configuration#hooks-path) for the
+directory that agent level hooks are defined.
 
 {:toc}
 
-## Lifecycle hooks
+## Agent lifecycle hooks
 
 <table>
   <thead>
@@ -65,17 +66,16 @@ feature which covers hooks for both the Agent and Bootstrap processes.
   </tbody>
 </table>
 
-### Creating lifecycle hooks
+### Creating agent lifecycle hooks
 
-Lifecycle hooks can be written in the programming language of your choice and
-are executed by the Buildkite Agent. See the documentation for each lifecycle
-hook for details on the interface between the Buildkite Agent and the
-Lifecycle hook.
+Agent lifecycle hooks can be written in the programming language of your choice
+and are executed by the Buildkite Agent. See the documentation for each agent
+lifecycle hook for details on the interface between them and the Buildkite
+Agent.
 
-Lifecycle hooks can only be defined in the [agent hooks](#hook-locations-agent-hooks)
-directory.
+These hooks can only be defined in the [agent `hooks-path`](#hook-locations-agent-hooks) directory.
 
-## Job hooks
+## Job lifecycle hooks
 
 The following is a complete list of available job hooks, and the order in which
 they are run as part of each job:
@@ -132,25 +132,25 @@ they are run as part of each job:
   </tbody>
 </table>
 
-### Creating job hooks
+### Creating job lifecycle hooks
 
-Job hooks are shell scripts you can use to run commands and export environment
-variables. Job hooks have access to all the standard
-[Buildkite environment variables](/docs/pipelines/environment-variables).
+Job lifecyle hooks run for every job an agent accepts. They are shell
+scripts you can use to run commands and export environment variables. These
+hooks have access to all the standard [Buildkite environment variables](/docs/pipelines/environment-variables).
 
-Job hooks are copied to `$TMPDIR` directory and *sourced* by the default shell
-on the Agent that is running the build. This has a few implications:
+Job lifecycle hooks are copied to `$TMPDIR` directory and *sourced* by the
+agent’s default shell. This has a few implications:
 
 * `$BASH_SOURCE` contains the location the hook is sourced from
 * `$0` contains the location of the copy of the script that is running from `$TMPDIR`
 * the shebang line of the hook script has no effect
 
-To write job hooks in another programming language, you need to execute them
-from within the shell script, and explicitly pass any Buildkite environment
-variables you need to the script when you call it.
+To write job lifecycle hooks in another programming language, you need to
+execute them from within the shell script, and explicitly pass any Buildkite
+environment variables you need to the script when you call it.
 
-The following is an example of a custom `environment` hook which exports a
-GitHub API key for the pipeline’s release build step:
+The following is an example of an `environment` hook which exports a GitHub API
+key for the pipeline’s release build step:
 
 ```bash
 set -eu
@@ -161,12 +161,12 @@ export GITHUB_RELEASE_ACCESS_KEY='xxx'
 
 ## Job hooks on Windows
 
-Agents running on Windows require hook files to have either:
+Buildkite Agents running on Windows require job lifecycle hooks to have either:
 
 * A `.bat` extension, and be written in [Windows Batch](https://en.wikipedia.org/wiki/Batch_file), or
 * Access to <a href="/docs/agent/v3/windows#git-for-windows">Git for Windows</a>, which includes bash
 
-An example of a windows `environment.bat` hook:
+An example of a Windows `environment.bat` hook:
 
 ```batch
 @ECHO OFF
@@ -179,16 +179,17 @@ SET GITHUB_RELEASE_ACCESS_KEY='xxx'
 Hooks can be defined in three locations:
 
 * Agent hooks - these exist on the agent file system in a directory created by
-your agent installer and configured by the [`hooks-path`](/docs/agent/v3/configuration#hooks-path)
-setting. You can define both Lifecycle and Job hooks in the agent hooks
-location. Job hooks defined here will be run for every job the agent receives,
-from any pipeline.
+your agent installer and configured by the [`hooks-path`](configuration#hooks-path)
+setting. You can define both agent lifecycle and job lifecycle hooks in the
+agent hooks location. Job lifecycle hooks defined here will be run for every job
+the agent receives, from any pipeline.
 * Repository hooks - these exist in your pipeline repository’s
-`.buildkite/hooks` directory and can define job hooks. Job hooks defined here
-will be run for every pipeline that uses the repository.
+`.buildkite/hooks` directory and can define job lifecycle hooks. Job lifecycle
+hooks defined here will be run for every pipeline that uses the repository.
 * Plugin hooks - these are provided by any [plugins](/docs/plugins) you’ve
-included in your pipeline steps and can define job hooks. Job hooks defined by
-a plugin will only be run for the step that includes them.
+included in your pipeline steps and can define job lifecycle hooks. Job
+lifecycle hooks defined by a plugin will only be run for the step that includes
+them.
 
 ### Agent hooks
 
@@ -199,8 +200,9 @@ platform’s installation documentation.
 To get started with agent hooks copy the relevant example script and remove the
 `.sample` file extension.
 
-See [lifecycle hooks](#lifecycle-hooks) and [job hooks](#job-hooks) for the hook
-types that can be defined in the agent hooks directory.
+See [agent lifecycle hooks](#agent-lifecycle-hooks) and
+[job lifecycle hooks](#job-lifecycle-hooks) for the hook types that can be
+defined in the agent hooks directory.
 
 ### Repository hooks
 
@@ -212,8 +214,8 @@ To get started, create a shell script in `.buildkite/hooks` named
 `post-checkout`. It will be sourced and run after your repository has been
 checked out as part of every job for any pipeline that uses this repository.
 
-You can define any of the [job hooks](#job-hooks) whose `Order` includes
-*Repository*.
+You can define any of the [job lifecycle hooks](#job-lifecycle-hooks) whose
+`Order` includes *Repository*.
 
 ### Plugin hooks
 
@@ -221,4 +223,5 @@ Plugin hooks allow plugins you’ve defined in your Pipeline Steps to override
 default behavior.
 
 See the [plugin documentation](/docs/plugins) for how to implement plugin hooks
-and [job hooks](#job-hooks) for the list of hook types that a plugin can define.
+and [job lifecycle hooks](#job-lifecycle-hooks) for the list of hook types that
+a plugin can define.

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -48,7 +48,7 @@ directory that agent level hooks are defined.
       <td style="white-space: nowrap"><code>pre-bootstrap</code></td>
       <td style="white-space: nowrap">Agent</td>
       <td>
-        <p>Executed before any job is started. Useful for <a href="/docs/agent/v3/securing#strict-checks-using-agent-hooks">adding strict checks</a> before jobs are permitted to run.</p>
+        <p>Executed before any job is started. Useful for <a href="/docs/agent/v3/securing#strict-checks-using-a-pre-bootstrap-hook">adding strict checks</a> before jobs are permitted to run.</p>
         <p>The proposed job command and environment is written to a file and
         the path to this file provided in the <code>BUILDKITE_ENV_FILE</code>
         environment variable. Use the contents of this file to determine whether

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -30,55 +30,6 @@ environment variables are carried to the job’s subsequent phases and hooks. Fo
 example, the `environment` hook can modify or export new environment variables
 for the job’s subsequent phases and hooks.
 
-## Agent Hook Locations
-
-Agent hooks can be defined in three locations:
-
-* Global hooks - these exist on the agent file system in a directory created by
-your agent installer. The global hooks directory can define both Lifecycle and
-Job hooks. Global job hooks are run for every job the agent receives, from any
-pipeline.
-* Repository hooks - these exist in your pipeline repository’s
-`.buildkite/hooks` directory and can define job hooks. Repository hooks are run
-for every pipeline that uses the repository.
-* Plugin hooks - these are provided by any [plugins](/docs/plugins) you’ve
-defined in your `pipeline.yml` and can define job hooks.
-
-### Global hooks
-
-Every agent installer creates a global hooks directory containing a set of
-sample hooks. You can find the location of your agent hooks directory in your
-platform’s installation documentation.
-
-To get started with global hooks copy the relevant example script and remove the
-`.sample` file extension.
-
-See the lists of [lifecycle hooks](#available-lifecycle-hooks) and
-[job hooks](#available-job-hooks) for the hook types that can be included in the
-global hooks directory.
-
-### Repository hooks
-
-Repository hooks allow you to execute repository-specific scripts. Repository
-hooks live alongside your repository’s source code under the `.buildkite/hooks`
-directory.
-
-To get started, create a shell script in `.buildkite/hooks` named
-`post-checkout`. It will be sourced and run after your repository has been
-checked out as part of every job for any pipeline that uses this repository.
-
-You can include any of the [available job hooks](#available-job-hooks) whose
-`Order` includes *Repository*.
-
-### Plugin hooks
-
-Plugin hooks allow plugins you’ve defined in your Pipeline Steps to override
-default behavior.
-
-See the [plugin documentation](/docs/plugins) for how to implement plugin hooks
-and [available job hooks](#available-job-hooks) for the list of hook types that
-a plugin can include.
-
 ## Available Lifecycle hooks
 
 <table>
@@ -216,3 +167,52 @@ An example of a windows `environment.bat` hook:
 ECHO "--- \:house_with_garden\: Setting up the environment"
 SET GITHUB_RELEASE_ACCESS_KEY='xxx'
 ```
+
+## Agent Hook Locations
+
+Agent hooks can be defined in three locations:
+
+* Global hooks - these exist on the agent file system in a directory created by
+your agent installer. The global hooks directory can define both Lifecycle and
+Job hooks. Global job hooks are run for every job the agent receives, from any
+pipeline.
+* Repository hooks - these exist in your pipeline repository’s
+`.buildkite/hooks` directory and can define job hooks. Repository hooks are run
+for every pipeline that uses the repository.
+* Plugin hooks - these are provided by any [plugins](/docs/plugins) you’ve
+defined in your `pipeline.yml` and can define job hooks.
+
+### Global hooks
+
+Every agent installer creates a global hooks directory containing a set of
+sample hooks. You can find the location of your agent hooks directory in your
+platform’s installation documentation.
+
+To get started with global hooks copy the relevant example script and remove the
+`.sample` file extension.
+
+See the lists of [lifecycle hooks](#available-lifecycle-hooks) and
+[job hooks](#available-job-hooks) for the hook types that can be included in the
+global hooks directory.
+
+### Repository hooks
+
+Repository hooks allow you to execute repository-specific scripts. Repository
+hooks live alongside your repository’s source code under the `.buildkite/hooks`
+directory.
+
+To get started, create a shell script in `.buildkite/hooks` named
+`post-checkout`. It will be sourced and run after your repository has been
+checked out as part of every job for any pipeline that uses this repository.
+
+You can include any of the [available job hooks](#available-job-hooks) whose
+`Order` includes *Repository*.
+
+### Plugin hooks
+
+Plugin hooks allow plugins you’ve defined in your Pipeline Steps to override
+default behavior.
+
+See the [plugin documentation](/docs/plugins) for how to implement plugin hooks
+and [available job hooks](#available-job-hooks) for the list of hook types that
+a plugin can include.

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -1,11 +1,12 @@
 # Buildkite Agent Hooks
 
-Hooks can be used to extend or override built-in behaviours of the Buildkite
-Agent. Hooks can be configured on your agent hosts, in your repository, or from
-Pipeline Plug-ins. For example, you could create an agent `checkout` hook which
-speeds up a fresh `git clone` on a new build machine, a repository `pre-command`
-hook which sets up repository-specific environment variables, or a plug-in
-`environment` hook which exports secret API keys as environment variables.
+Agent hooks can be used to extend or override built-in behaviours of the
+Buildkite Agent. Hooks can be configured on your agent hosts, in your
+repository, or from Pipeline Plug-ins. For example, you could create an agent
+`checkout` hook which speeds up a fresh `git clone` on a new build machine, a
+repository `pre-command` hook which sets up repository-specific environment\
+variables, or a plug-in `environment` hook which exports secret API keys as
+environment variables.
 
 {:toc}
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -36,12 +36,14 @@ for the job’s subsequent phases and hooks.
   <thead>
     <tr>
         <th>Hook</th>
+        <th>Order</th>
         <th>Description</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td style="white-space: nowrap"><code>pre-bootstrap</code></td>
+      <td style="white-space: nowrap">Global</td>
       <td>
         <p>Executed before any job is started. Useful for <a href="/docs/agent/v3/securing#strict-checks-using-agent-hooks">adding strict checks</a> before jobs are permitted to run.</p>
         <p>The proposed job command and environment is written to a file and
@@ -55,6 +57,7 @@ for the job’s subsequent phases and hooks.
         </td></tr>
     <tr>
       <td style="white-space: nowrap"><code>agent-shutdown</code></td>
+      <td style="white-space: nowrap">Global</td>
       <td>Executed when the agent shuts down. Useful for performing cleanup
       tasks for the entire agent, outside of the job lifecycle.</td></tr>
   </tbody>

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -26,6 +26,10 @@ environment variables are carried to the job’s subsequent phases and hooks. Fo
 example, the `environment` hook can modify or export new environment variables
 for the job’s subsequent phases and hooks.
 
+In July 2021 we changed how we refer to Agent Hooks to differentiate between the
+global file system location that hooks are defined in, and the feature which
+covers hooks for both the Agent and Bootstrap processes.
+
 {:toc}
 
 ## Lifecycle hooks

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -20,7 +20,7 @@ There are two types of hook:
 
 Lifecycle hooks are **executed** as part of the agent lifecycle. For example,
 the `pre-bootstrap` hook is executed before starting the per-job bootstrap
-process, and the `agent-shutdown` is executed before the agent process
+process, and the `agent-shutdown` hook is executed before the agent process
 terminates.
 
 Step hooks are **sourced** as part of each Buildkite Job. Step hooks are run in

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -3,12 +3,12 @@
 Agent hooks extend or override the built-in behaviours of the
 Buildkite Agent and Bootstrap binaries.
 
-Hooks can be defined globally on your agent hosts, in your repository, or from
-[Plugins](/docs/plugins). For example, you could create a global `checkout` hook
-which speeds up a fresh `git clone` on a new build machine, a repository
-`pre-command` hook which sets up repository-specific environment variables, or a
-plugin `environment` hook which exports secret API keys as environment
-variables.
+Hooks can be defined in three locations: agent-wide, your pipeline’s repository,
+or specific [plugins](/docs/plugins). For example, you could create an agent
+level `checkout` hook which speeds up a fresh `git clone` on a new build
+machine, a repository `pre-command` hook which sets up repository-specific
+environment variables, or a plugin `environment` hook which fetches API keys
+from a secret management service.
 
 There are two categories of hook:
 
@@ -17,7 +17,7 @@ There are two categories of hook:
 
 Lifecycle hooks are **executed** by the Buildkite Agent as part of the agent
 lifecycle. For example, the `pre-bootstrap` hook is executed before starting a
-per-job bootstrap process, and the `agent-shutdown` hook is executed before the
+job’s bootstrap process, and the `agent-shutdown` hook is executed before the
 agent process terminates.
 
 Job hooks are **sourced** by the Buildkite Bootstrap in the different job
@@ -27,8 +27,8 @@ example, the `environment` hook can modify or export new environment variables
 for the job’s subsequent phases and hooks.
 
 In July 2021 we changed how we refer to Agent Hooks to differentiate between the
-global file system location that hooks are defined in, and the feature which
-covers hooks for both the Agent and Bootstrap processes.
+agent configuration for the location that hooks are defined in, and the hooks
+feature which covers hooks for both the Agent and Bootstrap processes.
 
 {:toc}
 
@@ -45,7 +45,7 @@ covers hooks for both the Agent and Bootstrap processes.
   <tbody>
     <tr>
       <td style="white-space: nowrap"><code>pre-bootstrap</code></td>
-      <td style="white-space: nowrap">Global</td>
+      <td style="white-space: nowrap">Agent</td>
       <td>
         <p>Executed before any job is started. Useful for <a href="/docs/agent/v3/securing#strict-checks-using-agent-hooks">adding strict checks</a> before jobs are permitted to run.</p>
         <p>The proposed job command and environment is written to a file and
@@ -59,7 +59,7 @@ covers hooks for both the Agent and Bootstrap processes.
         </td></tr>
     <tr>
       <td style="white-space: nowrap"><code>agent-shutdown</code></td>
-      <td style="white-space: nowrap">Global</td>
+      <td style="white-space: nowrap">Agent</td>
       <td>Executed when the agent shuts down. Useful for performing cleanup
       tasks for the entire agent, outside of the job lifecycle.</td></tr>
   </tbody>
@@ -72,7 +72,7 @@ are executed by the Buildkite Agent. See the documentation for each lifecycle
 hook for details on the interface between the Buildkite Agent and the
 Lifecycle hook.
 
-Lifecycle hooks can only be defined in the [global hooks](#agent-hook-locations-global-hooks)
+Lifecycle hooks can only be defined in the [agent hooks](#hook-locations-agent-hooks)
 directory.
 
 ## Job hooks
@@ -91,43 +91,43 @@ they are run as part of each job:
   <tbody>
     <tr>
       <td style="white-space: nowrap"><code>environment</code></td>
-      <td style="white-space: nowrap">Global, Plugin</td>
+      <td style="white-space: nowrap">Agent, Plugin</td>
       <td>Runs before all other hooks. Useful for <a href="/docs/pipelines/secrets#storing-secrets-in-environment-hooks">exposing secret keys</a>.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>pre-checkout</code></td>
-      <td style="white-space: nowrap">Global, Plugin</td>
+      <td style="white-space: nowrap">Agent, Plugin</td>
       <td>Runs before checkout.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>checkout</code></td>
-      <td style="white-space: nowrap">Plugin, Global</td>
+      <td style="white-space: nowrap">Plugin, Agent</td>
       <td>Overrides the default <code>git checkout</code> behavior.<br><em>Note:</em> As of Agent v3.15.0, if multiple checkout hooks are found, only the first will be run.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>post-checkout</code></td>
-      <td style="white-space: nowrap">Global, Repository, Plugin</td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
       <td>Runs after checkout.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>pre-command</code></td>
-      <td style="white-space: nowrap">Global, Repository, Plugin</td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
       <td>Runs before the build command.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>command</code></td>
-      <td style="white-space: nowrap">Plugin, Repository, Global</td>
+      <td style="white-space: nowrap">Plugin, Repository, Agent</td>
       <td>Overrides the default command running behavior. If multiple command hooks are found, only the first will be run.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>post-command</code></td>
-      <td style="white-space: nowrap">Global, Repository, Plugin</td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
       <td>Runs after the command.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>pre-artifact</code></td>
-      <td style="white-space: nowrap">Global, Repository, Plugin</td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
       <td>Runs before artifacts are uploaded, if an artifact upload pattern was defined for the job.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>post-artifact</code></td>
-      <td style="white-space: nowrap">Global, Repository, Plugin</td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
       <td>Runs after artifacts have been uploaded, if an artifact upload pattern was defined for the job.</td></tr>
     <tr>
       <td style="white-space: nowrap"><code>pre-exit</code></td>
-      <td style="white-space: nowrap">Global, Repository, Plugin</td>
+      <td style="white-space: nowrap">Agent, Repository, Plugin</td>
       <td>Runs before the job finishes. Useful for performing cleanup tasks.</td></tr>
   </tbody>
 </table>
@@ -174,32 +174,33 @@ ECHO "--- \:house_with_garden\: Setting up the environment"
 SET GITHUB_RELEASE_ACCESS_KEY='xxx'
 ```
 
-## Agent Hook Locations
+## Hook Locations
 
-Agent hooks can be defined in three locations:
+Hooks can be defined in three locations:
 
-* Global hooks - these exist on the agent file system in a directory created by
-your agent installer. The global hooks directory can define both Lifecycle and
-Job hooks. The agent will run the global job hooks for every job it receives,
+* Agent hooks - these exist on the agent file system in a directory created by
+your agent installer and configured by the [`hooks-path`](/docs/agent/v3/configuration#hooks-path)
+setting. You can define both Lifecycle and Job hooks in the agent hooks
+location. Job hooks defined here will be run for every job the agent receives,
 from any pipeline.
 * Repository hooks - these exist in your pipeline repository’s
-`.buildkite/hooks` directory and can define job hooks. The agent will run the
-repository hooks for every pipeline that uses the repository that defines them.
+`.buildkite/hooks` directory and can define job hooks. Job hooks defined here
+will be run for every pipeline that uses the repository.
 * Plugin hooks - these are provided by any [plugins](/docs/plugins) you’ve
-defined in your `pipeline.yml` and can define job hooks. The agent will run any
-plugin hooks defined by the step’s [plugins](plugins) for every job it receives.
+included in your pipeline steps and can define job hooks. Job hooks defined by
+a plugin will only be run for the step that includes them.
 
-### Global hooks
+### Agent hooks
 
-Every agent installer creates a global hooks directory containing a set of
+Every agent installer creates a hooks directory containing a set of
 sample hooks. You can find the location of your agent hooks directory in your
 platform’s installation documentation.
 
-To get started with global hooks copy the relevant example script and remove the
+To get started with agent hooks copy the relevant example script and remove the
 `.sample` file extension.
 
 See [lifecycle hooks](#lifecycle-hooks) and [job hooks](#job-hooks) for the hook
-types that can be defined in the global hooks directory.
+types that can be defined in the agent hooks directory.
 
 ### Repository hooks
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -3,8 +3,8 @@
 Agent hooks can be used to extend or override the built-in behaviours of the
 Buildkite Agent and Bootstrap binaries.
 
-Hooks can be configured globally on your agent hosts, in your repository, or
-from [Plugins](/docs/plugins). For example, you could create a global `checkout` hook
+Hooks can be defined globally on your agent hosts, in your repository, or from
+[Plugins](/docs/plugins). For example, you could create a global `checkout` hook
 which speeds up a fresh `git clone` on a new build machine, a repository
 `pre-command` hook which sets up repository-specific environment variables, or a
 plugin `environment` hook which exports secret API keys as environment

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -1,11 +1,11 @@
 # Buildkite Agent Hooks
 
-Every agent installer comes with a hooks directory which can be used to override
-and extend the built-in agent behavior. For example, you could create an agent
-`checkout` hook which speeds up a fresh `git clone` on a new build machine, an
-agent `environment` hook which exports secret API keys as environment
-variables, or a repository `pre-command` hook which sets up repository-specific
-environment variables.
+Hooks can be used to extend or override built-in behaviours of the Buildkite
+Agent. Hooks can be configured on your agent hosts, in your repository, or from
+Pipeline Plug-ins. For example, you could create an agent `checkout` hook which
+speeds up a fresh `git clone` on a new build machine, a repository `pre-command`
+hook which sets up repository-specific environment variables, or a plug-in
+`environment` hook which exports secret API keys as environment variables.
 
 {:toc}
 
@@ -13,29 +13,32 @@ environment variables.
 
 There are two types of hook:
 
-* Agent hooks
+* Lifecycle hooks
 * Step hooks
 
-Agent hooks are executed as part of the agent lifecycle. For example, the
-`pre-bootstrap` hook is executed before starting the per-job bootstrap process.
+Lifecycle hooks are **executed** as part of the agent lifecycle. For example,
+the `pre-bootstrap` hook is executed before starting the per-job bootstrap
+process, and the `agent-shutdown` is executed before the agent process
+terminates.
 
-Step hooks are sourced as part of each Buildkite Job. Step hooks are run in a
-per-job shell environment, and environment variables are carried between the
-phases and hooks for a given step. For example, the `environment` hook can
-modify or export new environment variables for the subsequent job phases and
-hooks.
+Step hooks are **sourced** as part of each Buildkite Job. Step hooks are run in
+a per-job shell environment, and any exported environment variables are carried
+to subsequent phases and hooks for a given job. For example, the `environment`
+hook can modify or export new environment variables for the subsequent job
+phases and hooks.
 
-## Hook locations
+## Agent Hook Locations
 
-There are three hook locations:
+There are three locations that agent hooks are found:
 
-* Agent hooks - these exist on the agent’s machine and can define both agent and step hooks. Step hooks are run for every job on any pipeline.
-* Repository hooks - these exist in your pipeline repository’s `.buildkite/hooks` directory and can define step hooks.
-* Plugin hooks - these are provided by any [plugins](/docs/plugins) you've defined in your `pipeline.yml` and can define step hooks.
+* Global hooks - these exist on the agent file system in a directory created by your agent installer and can define both
+Lifecycle and Step hooks. The Step hooks are run for every job on any pipeline.
+* Repository hooks - these exist in your pipeline repository’s `.buildkite/hooks` directory and can define Step hooks.
+* Plugin hooks - these are provided by any [plugins](/docs/plugins) you've defined in your `pipeline.yml` and can define Step hooks.
 
-### Agent hooks
+### Global hooks
 
-Each agent installer comes with a hooks directory containing a set of sample
+Each agent installer creates a global hooks directory containing a set of sample
 hooks. You can find the location of your agent hooks directory in your
 platform’s installation documentation.
 
@@ -60,7 +63,7 @@ behavior.
 
 See the [plugin documentation](/docs/plugins) for how to implement plugin hooks.
 
-## Available Agent Hooks
+## Available Lifecycle hooks
 
 <table>
   <thead>
@@ -80,7 +83,7 @@ See the [plugin documentation](/docs/plugins) for how to implement plugin hooks.
   </tbody>
 </table>
 
-## Available Step Hooks
+## Available Step hooks
 
 The following is a complete list of available step hooks, and the order in which
 they are run as part of each job:
@@ -137,11 +140,11 @@ they are run as part of each job:
   </tbody>
 </table>
 
-## Creating agent hooks
+## Creating Lifecycle hooks
 
 Agent hooks are executed and can be written in any programming language.
 
-## Creating step hooks
+## Creating Step hooks
 
 Step hooks are shell scripts you can use to run commands and export environment
 variables. Hooks have access to all the standard [Buildkite environment variables](/docs/pipelines/environment-variables).

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -2,7 +2,7 @@
 
 Agent hooks can be used to extend or override built-in behaviours of the
 Buildkite Agent. Hooks can be configured on your agent hosts, in your
-repository, or from Pipeline Plug-ins. For example, you could create an agent
+repository, or from Pipeline Plug-ins. For example, you could create a global
 `checkout` hook which speeds up a fresh `git clone` on a new build machine, a
 repository `pre-command` hook which sets up repository-specific environment\
 variables, or a plug-in `environment` hook which exports secret API keys as

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -123,7 +123,7 @@ Lifecycle hooks are executed and can be written in any programming language of
 your choice. See the specific lifecycle hook documentation for details on the
 interface between them and the Buildkite Agent.
 
-Lifecycle hooks are only executed from the [global hooks](#global-hooks)
+Lifecycle hooks can only be defined in the [global hooks](#agent-hook-locations)
 directory.
 
 ## Creating Job hooks

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -36,7 +36,7 @@ for the job’s subsequent phases and hooks.
   <thead>
     <tr>
         <th>Hook</th>
-        <th>Order</th>
+        <th>Location Order</th>
         <th>Description</th>
     </tr>
   </thead>
@@ -72,7 +72,7 @@ they are run as part of each job:
   <thead>
     <tr>
         <th>Hook</th>
-        <th>Order</th>
+        <th>Location Order</th>
         <th>Description</th>
     </tr>
   </thead>

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -33,15 +33,18 @@ phases and hooks.
 
 There are three locations that agent hooks are found:
 
-* Global hooks - these exist on the agent file system in a directory created by your agent installer and can define both
-Lifecycle and Step hooks. The Step hooks are run for every job on any pipeline.
-* Repository hooks - these exist in your pipeline repository’s `.buildkite/hooks` directory and can define Step hooks.
-* Plugin hooks - these are provided by any [plugins](/docs/plugins) you've defined in your `pipeline.yml` and can define Step hooks.
+* Global hooks - these exist on the agent file system in a directory created by
+your agent installer and can define both Lifecycle and Step hooks. These step
+hooks are run for every job the agent receives, from any pipeline.
+* Repository hooks - these exist in your pipeline repository’s
+`.buildkite/hooks` directory and can define step hooks.
+* Plugin hooks - these are provided by any [plugins](/docs/plugins) you’ve
+defined in your `pipeline.yml` and can define step hooks.
 
 ### Global hooks
 
-Each agent installer creates a global hooks directory containing a set of sample
-hooks. You can find the location of your agent hooks directory in your
+Every agent installer creates a global hooks directory containing a set of
+sample hooks. You can find the location of your agent hooks directory in your
 platform’s installation documentation.
 
 To get started with agent hooks copy the relevant example script and remove the

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -12,35 +12,36 @@ variables.
 
 {:toc}
 
-## Types of hooks
+## Categories of hooks
 
-There are two types of hook:
+There are two categories of hook:
 
 * Lifecycle hooks
-* Step hooks
+* Job hooks
 
 Lifecycle hooks are **executed** as part of the agent lifecycle. For example,
 the `pre-bootstrap` hook is executed before starting the per-job bootstrap
 process, and the `agent-shutdown` hook is executed before the agent process
 terminates.
 
-Step hooks are **sourced** as part of each Buildkite Job. Step hooks are run in
-a per-job shell environment, and any exported environment variables are carried
-to subsequent phases and hooks for a given job. For example, the `environment`
-hook can modify or export new environment variables for the subsequent job
-phases and hooks.
+Job hooks are **sourced** as part a job’s phases. Job hooks are run in a per-job
+shell environment, and any exported environment variables are carried to the
+job’s subsequent phases and hooks. For example, the `environment` hook can
+modify or export new environment variables for the job’s subsequent phases and
+hooks.
 
 ## Agent Hook Locations
 
 There are three locations that agent hooks are found:
 
 * Global hooks - these exist on the agent file system in a directory created by
-your agent installer and can define both Lifecycle and Step hooks. These step
-hooks are run for every job the agent receives, from any pipeline.
+your agent installer. The global hooks directory can define both Lifecycle and
+Job hooks. Global job hooks are run for every job the agent receives, from any
+pipeline.
 * Repository hooks - these exist in your pipeline repository’s
-`.buildkite/hooks` directory and can define step hooks.
+`.buildkite/hooks` directory and can define job hooks.
 * Plugin hooks - these are provided by any [plugins](/docs/plugins) you’ve
-defined in your `pipeline.yml` and can define step hooks.
+defined in your `pipeline.yml` and can define job hooks.
 
 ### Global hooks
 
@@ -48,26 +49,34 @@ Every agent installer creates a global hooks directory containing a set of
 sample hooks. You can find the location of your agent hooks directory in your
 platform’s installation documentation.
 
-To get started with agent hooks copy the relevant example script and remove the
+To get started with global hooks copy the relevant example script and remove the
 `.sample` file extension.
+
+See the lists of [lifecycle hooks](#available-lifecycle-hooks) and
+[job hooks](#available-job-hooks) for the hook types that can be included in the
+global hooks directory.
 
 ### Repository hooks
 
 Repository hooks allow you to execute repository-specific scripts. Repository
-hooks live alongside your repository’s source code under the directory
-`.buildkite/hooks`.
+hooks live alongside your repository’s source code under the `.buildkite/hooks`
+directory.
 
 To get started, create a shell script in `.buildkite/hooks` named
-`post-checkout`. It will be sourced and run every build, after the Agent checks
-your repository out. You can also use one of the other available *Repository*
-hooks, according to when you want your custom script to run.
+`post-checkout`. It will be sourced and run after your repository has been
+checked out as part of every job for any pipeline that uses this repository.
+
+You can include any of the [available job hooks](#available-job-hooks) whose
+`Order` includes *Repository*.
 
 ### Plugin hooks
 
-Plugin hooks allow plugins you’ve defined in your Pipeline to override default
-behavior.
+Plugin hooks allow plugins you’ve defined in your Pipeline Steps to override
+default behavior.
 
-See the [plugin documentation](/docs/plugins) for how to implement plugin hooks.
+See the [plugin documentation](/docs/plugins) for how to implement plugin hooks
+and [available job hooks](#available-job-hooks) for the list of hook types that
+a plugin can include.
 
 ## Available Lifecycle hooks
 
@@ -81,17 +90,27 @@ See the [plugin documentation](/docs/plugins) for how to implement plugin hooks.
   <tbody>
     <tr>
       <td style="white-space: nowrap"><code>pre-bootstrap</code></td>
-      <td>Runs before a step’s job is started. Useful for <a href="/docs/agent/v3/securing#strict-checks-using-agent-hooks">adding strict checks</a> before jobs are permitted to run.</td></tr>
+      <td>
+        <p>Executed before any job is started. Useful for <a href="/docs/agent/v3/securing#strict-checks-using-agent-hooks">adding strict checks</a> before jobs are permitted to run.</p>
+        <p>The proposed job command and environment is written to a file and
+        the path to this file provided in the <code>BUILDKITE_ENV_FILE</code>
+        environment variable. Use the contents of this file to determine whether
+        to permit the job to run on this agent.</p>
+        <p>If the <code>pre-bootstrap</code> hook terminates with an exit code
+        of <code>0</code>, the job is permitted to run. Any other exit code
+        results in the job being rejected, and job failure being reported to the
+        Buildkite API.</p>
+        </td></tr>
     <tr>
       <td style="white-space: nowrap"><code>agent-shutdown</code></td>
-      <td>Runs when each agent shuts down. Useful for performing cleanup tasks
-      for the entire agent, outside of the job lifecycle.</td></tr>
+      <td>Executed when the agent shuts down. Useful for performing cleanup
+      tasks for the entire agent, outside of the job lifecycle.</td></tr>
   </tbody>
 </table>
 
-## Available Step hooks
+## Available Job hooks
 
-The following is a complete list of available step hooks, and the order in which
+The following is a complete list of available job hooks, and the order in which
 they are run as part of each job:
 
 <table>
@@ -148,23 +167,29 @@ they are run as part of each job:
 
 ## Creating Lifecycle hooks
 
-Agent hooks are executed and can be written in any programming language.
+Lifecycle hooks are executed and can be written in any programming language of
+your choice. See the specific lifecycle hook documentation for details on the
+interface between them and the Buildkite Agent.
 
-## Creating Step hooks
+Lifecycle hooks are only executed from the [global hooks](#global-hooks)
+directory.
 
-Step hooks are shell scripts you can use to run commands and export environment
-variables. Hooks have access to all the standard [Buildkite environment variables](/docs/pipelines/environment-variables).
+## Creating Job hooks
 
-Step hooks are copied to `$TMPDIR` directory and *sourced* by the default shell
-on the Agent that is running the build, which has a few implications:
+Job hooks are shell scripts you can use to run commands and export environment
+variables. Job hooks have access to all the standard
+[Buildkite environment variables](/docs/pipelines/environment-variables).
+
+Job hooks are copied to `$TMPDIR` directory and *sourced* by the default shell
+on the Agent that is running the build. This has a few implications:
 
 * `$BASH_SOURCE` contains the location the hook is sourced from
 * `$0` contains the location of the copy of the script that is running from `$TMPDIR`
 * the shebang line of the hook script has no effect
 
-To write step hooks in another programming language, you need to call them from
-within the shell script, and explicitly pass any Buildkite environment variables
-you need to the script when you call it.
+To write job hooks in another programming language, you need to execute them
+from within the shell script, and explicitly pass any Buildkite environment
+variables you need to the script when you call it.
 
 The following is an example of a custom `environment` hook which exports a
 GitHub API key for the pipeline’s release build step:
@@ -176,9 +201,9 @@ echo '--- \:house_with_garden\: Setting up the environment'
 export GITHUB_RELEASE_ACCESS_KEY='xxx'
 ```
 
-## Step hooks on Windows
+## Job hooks on Windows
 
-Agents running Windows require hook files to have either:
+Agents running on Windows require hook files to have either:
 
 * A `.bat` extension, and be written in [Windows Batch](https://en.wikipedia.org/wiki/Batch_file), or
 * Access to <a href="/docs/agent/v3/windows#git-for-windows">Git for Windows</a>, which includes bash

--- a/pages/agent/v3/linux.md.erb
+++ b/pages/agent/v3/linux.md.erb
@@ -34,7 +34,7 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 ## File Locations
 
 * Configuration: `~/.buildkite-agent/buildkite-agent.cfg`
-* Hooks: `~/.buildkite-agent/hooks`
+* Agent Hooks: `~/.buildkite-agent/hooks`
 * Builds: `~/.buildkite-agent/builds`
 * SSH keys: `~/.ssh`
 

--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -36,14 +36,14 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 Homebrew install file locations:
 
 * Configuration: `/usr/local/etc/buildkite-agent/buildkite-agent.cfg`
-* Hooks: `/usr/local/etc/buildkite-agent/hooks`
+* Agent Hooks: `/usr/local/etc/buildkite-agent/hooks`
 * Builds: `/usr/local/var/buildkite-agent/builds`
 * Log: `/usr/local/var/log/buildkite-agent.log`
 
 Linux installer script file locations:
 
 * Configuration: `~/.buildkite-agent/buildkite-agent.cfg`
-* Hooks: `~/.buildkite-agent/hooks`
+* Agent Hooks: `~/.buildkite-agent/hooks`
 * Builds: `~/.buildkite-agent/builds`
 
 ## Configuration

--- a/pages/agent/v3/redhat.md.erb
+++ b/pages/agent/v3/redhat.md.erb
@@ -55,7 +55,7 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 ## File Locations
 
 * Configuration: `/etc/buildkite-agent/buildkite-agent.cfg`
-* Hooks: `/etc/buildkite-agent/hooks/`
+* Agent Hooks: `/etc/buildkite-agent/hooks/`
 * Builds: `/var/buildkite-agent/builds/`
 * Logs, depending on your system:
   - `journalctl -f -u buildkite-agent` (systemd)

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -105,7 +105,7 @@ done
 ## Allowing a list of plugins
 
 Defining an [environment hook](hooks#job-lifecycle-hooks) in the
-[agent `hooks-path`](hooks#agent-hook-locations-agent-hooks), you can create a
+[agent `hooks-path`](hooks#hook-locations-agent-hooks), you can create a
 list of plugins that an agent is allowed to run by inspecting the
 `BUILDKITE_PLUGINS` [environment variable](https://buildkite.com/docs/pipelines/environment-variables).
 For an example of this, see the [buildkite/buildkite-allowed-plugins-hook-example](https://github.com/buildkite/buildkite-allowed-plugins-hook-example)
@@ -175,7 +175,7 @@ To safeguard your organization's infrastructure in case of Buildkite infrastruct
 * Disallow execution of arbitrary commands by [customizing the list of allowed plugins](#allowing-a-list-of-plugins) or [disabling plugins](#disabling-plugins) entirely
 * [Disable command-eval](#disabling-command-eval)  
 * [Disable local hooks](#disabling-local-hooks)  
-* [Enable strict validation](#strict-checks-using-agent-hooks)  
+* [Enable strict validation](#strict-checks-using-a-pre-bootstrap-hook)
  
 As a result, your Buildkite agent will refuse to run anything that's not a single argumentless invocation of a script that exists locally (after the `git clone` step of the setup) unless it's explicitly allowed by you. 
 Since the [agent](https://github.com/buildkite/agent) is open-source, if necessary you can verify that assertion to whatever degree of certainty is required.  

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -58,6 +58,15 @@ also disable plugins.
 You can disable local hooks with the [`no-local-hooks`](/agent/v3/configuration#no-local-hooks)
 setting.
 
+If local hooks are disabled and one is in the checkout, the job will fail.
+
+<div class="Docs__troubleshooting-note">
+  <h3>Building untrusted commits</h3>
+  <p>If you build untrusted commits, be careful to contain the build scripts
+  and anything else that may be influenced by the repository contents within
+  chroots, containers, VMs, etc as is appropriate for your needs.</p>
+</div>
+
 ## Strict checks using agent hooks
 
 You can use a [global `pre-bootstrap` hook](hooks) to add strict checks for
@@ -123,18 +132,6 @@ exit 1
 ## Forcing clean checkouts
 
 By default Buildkite will reuse (after cleaning) a previous checkout. This may not be safe if building commits from untrusted sources (e.g. 3rd party pull requests). To force a clean checkout every time, set `BUILDKITE_CLEAN_CHECKOUT=true` in the environment.
-
-## Disallowing hooks in the repository
-
-The default bootstrap script will execute hooks from the agent hots (global) and
-the repository (local). Running local hooks may be undesirable if you are
-building commits from untrusted sources (e.g. 3rd party pull requests).
-
-Local hooks can be disabled by setting [no-local-hooks](/agent/v3/configuration#no-local-hooks).
-
-If local hooks are disabled and one is in the checkout, the job will fail.
-
-NOTE: If building untrusted commits, you should also contain the build scripts and anything else that may be influenced by the repository contents within chroots, containers, VMs, etc as is appropriate for your needs.
 
 ## Running the Agent behind a proxy
 

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -18,7 +18,7 @@ ssh-keyscan "<host>" >> "~/.ssh/known_hosts"
 
 If you choose to disable this functionality, you'll need to manually perform your first checkout, or ensure the SSH fingerprint of your source code host is already present on your build machine.
 
-This operation can be disabled by setting `no-ssh-keyscan` in one of the following ways:
+Automatic ssh-keyscan can be disabled by setting [`no-ssh-keyscan`](/agent/v3/configuration#no-ssh-keyscan):
 
 * Environment variable: `BUILDKITE_NO_SSH_KEYSCAN=true`
 * Command line flag: `--no-ssh-keyscan`
@@ -30,7 +30,7 @@ By default the agent allows you to run any command on the build server (e.g. `ma
 
 Once disabled your build steps will need to be checked into your repository as scripts, and the only way to pass arguments is via environment variables.
 
-To disable command line evaluation use one of the following settings:
+Command line evaluation can be disabled by setting [`no-command-eval`](/agent/v3/configuration#no-command-eval):
 
 * Environment variable: `BUILDKITE_NO_COMMAND_EVAL=1`
 * Command line flag: `--no-command-eval`
@@ -45,13 +45,15 @@ To disable command line evaluation use one of the following settings:
 
 As plugins execute in the same way as local hooks, they can pose a potential security risk. If you're using third party plugins, you'll be executing the third party's code on your agent.
 
-You can disable plugins with the command line flag: `--no-plugins`.
+You can disable plugins with the [`no-plugins`](/agent/v3/configuration#no-plugins)
+setting.
 
 ## Disabling local hooks
 
 If you have configured your agent to do very specific things with global hooks (i.e. run commands within a Docker container or a chroot environment), you probably don't want them overridden with local ones. Disabling local hooks will also disable plugins.
 
-You can disable local hooks with the command line flag: `--no-local-hooks`.
+You can disable local hooks with the [`no-local-hooks`](/agent/v3/configuration#no-local-hooks)
+setting.
 
 ## Strict checks using agent hooks
 
@@ -105,7 +107,7 @@ By default Buildkite will reuse (after cleaning) a previous checkout. This may n
 
 The default bootstrap script will execute hooks from the agent configuration (global) and the repository (local). Running local hooks may be undesirable if you are building commits from untrusted sources (e.g. 3rd party pull requests).
 
-Local hooks can be disabled by setting `BUILDKITE_NO_LOCAL_HOOKS=true` in the environment.
+Local hooks can be disabled by setting [no-local-hooks](/agent/v3/configuration#no-local-hooks).
 
 If local hooks are disabled and one is in the checkout, the job will fail.
 

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -38,7 +38,7 @@ Command line evaluation can be disabled by setting [`no-command-eval`](/docs/age
 
 <div class="Docs__troubleshooting-note">
   <h3>Custom hooks</h3>
-  <p>If you have a custom 'command' hook, using <code>no-command-eval</code> will have no effect on your command execution. See <a href="#allowing-a-list-of-plugins">Allowing a List of Plugins</a> and <a href="#customizing-the-bootstrap">Custom bootstrap scripts</a> for examples of how to completely lock down your agent from arbitrary code execution.</p>
+  <p>If you have a custom <code>command</code> hook, using <code>no-command-eval</code> will have no effect on your command execution. See <a href="#allowing-a-list-of-plugins">Allowing a List of Plugins</a> and <a href="#customizing-the-bootstrap">Custom bootstrap scripts</a> for examples of how to completely lock down your agent from arbitrary code execution.</p>
 </div>
 
 ## Disabling plugins
@@ -50,10 +50,10 @@ setting.
 
 ## Disabling local hooks
 
-If you have configured your agent to do very specific things with agent hooks
-(i.e. run commands within a Docker container or a chroot environment), you
-probably don't want them overridden with local ones. Disabling local hooks will
-also disable plugins.
+If you have enforced a security policy using agent hooks (e.g. force commands to
+run within a Docker container or a chroot environment), you should also disable
+local hooks so that your security measures cannot be evaded with local hooks.
+Disabling local hooks will also disable plugins.
 
 You can disable local hooks with the [`no-local-hooks`](/docs/agent/v3/configuration#no-local-hooks)
 setting.
@@ -67,12 +67,12 @@ If local hooks are disabled and one is in the checkout, the job will fail.
   chroots, containers, VMs, etc as is appropriate for your needs.</p>
 </div>
 
-## Strict checks using agent hooks
+## Strict checks using a `pre-bootstrap` hook
 
-You can use a [`pre-bootstrap` hook](hooks#lifecycle-hooks) to add strict checks
-for which repositories, commands, and plugins are allowed to run. The
-`pre-bootstrap` hook is executed before any source code is checked out, and
-before any commands are executed.
+You can use a [`pre-bootstrap` hook](hooks#agent-lifecycle-hooks) to add strict
+checks for which repositories, commands, and plugins are allowed to run on your
+agent. The `pre-bootstrap` hook is executed before any source code is checked
+out, and before any commands are executed.
 
 For example, the following `pre-bootstrap` hook allows only a single file from a
 single repository to be executed by the agent:
@@ -104,10 +104,11 @@ done
 
 ## Allowing a list of plugins
 
-Defining an [agent](hooks#agent-hook-locations-agent-hooks)
-[environment hook](hooks#job-hooks), you can create a list of plugins that an
-agent is allowed to run by inspecting the `BUILDKITE_PLUGINS` [environment variable](https://buildkite.com/docs/pipelines/environment-variables).
-For an example of how to do this, see the [buildkite/buildkite-allowed-plugins-hook-example](https://github.com/buildkite/buildkite-allowed-plugins-hook-example)
+Defining an [environment hook](hooks#job-lifecycle-hooks) in the
+[agent `hooks-path`](hooks#agent-hook-locations-agent-hooks), you can create a
+list of plugins that an agent is allowed to run by inspecting the
+`BUILDKITE_PLUGINS` [environment variable](https://buildkite.com/docs/pipelines/environment-variables).
+For an example of this, see the [buildkite/buildkite-allowed-plugins-hook-example](https://github.com/buildkite/buildkite-allowed-plugins-hook-example)
 repository on GitHub.
 
 ## Customizing the bootstrap
@@ -174,7 +175,7 @@ To safeguard your organization's infrastructure in case of Buildkite infrastruct
 * Disallow execution of arbitrary commands by [customizing the list of allowed plugins](#allowing-a-list-of-plugins) or [disabling plugins](#disabling-plugins) entirely
 * [Disable command-eval](#disabling-command-eval)  
 * [Disable local hooks](#disabling-local-hooks)  
-* [Enable strict validation in agent hooks](#strict-checks-using-agent-hooks)  
+* [Enable strict validation](#strict-checks-using-agent-hooks)  
  
 As a result, your Buildkite agent will refuse to run anything that's not a single argumentless invocation of a script that exists locally (after the `git clone` step of the setup) unless it's explicitly allowed by you. 
 Since the [agent](https://github.com/buildkite/agent) is open-source, if necessary you can verify that assertion to whatever degree of certainty is required.  

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -50,7 +50,7 @@ setting.
 
 ## Disabling local hooks
 
-If you have configured your agent to do very specific things with global hooks
+If you have configured your agent to do very specific things with agent hooks
 (i.e. run commands within a Docker container or a chroot environment), you
 probably don't want them overridden with local ones. Disabling local hooks will
 also disable plugins.
@@ -104,8 +104,9 @@ done
 
 ## Allowing a list of plugins
 
-Using a [global environment hook](hooks), you can create a list of plugins
-that an agent is allowed to run using the `BUILDKITE_PLUGINS` [environment variable](https://buildkite.com/docs/pipelines/environment-variables).
+Defining an [agent](hooks#agent-hook-locations-agent-hooks)
+[environment hook](hooks#job-hooks), you can create a list of plugins that an
+agent is allowed to run by inspecting the `BUILDKITE_PLUGINS` [environment variable](https://buildkite.com/docs/pipelines/environment-variables).
 For an example of how to do this, see the [buildkite/buildkite-allowed-plugins-hook-example](https://github.com/buildkite/buildkite-allowed-plugins-hook-example)
 repository on GitHub.
 

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -50,16 +50,23 @@ setting.
 
 ## Disabling local hooks
 
-If you have configured your agent to do very specific things with global hooks (i.e. run commands within a Docker container or a chroot environment), you probably don't want them overridden with local ones. Disabling local hooks will also disable plugins.
+If you have configured your agent to do very specific things with global hooks
+(i.e. run commands within a Docker container or a chroot environment), you
+probably don't want them overridden with local ones. Disabling local hooks will
+also disable plugins.
 
 You can disable local hooks with the [`no-local-hooks`](/agent/v3/configuration#no-local-hooks)
 setting.
 
 ## Strict checks using agent hooks
 
-You can use the [agent’s environment hook](hooks) to add strict checks for what repositories, commands, and plugins are allowed to run. The environment hook will be run before any source code is checked out onto the machine, and before any commands are executed.
+You can use a [global `pre-bootstrap` hook](hooks) to add strict checks for
+which repositories, commands, and plugins are allowed to run. The
+`pre-bootstrap` hook will be run before any source code is checked out, and
+before any commands are executed.
 
-For example, the following environment hook allows only a single file from a single repository to be executed on the agent machine:
+For example, the following `pre-bootstrap` hook allows only a single file from a
+single repository to be executed by the agent:
 
 ```bash
 #!/bin/bash
@@ -75,18 +82,32 @@ if [[ "${BUILDKITE_COMMAND}" != "some-script.sh" ]]; then
   exit 1
 fi
 ```
-  
+
 ## Allowing a list of plugins
 
-Using the [agent’s environment hook](hooks), you can create a list of plugins that an agent is allowed to run using the `BUILDKITE_PLUGINS` [environment variable](https://buildkite.com/docs/pipelines/environment-variables). For example of how to do this, see the [buildkite/buildkite-allowed-plugins-hook-example](https://github.com/buildkite/buildkite-allowed-plugins-hook-example) repository on GitHub.
+Using a [global environment hook](hooks), you can create a list of plugins
+that an agent is allowed to run using the `BUILDKITE_PLUGINS` [environment variable](https://buildkite.com/docs/pipelines/environment-variables).
+For an example of how to do this, see the [buildkite/buildkite-allowed-plugins-hook-example](https://github.com/buildkite/buildkite-allowed-plugins-hook-example)
+repository on GitHub.
 
 ## Customizing the bootstrap
 
-The Buildkite Agent comes with a default bootstrap script, but can be [configured](/docs/agent/v3/configuration) to run your own. Providing your own bootstrap provides the highest level of security and control of your agent machine. You can use it to customize your agent, sanitize command output, and implement your own security logic.
+The Buildkite Agent comes with a default bootstrap handler, but can be
+[configured](/docs/agent/v3/configuration#bootstrap-script) to run your own
+instead. Providing your own bootstrap provides the highest level of security and
+control of your agent. You can use it to customize your agent, sanitize command
+output, and implement your own security logic.
 
-The Buildkite Agent is separated into a daemon executable and a bootstrap executable. The daemon is responsible for communicating with the Buildkite API and executing the bootstrap. The bootstrap is responsible for checking out source code, calling hooks, running commands, and uploading build artifacts. The bootstrap is passed environment variables by the daemon process, and has its output streams and exit status captured.
+The Buildkite Agent is separated into a daemon executable and a bootstrap
+executable. The daemon is responsible for communicating with the Buildkite API
+and executing the bootstrap for each assigned job. The bootstrap is responsible
+for checking out source code, calling hooks, running commands, and uploading
+build artifacts. The bootstrap is passed environment variables by the daemon
+process, and has its output streams and exit status captured.
 
-For example, the following custom bootstrap will print out the environment variables passed by the main agent process, print a hello world, and exit with a failure status:
+For example, the following custom bootstrap will print out the environment
+variables passed by the main agent process, print a hello world, and exit with a
+failure status:
 
 ```bash
 #!/bin/bash
@@ -105,7 +126,9 @@ By default Buildkite will reuse (after cleaning) a previous checkout. This may n
 
 ## Disallowing hooks in the repository
 
-The default bootstrap script will execute hooks from the agent configuration (global) and the repository (local). Running local hooks may be undesirable if you are building commits from untrusted sources (e.g. 3rd party pull requests).
+The default bootstrap script will execute hooks from the agent hots (global) and
+the repository (local). Running local hooks may be undesirable if you are
+building commits from untrusted sources (e.g. 3rd party pull requests).
 
 Local hooks can be disabled by setting [no-local-hooks](/agent/v3/configuration#no-local-hooks).
 

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -81,15 +81,25 @@ single repository to be executed by the agent:
 #!/bin/bash
 set -euo pipefail
 
-if [[ "${BUILDKITE_REPO}" != "git@server:repo.git" ]]; then
-  echo "Repository not allowed: ${BUILDKITE_REPO}"
-  exit 1
-fi
+for line in "$(grep "^BUILDKITE_REPO=" "${BUILDKITE_ENV_FILE}")"
+do
+  repo="$(echo "${line}" | cut -d= -f2)"
+  if [ "${repo}" != "git@server:repo.git" ]
+  then
+    echo "Repository not allowed: ${repo}"
+    exit 1
+  fi
+done
 
-if [[ "${BUILDKITE_COMMAND}" != "some-script.sh" ]]; then
-  echo "Command not allowed: ${BUILDKITE_COMMAND}"
-  exit 1
-fi
+for line in "$(grep "^BUILDKITE_COMMAND=" "${BUILDKITE_ENV_FILE}")"
+do
+  command="$(echo "${line}" | cut -d= -f2)"
+  if [ "${command}" != "some-script.sh" ]
+  then
+    echo "Command not allowed: ${command}"
+    exit 1
+  fi
+done
 ```
 
 ## Allowing a list of plugins

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -18,7 +18,7 @@ ssh-keyscan "<host>" >> "~/.ssh/known_hosts"
 
 If you choose to disable this functionality, you'll need to manually perform your first checkout, or ensure the SSH fingerprint of your source code host is already present on your build machine.
 
-Automatic ssh-keyscan can be disabled by setting [`no-ssh-keyscan`](/agent/v3/configuration#no-ssh-keyscan):
+Automatic ssh-keyscan can be disabled by setting [`no-ssh-keyscan`](/docs/agent/v3/configuration#no-ssh-keyscan):
 
 * Environment variable: `BUILDKITE_NO_SSH_KEYSCAN=true`
 * Command line flag: `--no-ssh-keyscan`
@@ -30,7 +30,7 @@ By default the agent allows you to run any command on the build server (e.g. `ma
 
 Once disabled your build steps will need to be checked into your repository as scripts, and the only way to pass arguments is via environment variables.
 
-Command line evaluation can be disabled by setting [`no-command-eval`](/agent/v3/configuration#no-command-eval):
+Command line evaluation can be disabled by setting [`no-command-eval`](/docs/agent/v3/configuration#no-command-eval):
 
 * Environment variable: `BUILDKITE_NO_COMMAND_EVAL=1`
 * Command line flag: `--no-command-eval`
@@ -45,7 +45,7 @@ Command line evaluation can be disabled by setting [`no-command-eval`](/agent/v3
 
 As plugins execute in the same way as local hooks, they can pose a potential security risk. If you're using third party plugins, you'll be executing the third party's code on your agent.
 
-You can disable plugins with the [`no-plugins`](/agent/v3/configuration#no-plugins)
+You can disable plugins with the [`no-plugins`](/docs/agent/v3/configuration#no-plugins)
 setting.
 
 ## Disabling local hooks
@@ -55,7 +55,7 @@ If you have configured your agent to do very specific things with global hooks
 probably don't want them overridden with local ones. Disabling local hooks will
 also disable plugins.
 
-You can disable local hooks with the [`no-local-hooks`](/agent/v3/configuration#no-local-hooks)
+You can disable local hooks with the [`no-local-hooks`](/docs/agent/v3/configuration#no-local-hooks)
 setting.
 
 If local hooks are disabled and one is in the checkout, the job will fail.

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -69,9 +69,9 @@ If local hooks are disabled and one is in the checkout, the job will fail.
 
 ## Strict checks using agent hooks
 
-You can use a [global `pre-bootstrap` hook](hooks) to add strict checks for
-which repositories, commands, and plugins are allowed to run. The
-`pre-bootstrap` hook will be run before any source code is checked out, and
+You can use a [`pre-bootstrap` hook](hooks#lifecycle-hooks) to add strict checks
+for which repositories, commands, and plugins are allowed to run. The
+`pre-bootstrap` hook is executed before any source code is checked out, and
 before any commands are executed.
 
 For example, the following `pre-bootstrap` hook allows only a single file from a

--- a/pages/agent/v3/ssh_keys.md.erb
+++ b/pages/agent/v3/ssh_keys.md.erb
@@ -118,7 +118,7 @@ Alternatively, you can use a shorter approach to creating multiple SSH keys by a
 
 If you need to use multiple keys, or want to use keys with pass-phrases, an alternative to the above hostname method is to use `ssh-agent`.
 
-After running `ssh-agent` and adding the keys, you’ll need to ensure the `SSH_AUTH_SOCK` environment variable is exported in your environment [agent hook](/docs/agent/v3/hooks).
+After starting an `ssh-agent` process and adding the keys, ensure the `SSH_AUTH_SOCK` environment variable is exported by your [`environment` hook](/docs/agent/v3/hooks#job-lifecycle-hooks).
 
 For example, if you set up `ssh-agent` like so:
 
@@ -132,7 +132,8 @@ $ ssh-add ~/.ssh/id_rsa-pipeline-2
 Identity added: /var/lib/buildkite-agent/.ssh/id_rsa-pipeline-2
 ```
 
-Then you will need the following environment [agent hook](/docs/agent/v3/hooks) so that the build’s git operations use the `ssh-agent` socket:
+The following [`environment` hook](/docs/agent/v3/hooks#job-lifecycle-hooks)
+will direct your build’s git operations to use the `ssh-agent` socket:
 
 ```bash
 #!/bin/bash

--- a/pages/agent/v3/windows.md.erb
+++ b/pages/agent/v3/windows.md.erb
@@ -36,7 +36,7 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 ## File locations
 
 * Configuration: `C:\buildkite-agent\buildkite-agent.cfg`
-* Hooks: `C:\buildkite-agent\hooks`
+* Agent Hooks: `C:\buildkite-agent\hooks`
 * Builds: `C:\buildkite-agent\builds`
 * SSH keys: `%USERPROFILE%\.ssh`
 

--- a/pages/apis/rest_api/metrics.md.erb
+++ b/pages/apis/rest_api/metrics.md.erb
@@ -1,0 +1,55 @@
+# Metrics API
+
+The Metrics API provides information about a particular buildkite agent.
+
+
+{:toc}
+
+## Get metrics
+
+Returns an object with properties describing Buildkite.
+
+`webhook_ips` is a list of IP addresses in CIDR notation that Buildkite uses to send outbound traffic such as webhooks and commit statuses. These are subject to change from time to time. We recommend checking for new addresses daily, and will try to advertise new addresses for at least 7 days before they are used.
+
+Note: The IP addresses shown here are examples. You must query the API to get the current set of IP addresses.
+
+```bash
+curl -H "Authorization: Token XXXXXXXXXXXXXXXX" https://agent.buildkite.com/v3/metrics
+```
+
+```json
+{
+  "agents": {
+    "idle": 1,
+    "busy": 0,
+    "total": 1,
+    "queues": {
+      "default": {
+        "idle": 1,
+        "busy": 0,
+        "total": 1
+      }
+    }
+  },
+  "jobs": {
+    "scheduled": 5,
+    "running": 0,
+    "waiting": 0,
+    "total": 5,
+    "queues": {
+      "default}": {
+        "scheduled": 5,
+        "running": 0,
+        "waiting": 0,
+        "total": 5
+      }
+    }
+  },
+  "organization": {
+    "slug": "plaindocs"
+  }
+}
+
+```
+
+Success response: `200 OK`

--- a/pages/integrations/bitbucket.md.erb
+++ b/pages/integrations/bitbucket.md.erb
@@ -46,6 +46,8 @@ Buildkite prompts you to give permission for Buildkite to post status updates, t
 
 ## Mercurial support
 
-Buildkite Agent’s default source control tool is Git, and doesn’t support [Mercurial](https://www.mercurial-scm.org) out of the box. If you want to use Buildkite with a Bitbucket Mercurial repository, you need to add your own Mercurial checkout code using a custom [Buildkite Agent global checkout hook](/docs/agent/v3/hooks).
+Buildkite Agent’s default source control tool is Git, and doesn’t support [Mercurial](https://www.mercurial-scm.org) out of the box. If you want to use
+Buildkite with a Bitbucket Mercurial repository, you need to add your own
+Mercurial checkout code using a [checkout hook](/docs/agent/v3/hooks#job-hooks).
 
 <%= render_markdown 'integrations/one_repo_multi_org' %>

--- a/pages/integrations/bitbucket.md.erb
+++ b/pages/integrations/bitbucket.md.erb
@@ -47,7 +47,7 @@ Buildkite prompts you to give permission for Buildkite to post status updates, t
 ## Mercurial support
 
 Buildkite Agent’s default source control tool is Git, and doesn’t support [Mercurial](https://www.mercurial-scm.org) out of the box. If you want to use
-Buildkite with a Bitbucket Mercurial repository, you need to add your own
-Mercurial checkout code using a [checkout hook](/docs/agent/v3/hooks#job-hooks).
+Buildkite with a Bitbucket Mercurial repository, you must supply your own
+Mercurial checkout code using a [`checkout` hook](/docs/agent/v3/hooks#job-lifecycle-hooks).
 
 <%= render_markdown 'integrations/one_repo_multi_org' %>

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -1,6 +1,7 @@
 # Environment Variables
 
-When the agent invokes your build scripts it passes in a set of standard Buildkite environment variables, along with any that you've defined in your build configuration. You can use these environment variables in your [build steps](/docs/pipelines/defining-steps) and [agent hooks](/docs/agent/v3/hooks).
+When the agent invokes your build scripts it passes in a set of standard Buildkite environment variables, along with any that you've defined in your build configuration. You can use these environment variables in your [build steps](/docs/pipelines/defining-steps) and
+[job lifecycle hooks](/docs/agent/v3/hooks#job-lifecycle-hooks).
 
 For best practices and recommendations about using secrets in your environment variables, see the [Managing Secrets](/docs/pipelines/secrets) guide.
 

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -708,7 +708,10 @@ Once the job is accepted by an agent, more environment merging happens. Starting
 
 After the agent variables have been merged, the bootstrap script is run.
 
-The bootstrap runs any local and global <a href="/docs/agent/v3/hooks">hooks</a> that have been defined on the agent machine, and any hooks provided by <a href="/docs/plugins">plugins</a>. Variables that are set in these hooks will be merged into the runtime environment, and will override any previous values that are set.
+The bootstrap runs any hooks that have been defined by your
+[agent](/docs/agent/v3/hooks#hook-locations-agent-hooks), your [repository](/docs/agent/v3/hooks#hook-locations-repository-hooks) or [plugins](/docs/agent/v3/hooks#hook-locations-plugin-hooks).
+Variables that are set in these hooks will be merged into the runtime
+environment, and will override any previous values that are set.
 
 <div class="Docs__troubleshooting-note">
   <h3>Take care with environment variables in hooks</h3>

--- a/pages/pipelines/permissions.md.erb
+++ b/pages/pipelines/permissions.md.erb
@@ -40,7 +40,8 @@ If you're creating pipelines programmatically using the REST API, you can add th
 
 You can also restrict agents to specific teams with the `BUILDKITE_BUILD_CREATOR_TEAMS` environment variable. Using agent hooks, you can allow or disallow builds based on the creator's team memberships.
 
-For example, the following [agent environment hook](/docs/agent/v3/hooks) prevents anyone from outside of the ops team from running a build on the agent:
+For example, the following [`environment` hook](/docs/agent/v3/hooks#job-lifecycle-hooks) 
+prevents anyone from outside of the ops team from running a build on the agent:
 
 ```bash
 set -euo pipefail

--- a/pages/pipelines/secrets.md.erb
+++ b/pages/pipelines/secrets.md.erb
@@ -8,13 +8,18 @@ When you need to use secret values in your pipelines, there are some best practi
 
 A best practice for secret storage is to use your own secrets storage service, such as [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) or [Hashicorp Vault](https://www.vaultproject.io).
 
-There are also various [Buildkite Plugins](/docs/plugins) that integrate reading and exposing secrets to your build steps using secrets storage services.
+There are also various [Buildkite Plugins](/docs/plugins) that integrate reading
+and exposing secrets to your build steps using secrets storage services.
 
 ## Storing secrets in environment hooks
 
-If you don’t use a secrets storage service, the recommended place to store secrets is in [agent environment hooks](/docs/agent/v3/hooks). Agent hooks are stored on your agent machine, are only accessible by you, and can conditionally expose secrets to your pipeline steps.
+If you don’t use a secrets storage service, the recommended place to store
+secrets is in an [`environment` hook](/docs/agent/v3/hooks#job-lifecycle-hooks).
+[Agent hooks](/docs/agent/v3/hooks#hook-locations-agent-hooks) are stored on
+your agent machine, are only accessible by you, and can conditionally expose
+secrets to your pipeline steps.
 
-For example, say you had the following deploy [command step](/docs/pipelines/command-step) in a pipeline:
+For example, say you had the following deploy [`command` step](/docs/pipelines/command-step) in a pipeline:
 
 ```yml
 steps:
@@ -37,7 +42,10 @@ curl \
 ```
 {: codeblock-file="scripts/trigger-github-deploy"}
 
-To set up the `GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN` secret for the step, you would create an `environment` [agent hook](/docs/agent/v3/hooks) on your agent machine to conditionally export it. For example:
+To set up the `GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN` secret for the step, you
+could define an [`environment` hook](/docs/agent/v3/hooks#job-lifecycle-hooks)
+in your [agent `hooks-path` directory](/docs/agent/v3/hooks#hook-locations-agent-hooks)
+to conditionally export it. For example:
 
 ```bash
 #!/bin/bash
@@ -57,9 +65,13 @@ fi
 
 ## Storing secrets with the Elastic CI Stack for AWS
 
-To store secrets when using the [Elastic CI Stack for AWS](https://github.com/buildkite/elastic-ci-stack-for-aws), place them inside your stack’s encrypted S3 bucket. Unlike regular agent hooks, the Elastic CI Stack’s `env` hooks are per-pipeline.
+To store secrets when using the [Elastic CI Stack for AWS](https://github.com/buildkite/elastic-ci-stack-for-aws), place them inside your stack’s encrypted S3 bucket.
+Unlike hooks defined in [agent `hooks-path`](/docs/agent/v3/hooks#hook-locations-agent-hooks),
+the Elastic CI Stack’s `env` hooks are defined per-pipeline.
 
-For example, to expose a `GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN` environment variable to a step with identifier `trigger-github-deploy`, you would create the following `env` file on your local development machine:
+For example, to expose a `GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN` environment
+variable to a step with identifier `trigger-github-deploy`, you would create the
+following `env` file on your local development machine:
 
 ```bash
 #!/bin/bash
@@ -71,7 +83,8 @@ fi
 ```
 {: codeblock-file="env"}
 
-You then upload the `env` file, encrypted, into the secrets S3 bucket with the following command:
+You then upload the `env` file, encrypted, into the secrets S3 bucket with the
+following command:
 
 ```bash
 # Upload the env
@@ -157,5 +170,3 @@ steps:
         https://api.github.com/repos/my-org/my-app/deployments
 ```
 {: codeblock-file="pipeline.yml"}
-
-

--- a/pages/pipelines/writing_build_scripts.md.erb
+++ b/pages/pipelines/writing_build_scripts.md.erb
@@ -100,7 +100,11 @@ The first step in debugging your build script is to view the environment variabl
 
 <%= image "viewing-job-environment-variables.png", width: 1044/2, height: 542/2, alt: 'Screenshot of viewing a job’s environment tab' %>
 
-There may be additional environment variables available in your build job that don’t appear in this list, such as ones set by your own [agent hooks](/docs/agent/v3/hooks). To debug these, you can print them using `echo $SOME_VAR` before the command you're wanting to run. For example:
+There may be additional environment variables available in your build job that
+don’t appear in this list, such as ones set by your
+[job lifecycle hooks](/docs/agent/v3/hooks#job-lifecycle-hooks).
+To debug these, you can print them using `echo $SOME_VAR` before the command
+you're wanting to run. For example:
 
 ```bash
 #!/bin/bash

--- a/pages/plugins/using.md.erb
+++ b/pages/plugins/using.md.erb
@@ -147,10 +147,7 @@ steps:
 
 ## Disabling plugins
 
-To selectively allow and disallow plugins you can use a Global [environment hook](/docs/agent/v3/hooks) and the `BUILDKITE_PLUGINS` [environment variable](/docs/pipelines/environment-variables). See the [github.com/buildkite/buildkite-allowed-plugins-hook-example](https://github.com/buildkite/buildkite-allowed-plugins-hook-example) repository for an example implementation.
+To selectively allow and disallow plugins you can use a [global environment hook](/docs/agent/v3/hooks) and the `BUILDKITE_PLUGINS` [environment variable](/docs/pipelines/environment-variables). See the [github.com/buildkite/buildkite-allowed-plugins-hook-example](https://github.com/buildkite/buildkite-allowed-plugins-hook-example) repository for an example implementation.
 
-To disable plugins entirely, set the `no-plugins` [agent configuration](/docs/agent/v3/configuration) option:
-
-```
-no-plugins: true
-```
+To disable plugins entirely, set the [`no-plugins`](/docs/agent/v3/configuration#no-plugins)
+option.

--- a/pages/plugins/using.md.erb
+++ b/pages/plugins/using.md.erb
@@ -41,8 +41,9 @@ Although there's no `command` attribute in the above example, this is still
 considered a command step, so all command attributes are available for use. 
 
 If you are using [global hooks](/docs/agent/v3/hooks) as well as plugins, some
-global hooks will run before any plugin hooks. For a description of each job
-hook type, and the order it is run in, see [Available Job Hooks](/docs/agent/v3/hooks#available-job-hooks).
+hooks types run a globally defined hook before a plugin defined hook. See
+[Job Hooks](/docs/agent/v3/hooks#job-hooks) for a description of each job hook
+type, the order their locations are run in, and the overall order of hooks.
 
 ## Configuring plugins
 

--- a/pages/plugins/using.md.erb
+++ b/pages/plugins/using.md.erb
@@ -40,12 +40,12 @@ steps:
 Although there's no `command` attribute in the above example, this is still
 considered a command step, so all command attributes are available for use. 
 
-If you are using [agent hooks](/docs/agent/v3/hooks#hook-locations-agent-hooks)
-as well as [plugins](/docs/agent/v3/hooks#hook-locations-plugin-hooks), some
-hooks types run an agent defined hook before a plugin defined hook. See
-[job hooks](/docs/agent/v3/hooks#job-hooks) for a description of each job hook
-type, the order their locations are run in, and the overall order of hooks for a
-job.
+It is possible to define multiple hooks of the same type in both a
+[plugins](/docs/agent/v3/hooks#hook-locations-plugin-hooks) and the
+[agent hooks](/docs/agent/v3/hooks#hook-locations-agent-hooks) location.
+See [job lifecycle hooks](/docs/agent/v3/hooks#job-lifecycle-hooks)
+for the overall order of hooks, and the relative order of invocation for each
+location.
 
 ## Configuring plugins
 

--- a/pages/plugins/using.md.erb
+++ b/pages/plugins/using.md.erb
@@ -40,10 +40,9 @@ steps:
 Although there's no `command` attribute in the above example, this is still
 considered a command step, so all command attributes are available for use. 
 
-If you are using [Agent Hooks](/docs/agent/v3/hooks) as well as plugins, some
-Step hooks will run a Global hook before any plugin hooks. For a description of
-each hook type and the order it is run, see the
-[Available Step Hooks](/docs/agent/v3/hooks#available-step-hooks). 
+If you are using [global hooks](/docs/agent/v3/hooks) as well as plugins, some
+global hooks will run before any plugin hooks. For a description of each job
+hook type, and the order it is run in, see [Available Job Hooks](/docs/agent/v3/hooks#available-job-hooks).
 
 ## Configuring plugins
 

--- a/pages/plugins/using.md.erb
+++ b/pages/plugins/using.md.erb
@@ -40,10 +40,12 @@ steps:
 Although there's no `command` attribute in the above example, this is still
 considered a command step, so all command attributes are available for use. 
 
-If you are using [global hooks](/docs/agent/v3/hooks) as well as plugins, some
-hooks types run a globally defined hook before a plugin defined hook. See
-[Job Hooks](/docs/agent/v3/hooks#job-hooks) for a description of each job hook
-type, the order their locations are run in, and the overall order of hooks.
+If you are using [agent hooks](/docs/agent/v3/hooks#hook-locations-agent-hooks)
+as well as [plugins](/docs/agent/v3/hooks#hook-locations-plugin-hooks), some
+hooks types run an agent defined hook before a plugin defined hook. See
+[job hooks](/docs/agent/v3/hooks#job-hooks) for a description of each job hook
+type, the order their locations are run in, and the overall order of hooks for a
+job.
 
 ## Configuring plugins
 
@@ -148,7 +150,7 @@ steps:
 
 ## Disabling plugins
 
-To selectively allow and disallow plugins you can use a [global environment hook](/docs/agent/v3/hooks) and the `BUILDKITE_PLUGINS` [environment variable](/docs/pipelines/environment-variables). See the [github.com/buildkite/buildkite-allowed-plugins-hook-example](https://github.com/buildkite/buildkite-allowed-plugins-hook-example) repository for an example implementation.
+To selectively allow and disallow plugins see [securing your Buildkite Agent](/docs/agent/v3/securing#allowing-a-list-of-plugins).
 
 To disable plugins entirely, set the [`no-plugins`](/docs/agent/v3/configuration#no-plugins)
 option.

--- a/pages/plugins/using.md.erb
+++ b/pages/plugins/using.md.erb
@@ -37,9 +37,13 @@ steps:
           image-repository: index.docker.io/myorg/myrepo
 ```
 
-Although there's no `command` attribute in the above example, this is still considered a command step, so all command attributes are available for use. 
+Although there's no `command` attribute in the above example, this is still
+considered a command step, so all command attributes are available for use. 
 
-If you are using Agent hooks as well as plugins, some hook types will run the Agent hooks before the plugin hooks. For a description of each hook type and the order it is run, see the [Agent Hooks guide](/docs/agent/v3/hooks#available-hooks). 
+If you are using [Agent Hooks](/docs/agent/v3/hooks) as well as plugins, some
+Step hooks will run a Global hook before any plugin hooks. For a description of
+each hook type and the order it is run, see the
+[Available Step Hooks](/docs/agent/v3/hooks#available-step-hooks). 
 
 ## Configuring plugins
 
@@ -144,7 +148,7 @@ steps:
 
 ## Disabling plugins
 
-To selectively allow and disallow plugins you can use the agent’s [environment hook](/docs/agent/v3/hooks) and the `BUILDKITE_PLUGINS` [environment variable](/docs/pipelines/environment-variables). See the [github.com/buildkite/buildkite-allowed-plugins-hook-example](https://github.com/buildkite/buildkite-allowed-plugins-hook-example) repository for an example implementation.
+To selectively allow and disallow plugins you can use a Global [environment hook](/docs/agent/v3/hooks) and the `BUILDKITE_PLUGINS` [environment variable](/docs/pipelines/environment-variables). See the [github.com/buildkite/buildkite-allowed-plugins-hook-example](https://github.com/buildkite/buildkite-allowed-plugins-hook-example) repository for an example implementation.
 
 To disable plugins entirely, set the `no-plugins` [agent configuration](/docs/agent/v3/configuration) option:
 

--- a/pages/tutorials/docker_containerized_builds.md.erb
+++ b/pages/tutorials/docker_containerized_builds.md.erb
@@ -99,7 +99,8 @@ There are many configuration options available for the Docker plugin. For the co
 
 If your team has significant Docker experience you might find it worthwhile invoking your own runner scripts rather than using the simpler built-in Docker support.
 
-To do this see the [agent hooks](/docs/agent/v3/hooks) and [parallel builds](parallel-builds) documentation.
+To do this, see the [job lifecycle hooks](/docs/agent/v3/hooks#job-lifecycle-hooks)
+and [parallel builds](parallel-builds) documentation.
 
 ## Adding buildkite-agent to the Docker group
 


### PR DESCRIPTION
Presently, the term **agent hooks** can be used to refer to either the _buildkite-agent feature_ or the _location that hooks are stored in the file system_.

With the new `pre-bootstrap` and arguably `agent-shutdown` hooks we have introduced a new _category_ of hook, one that is run outside the step/job lifecycle and that is _executed_ rather than _sourced_.

I’d like to make that distinction clear and think introducing new terminology is the way to do that.

This feels like a significant change to the product area. ~I’m **not** tied to this particular terminology or this particular slicing of things, but I wanted to have something written down for us to discuss pros and cons 😄~ Edit: I have since discussed this with others and am fairly tied to this new naming. How I’ve named and sliced this up is elaborated on 👇 and the doc diff reflects this.

---

This change continues to use the term **agent hooks** to refer to the all encompassing **feature** of the Buildkite Agent.

There are **two categories of agent hook**: Agent Lifecycle Hooks and Job Lifecycle Hooks.

- Agent Lifecycle Hooks are **executed** as part of the agent lifecycle, presently `pre-bootstrap` and `agent-shutdown`.
- Job Lifecycle Hooks (the _new name_ for the _old feature_) are **sourced** as part of the bootstrap lifecycle, all our old favourites `environment`, `pre-command`, `post-artifact` etc

There are **three locations that agent hooks are defined**:

- Agent hooks (the _new name_ for the _old location_) are stored on the agent host. This location can define **both** agent lifecycle hooks, and job lifecycle hooks.
- Repository hooks, as before, can define job lifecycle hooks
- Plugin hooks, as before can define job lifecycle hooks

---

Next steps:

- [x] Update strict checks example to use `BUILDKITE_ENV_FILE` for vetting rather than env vars
- [x] Reach consensus on naming
- [x] Find other places to update naming
