### PR TITLE
Adding payment plans overview + small consistency fix

### DIFF
--- a/pages/tutorials/getting_started.md.erb
+++ b/pages/tutorials/getting_started.md.erb
@@ -42,8 +42,33 @@ Congratulations, you have run your first Buildkite build! :tada:
 
 To invite your team so they can see your build, go to your organization’s *Settings*, and under *Users* you’ll be able to paste in their email addresses.
 
-## Using a private repository
+## Use a private repository (optional)
 
 When you create a new pipeline with a private repository URL you’ll be shown instructions for configuring your SCM’s webhooks (in GitHub, Bitbucket, etc). Once you’ve followed those instructions make sure your [agent’s SSH keys](/docs/agent/v3/ssh-keys) are configured, and you’ll be good to run a build of your private pipeline.
 
 For more advanced pipelines it can be a good idea to use your development machine as the agent for your first few builds. That way all the dependencies are ready and you’ll sooner be able to share a link to a green build with the rest of your team.
+
+## Enable extra features by upgrading (optional)
+
+**Buildkite Free Plan** is free for open-source projects, students, and teaching organizations of any size and provides:
+* Unlimited agents
+* Unlimited builds
+* Unlimited artifacts
+
+Upgrading to Buildkite Standard Plan (up to 200 users per organization) adds:
+
+* [Teams permissions](/docs/pipelines/permissions#permissions-with-teams)
+* [Single Sign On](/docs/integrations/sso)
+* Priority email support
+
+**Buildkite Enterprise Plan** (100 users per organization with an expansion option) adds extended administration options: 
+
+* [Audit logging](/docs/pipelines/audit-log#main)
+* [Member permissions management tool](/docs/pipelines/permissions#member-permissions)
+* Extended logs storage options
+* Live chat support
+* Extended legal and accounting options
+ 
+Buildkite Enterprise license covers every user of your code repository provider organization (for example, GitHub organization) or anyone who directly or indirectly interacts with your Buildkite organization. This includes users who log in to your Buildkite organization and external users who trigger builds via merging pull requests. Suppose a Buildkite Enterprise organization exceeds 100 users. In that case, new members can still be invited (or — if SSO is enabled — new members will still be auto-created upon signing in) for extra monthly charges.
+
+To learn all about the pricing policy and additional features available with Buildkite Enterprise, see [Pricing](https://buildkite.com/pricing).  

--- a/pages/tutorials/getting_started.md.erb
+++ b/pages/tutorials/getting_started.md.erb
@@ -50,12 +50,13 @@ For more advanced pipelines it can be a good idea to use your development machin
 
 ## Enable extra features by upgrading (optional)
 
-**Buildkite Free Plan** is free for open-source projects, students, and teaching organizations of any size and provides:
+**Buildkite Free Plan** is free for open-source projects, students, and teaching organizations of any size and provides:  
+
 * Unlimited agents
 * Unlimited builds
 * Unlimited artifacts
 
-Upgrading to Buildkite Standard Plan (up to 200 users per organization) adds:
+Upgrading to Buildkite Standard Plan (up to 200 users per organization) adds:  
 
 * [Teams permissions](/docs/pipelines/permissions#permissions-with-teams)
 * [Single Sign On](/docs/integrations/sso)


### PR DESCRIPTION
- Added a new section that covers the existing payment plans from the POV of engineering usefulness (hopefully).
- For consistency's sake turned "Using a private repository" into "Use a private repository" + added "(optional)" for both this section & the payment plans section.
- I'm not 100% sure that "Enable extra features by upgrading" is the best title here. Other discarded variants are:
* For large organizations 
* Payment plans 
* Upgrade options