### PR TITLE
Update and expand HMAC docs

### DIFF
--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -38,8 +38,15 @@ The following HTTP headers are present in every webhook request, which allow you
 <table>
 <tbody>
   <tr><th><code>X-Buildkite-Event</code></th><td>The type of event<p class="Docs__api-param-eg"><em>Example:</em> <code>build.scheduled</code></p></td></tr>
-  <tr><th><code>X-Buildkite-Token</code></th><td>The token from your webhook configuration settings. It will only be sent if you selected the option to send the token in the token header. Its presence in the header of the webhook confirms that you are the originator of the the webhook request<p class="Docs__api-param-eg"><em>Example:</em> <code>309c9c842d8565adec5d7469160059f9</code></p></td></tr>
-  <tr><th><code>X-Buildkite-Signature</code></th><td>The signature signed from your webhook token. It will only be sent if you selected the option to send an HMAC signature in the signature header. Its presence in the header of the webhook confirms that you are the originator of the the webhook request<p class="Docs__api-param-eg"><em>Example:</em> <code>timestamp=1619071700,signature=30222eb518dc3fb61ec9e64dd78d163f62c6134a63db768f1d40e0edbe6e43f0</code></p></td></tr>
+</tbody>
+</table>
+
+One of either the Token or Signature headers will be present in every webhook request. Your selection in the Webhook notification service will determine which is sent:
+
+<table>
+<tbody>
+  <tr><th><code>X-Buildkite-Token</code></th><td>The webhook's token. <p class="Docs__api-param-eg"><em>Example:</em> <code>309c9c842d8565adec5d7469160059f9</code></p></td></tr>
+  <tr><th><code>X-Buildkite-Signature</code></th><td>The signature created from your webhook payload and .<p class="Docs__api-param-eg"><em>Example:</em> <code>timestamp=1619071700,signature=30222eb518dc3fb61ec9e64dd78d163f62c6134a63db768f1d40e0edbe6e43f0</code></p></td></tr>
 </tbody>
 </table>
 
@@ -60,17 +67,33 @@ Each event’s data is sent JSON encoded in the request body. See each event’s
 ```
 
 <div class="Docs__troubleshooting-note">
-  <h3>fast transitions and webhooks</h3>
-  <p>Note that if a builds transitions between states very quickly, for example from blocked (`finished`) to unblocked (`running`), the webhook may be in a different state from the actual build. This is a known limitation of webhooks, in that they may represent a later version of the object than the one that triggered the event.</p>
+  <h3>Fast transitions and webhooks</h3>
+  <p>Note that if a builds transitions between states very quickly, for example from blocked (<code>finished</code>) to unblocked (<code>running</code>), the webhook may be in a different state from the actual build. This is a known limitation of webhooks, in that they may represent a later version of the object than the one that triggered the event.</p>
 </div>
 
-## Verifying Webhook signatures
+## Webhook token
 
-The `X-Buildkite-Signature` header included in each signed event contains a timestamp and one signature. The timestamp is prefixed by `timestamp=`, and the signature is prefixed by `signature=`.
+By default, Buildkite will send a token with each webhook in the `X-Buildkite-Token` header.
 
-Buildkite generates the signature using a hash-based message authentication code ([HMAC](https://en.wikipedia.org/wiki/HMAC)) with [SHA-256](https://en.wikipedia.org/wiki/SHA-2). The timestamp is an integer representation of a UTC timestamp.
+The token is passed in clear text.
 
-Example using Ruby to verify the signature and timestamp:
+## Webhook signature
+
+Buildkite can optionally send an HMAC signature in place of a webhook token.
+
+The `X-Buildkite-Signature` header contains a timestamp and an HMAC signature. The timestamp is prefixed by `timestamp=` and the signature is prefixed by `signature=`. 
+
+Buildkite generates the signature using HMAC-SHA256; a hash-based message authentication code [HMAC](https://en.wikipedia.org/wiki/HMAC) used with the [SHA-256](https://en.wikipedia.org/wiki/SHA-2) hash function and a secret key. The webhook token value is used as the secret key. The timestamp is an integer representation of a UTC timestamp.
+
+### Verifying HMAC signatures
+
+When using HMAC signatures, you'll want to verify that the signature is legitimate.
+
+Using the token as the secret along with the timestamp and signature from the webhook, compute the authentication code. There should be a library available in the programming language you are using that can perform this operation.
+
+Compare the code to the signature received in the webhook. If they do not match, your payload has been altered.
+
+The below example in Ruby verifies the signature and timestamp using the OpenSSL gem's HMAC :
 
 ```ruby
 require 'openssl'
