### PR TITLE
Typo fixes

### DIFF
--- a/pages/agent/v2/cli_artifact.md.erb
+++ b/pages/agent/v2/cli_artifact.md.erb
@@ -146,7 +146,7 @@ Example:
 
 Options:
 
-   --step value                Scope the search to a paticular step by using either its name or job ID
+   --step value                Scope the search to a particular step by using either its name or job ID
    --build value               The build that the artifacts were uploaded to [$BUILDKITE_BUILD_ID]
    --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
    --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]
@@ -237,7 +237,7 @@ Example:
 
 Options:
 
-   --step value                Scope the search to a paticular step by using either its name of job ID
+   --step value                Scope the search to a particular step by using either its name of job ID
    --build value               The build that the artifacts were uploaded to [$BUILDKITE_BUILD_ID]
    --agent-access-token value  The access token used to identify the agent [$BUILDKITE_AGENT_ACCESS_TOKEN]
    --endpoint value            The Agent API endpoint (default: "https://agent.buildkite.com/v3") [$BUILDKITE_AGENT_ENDPOINT]

--- a/pages/agent/v2/gcloud.md.erb
+++ b/pages/agent/v2/gcloud.md.erb
@@ -159,7 +159,7 @@ buildkite-agent-3220167863-m3nm2   1/1       Running   0          24s
 To run builds from private repositories you can store [an SSH key for the agent](/docs/agent/v2/ssh-keys) in a secret and map it into the containers:
 
 ```shell
-# Use an existing keypair, or generate a new one with something like:
+# Use an existing key pair, or generate a new one with something like:
 $ ssh-keygen -t rsa -b 2048 -N "" -C buildkite-agent -f id_rsa
 Generating public/private rsa key pair.
 Your identification has been saved in id_rsa.

--- a/pages/agent/v3/gcloud.md.erb
+++ b/pages/agent/v3/gcloud.md.erb
@@ -174,7 +174,7 @@ buildkite-agent-67d54b9b88-qwfc5   2/2     Running   0          69s
 To run builds from private repositories you can store [an SSH key for the agent](/docs/agent/v3/ssh-keys) in a secret and map it into the containers:
 
 ```shell
-# Use an existing keypair, or generate a new one with something like:
+# Use an existing key pair, or generate a new one with something like:
 $ ssh-keygen -t rsa -b 2048 -N "" -C buildkite-agent -f id_rsa
 Generating public/private rsa key pair.
 Your identification has been saved in id_rsa.

--- a/pages/apis/managing_api_tokens.md.erb
+++ b/pages/apis/managing_api_tokens.md.erb
@@ -62,7 +62,7 @@ Removing access from a token will send a notification email to the token's owner
 <p>Removing access from a token does not delete the token. Token owners can re-add your organization to their token's scope.</p>
 </div>
 
-## Programatically managing tokens
+## Programmatically managing tokens
 
 The `access-token` REST API endpoint can be used to retrieve or revoke an API access token. See the [REST API Access Token](/docs/apis/rest-api/access-token) page for further information.
 

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -324,7 +324,7 @@ To run only when building a tag beginning with a `v` and ends with a `.0`, such 
 // Using the tag variable
 build.tag =~ /^v[0-9]+\.0\$/
 
-// Using the env fuction
+// Using the env function
 build.env("BUILDKITE_TAG") =~ /^v[0-9]+\.0\$/
 ```
 

--- a/pages/pipelines/example_pipelines.md.erb
+++ b/pages/pipelines/example_pipelines.md.erb
@@ -5,7 +5,7 @@ A list of repositories containing example [pipelines](/docs/pipelines).
 {:toc}
 
 <!-- vale off -->
-<!-- this turns it off for the whole file because I can't igore the emoji in the html :( -->
+<!-- this turns it off for the whole file because I can't ignore the emoji in the html :( -->
 
 ## Languages and Frameworks
 

--- a/vale/vocab.txt
+++ b/vale/vocab.txt
@@ -103,7 +103,6 @@ Powershell
 powershell
 preemptible
 prefill
-Programatically
 pty
 pullrequest
 pybuildkite


### PR DESCRIPTION
Super interesting tool called codespell that finds common spelling errors, rather than comparing files to a dictionary.

` ~/.local/bin/codespell -L iterm pages/`

From https://til.simonwillison.net/python/codespell 