### PR TITLE
Update table styling for more flexibility

### DIFF
--- a/app/assets/stylesheets/public/utils/_text_content.scss
+++ b/app/assets/stylesheets/public/utils/_text_content.scss
@@ -52,6 +52,23 @@
   th, td { padding: .5rem; }
   th { font-weight: inherit; color: currentColor; text-align: left; font-weight: 700; }
   th code { white-space: nowrap; font-weight: normal; }
+  table.two-column {
+    td {
+      border: none;
+    }
+
+    th:first-of-type,
+    td:first-of-type {
+      border-right: 1px solid #ddd;
+    }
+  }
+
+  table.no-formatting {
+    th,
+    td {
+      border: none;
+    }
+  }
 
   blockquote { padding-left: 1em; border-left: 5px solid #8E8E8E; }
 

--- a/pages/pipelines/defining_steps.md.erb
+++ b/pages/pipelines/defining_steps.md.erb
@@ -119,7 +119,7 @@ can progress to `skipped`  | can progress to `canceling` or `canceled`
 `limited`                  | `blocked`
 `accepted`                 | `unblocked`
 `broken`                   |
-{: class="no-formatting"}
+{: class="two-column"}
 
 Differentiating between `broken`, `skipped` and `canceled` states:
 


### PR DESCRIPTION
## Tables without borders now work with the class `no-formatting`.
<img width="713" alt="Screen Shot 2021-08-31 at 16 05 55" src="https://user-images.githubusercontent.com/3682/131451555-33b58491-88e4-4ace-bffd-48658e5fba97.png">

## Tables can now look like two columns with the class `two-columns`.
<img width="700" alt="Screen Shot 2021-08-31 at 16 06 10" src="https://user-images.githubusercontent.com/3682/131451577-02a8691b-1a43-46d2-aad9-6420484865a6.png">