@@ -95,12 +118,18 @@ BuildkiteWebhook.valid?(
 )
 ```
 
-### Preventing replay attacks
+### Defending against replay attacks
 
-A [replay attack](https://en.wikipedia.org/wiki/Replay_attack) is when an attacker intercepts a valid payload and its signature, then re-transmits them. To mitigate such attacks, Buildkite includes a timestamp in the `X-Buildkite-Signature` header. The timestamp is part of the signed payload, it is also verified by the signature, so an attacker cannot change the timestamp without invalidating the signature. To mitigate against a replay attack, the webhook receiver needs to:
+A [replay attack](https://en.wikipedia.org/wiki/Replay_attack) is when an attacker intercepts a valid payload and its signature, then re-transmits them. One way to help mitigate such attacks is to send a timestamp with your payload and only accept them within a short window (e.g. 5 minutes). 
+
+Buildkite sends a timestamp in the `X-Buildkite-Signature` header. The timestamp is part of the signed payload so that it is verified by the signature. An attacker will not be able to change the timestamp without invalidating the signature. 
+
+To help protect against a replay attack, upon receipt of a webhook:
 
 1. Verify the signature
-2. Check that the timestamp is within a reasonable time frame (e.g. 5 minutes)
+2. Check the timestamp against the current time
+
+If the webhook's timestamp is within your chosen window of the current time, it can reasonably be assumed to be the original webhook.
 
 ## Example implementations
 

--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -41,7 +41,7 @@ The following HTTP headers are present in every webhook request, which allow you
 </tbody>
 </table>
 
-One of either the Token or Signature headers will be present in every webhook request. Your selection in the Webhook notification service will determine which is sent:
+One of either the [Token](/docs/apis/webhooks#webhook-token) or [Signature](/docs/apis/webhooks#webhook-signature) headers will be present in every webhook request. Your selection in the Webhook notification service will determine which is sent:
 
 <table>
 <tbody>

--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -41,12 +41,14 @@ The following HTTP headers are present in every webhook request, which allow you
 </tbody>
 </table>
 
-One of either the [Token](/docs/apis/webhooks#webhook-token) or [Signature](/docs/apis/webhooks#webhook-signature) headers will be present in every webhook request. Your selection in the Webhook notification service will determine which is sent:
+One of either the [Token](/docs/apis/webhooks#webhook-token) or [Signature](/docs/apis/webhooks#webhook-signature) headers will be present in every webhook request. The token value and header setting can be found under _Token_ in your _Webhook Notification service_. 
+
+Your selection in the _Webhook Notification service_ will determine which is sent:
 
 <table>
 <tbody>
-  <tr><th><code>X-Buildkite-Token</code></th><td>The webhook's token. <p class="Docs__api-param-eg"><em>Example:</em> <code>309c9c842d8565adec5d7469160059f9</code></p></td></tr>
-  <tr><th><code>X-Buildkite-Signature</code></th><td>The signature created from your webhook payload and .<p class="Docs__api-param-eg"><em>Example:</em> <code>timestamp=1619071700,signature=30222eb518dc3fb61ec9e64dd78d163f62c6134a63db768f1d40e0edbe6e43f0</code></p></td></tr>
+  <tr><th><code>X-Buildkite-Token</code></th><td>The webhook's token. <p class="Docs__api-param-eg"><em>Example:</em> <code>309c9c842g8565adecpd7469x6005989</code></p></td></tr>
+  <tr><th><code>X-Buildkite-Signature</code></th><td>The signature created from your webhook payload, webhook token, and the SHA-256 hash function.<p class="Docs__api-param-eg"><em>Example:</em> <code>timestamp=1619071700,signature=30222eb518dc3fb61ec9e64dd78d163f62cb134a6ldb768f1d40e0edbn6e43f0</code></p></td></tr>
 </tbody>
 </table>
 

--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -75,6 +75,8 @@ Each event’s data is sent JSON encoded in the request body. See each event’s
 
 By default, Buildkite will send a token with each webhook in the `X-Buildkite-Token` header.
 
+The token value and header setting can be found under _Token_ in your _Webhook Notification service_.
+
 The token is passed in clear text.
 
 ## Webhook signature
@@ -84,6 +86,8 @@ Buildkite can optionally send an HMAC signature in place of a webhook token.
 The `X-Buildkite-Signature` header contains a timestamp and an HMAC signature. The timestamp is prefixed by `timestamp=` and the signature is prefixed by `signature=`. 
 
 Buildkite generates the signature using HMAC-SHA256; a hash-based message authentication code [HMAC](https://en.wikipedia.org/wiki/HMAC) used with the [SHA-256](https://en.wikipedia.org/wiki/SHA-2) hash function and a secret key. The webhook token value is used as the secret key. The timestamp is an integer representation of a UTC timestamp.
+
+The token value and header setting can be found under _Token_ in your _Webhook Notification service_.
 
 ### Verifying HMAC signatures
 


### PR DESCRIPTION
I was writing the changelog for HMAC this evening and thought that we needed some more info in the docs section. 

In this PR I have:
- Split out the HTTP Headers table into two sections so that I could add an intro to say that token and signature are an either/or deal
- Capitalised the title and fixed some formatting in the note block of HTTP Request body
- Added a section for webhook tokens so that I could mention that they're passed in clear text
- Renamed the verifying signatures section to the broader 'Webhook Signature'
- Reformatted/expanded/simplified the intro paragraphs about signatures
- Add info about where to find the signature/token settings in the BK UI
- Added a new subheading for the info about verifying signatures
- Added a text description of the steps to verify that isn't programming language-dependent
- Renamed the replay attack section to be more vague (less 'this will prevent attacks', more 'this can help')
- Reformatted/simplified the replay attack section

It might be worth adding some comments to the ruby code sample too, I might get to that tomorrow.

@plaindocs I'm keen to get the changelog out tomorrow, would you be able to have a quick squiz at these changes please?😊 🙇🏻‍♀️