### PR TITLE
State that step-level env variables override pipeline-level values

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -682,7 +682,7 @@ There are two places in a pipeline.yml file that you can set environment variabl
 Defining an environment variable at the top of your yaml file will set that variable on each of the command steps in the pipeline, and is equivalent to setting the `env` attribute on every step.
 
 <div class="Docs__note">
-  <p>Top level pipeline environment variables will override what is set in the <code>env</code> attribute of an individual step.</p>
+  <p>Individual step environment variables will override what is set in the top level pipeline <code>env</code> attribute.</p>
 </div>
 
 #### Setting variables in a Trigger step


### PR DESCRIPTION
This PR updates the note regarding the environment variables overriding behavior in the documentation to reflect the behavior experienced in production.

## Details

This pipeline:

```yml
env:
  GLOBAL: global value we don't try to override
  GLOBAL_OVERRIDE: if you read this, then the global value takes precendence

steps:
  - label: "Test for env variables resolution"
    command: |
      echo "GLOBAL = $$GLOBAL"
      echo "GLOBAL_OVERRIDE = $$GLOBAL_OVERRIDE"
      echo "LOCAL = $$LOCAL"
    env:
      LOCAL: local value
      GLOBAL_OVERRIDE: if you read this, then the global value was overridden by the local one
```

Results in this output:

```
GLOBAL = global value we don't try to override
GLOBAL_OVERRIDE = if you read this, then the global value was overridden by the local one
LOCAL = local value
```

That is, the value for `GLOBAL_OVERRIDE` set in the step `env` node takes precedence over the value set in the `env` node in the pipeline root.

You can verify the behavior in action [here](https://github.com/Automattic/ScreenObject/pull/7).

## Rationale

I opened a PR directly, rather than going through an issue first, because the behavior I see in production is what I would expect from a hierarchical configuration system and I'm guessing the docs are either out of date or wrong.

It's possible my expectation is incorrect, in which case this PR should be closed and a fix should be issued in the way the agent (?) resolves the variables hierarchy.

## Next Steps

I've checked the "Allow edits by maintainers" option, so you can take this over and reword my phrasing if needed.

---

Thanks! I love Buildkite ❤️ 