### PR TITLE
Improve link styles

### DIFF
--- a/app/assets/stylesheets/public/_variables.scss
+++ b/app/assets/stylesheets/public/_variables.scss
@@ -1,3 +1,4 @@
 $font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Helvetica, sans-serif;
 $text-on-dark-subdued-opacity: .8;
 $text-on-dark-very-subdued-opacity: .7;
+$color-brand-green: rgb(2, 129, 76);

--- a/app/assets/stylesheets/public/utils/_link.scss
+++ b/app/assets/stylesheets/public/utils/_link.scss
@@ -6,14 +6,13 @@
 .Link--no-underline {
   @extend .Link;
   text-decoration: none;
-  &:hover, &:active, &:focus { text-decoration: underline; }
+  &:hover, &:active, &:focus { color: $color-brand-green; }
 }
 
 .Link--on-white {
   @extend .Link;
   color: rgba(black, $text-on-dark-subdued-opacity);
-  font-weight: 700;
-  &:hover, &:active, &:focus { color: black; }
+  &:hover, &:active, &:focus { color: $color-brand-green; }
 }
 
 .Link--faded-on-white {

--- a/app/assets/stylesheets/public/utils/_text_content.scss
+++ b/app/assets/stylesheets/public/utils/_text_content.scss
@@ -7,8 +7,14 @@
   ol > li { list-style: decimal; }
   li li { margin-left: 1em; }
   hr { border: none; border-bottom: 1px solid #ddd; }
-  a { @extend .Link--on-white; @extend .Link--no-underline; }
-  code { font-family: "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", Courier, monospace; font-size: #{(16/18)}em; line-height: 1.5; }
+  a {
+    @extend .Link--on-white;
+  }
+  code { font-family: "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", Courier, monospace; }
+  pre code {
+    font-size: #{(16/18)}em;
+    line-height: 1.5;
+  }
   em { font-style: italic; }
   strong { font-weight: 600; }
   pre {
@@ -31,8 +37,10 @@
     border: 1px solid #ddd;
   }
   p { max-width: 37em; }
-  li, p, dt, td, th {
-    > code { border: 1px solid #ddd; font-size: 85%; padding: .1em .25em; }
+  li, p, dt, td, th, a {
+    > code {
+      font-size: #{(16/18)}em;
+    }
   }
   table {
     font-size: #{(16/18)}rem;

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -48,7 +48,7 @@ class Page::Renderer
     end
 
     def codespan(code)
-      %{<code class="dark-gray border border-gray rounded" style="padding: .1em .25em; font-size: 85%">#{EscapeUtils.escape_html(code)}</code>}
+      %{<code>#{EscapeUtils.escape_html(code)}</code>}
     end
   end
 


### PR DESCRIPTION
The links in the app were imported from Buildkite app in 2019 and
haven't been updated since.

We had an issue with `code` that are links or part of link text looking
odd or not consistently like a link. This commit re-styles links across
the whole site (!) but makes them consistent, including those with
`code`.

## `code` screenshots
<img width="526" alt="Screen Shot 2021-08-30 at 17 10 05" src="https://user-images.githubusercontent.com/3682/131306933-a650f27c-ad00-4e12-8dfe-aa05e702afeb.png">

<img width="778" alt="Screen Shot 2021-08-30 at 17 10 33" src="https://user-images.githubusercontent.com/3682/131306939-6eed1811-f79e-4942-b884-71d15fcbbcd5.png">


## side-effects
The main side-effect of these changes is that all links now have underlines. Except the sidebar menu links. These now highlight with the brand green for consistency. If any of this is a step too far, please let me know!

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/3682/131307883-9cf22de7-cbb3-43df-8032-fbcac46540c0.png">




