### PR TITLE
Update list styling to make columns possible

### DIFF
--- a/app/assets/stylesheets/public/utils/_text_content.scss
+++ b/app/assets/stylesheets/public/utils/_text_content.scss
@@ -5,6 +5,29 @@
   li { margin: 0.5em 0 0.5em 2em; }
   ul > li { list-style: disc; }
   ol > li { list-style: decimal; }
+
+  .two-column-list {
+    display: grid;
+    grid-gap: 1em;
+    grid-template-columns: repeat(2, 1fr);
+    width: max-content;
+    > li {
+      margin: 0 1em 0 1em;
+    }
+
+    @media (max-width: 500px) {
+      display: block;
+      > li {
+        margin: 0 0 0.5em 1em;
+      }
+    }
+  }
+
+  .three-column-list {
+    @extend .two-column-list;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
   li li { margin-left: 1em; }
   hr { border: none; border-bottom: 1px solid #ddd; }
   a {


### PR DESCRIPTION
Sometimes we want to make lists more compact by spreading them out in
columns. On small screens (<500px) these will revert to a single column.

Technically this is just a class and so could be used on any element. It'll apply a basic columnar CSS Grid.

These examples are just for the screenshots, I didn't actually commit the addition of these classes to this list:
## List with the class `two-column-list`.
<img width="863" alt="Screen Shot 2021-09-01 at 14 48 14" src="https://user-images.githubusercontent.com/3682/131614150-b3783c24-ea8e-40c3-97e0-49cf80ba19ae.png">

## List with the class `three-column-list`.
<img width="769" alt="Screen Shot 2021-09-01 at 14 47 43" src="https://user-images.githubusercontent.com/3682/131614137-a129a750-1a08-4e6d-b2be-06564d19d954.png">

## Either list on a viewport of less than 500px
<img width="409" alt="Screen Shot 2021-09-01 at 14 47 03" src="https://user-images.githubusercontent.com/3682/131614095-b9fb3aae-919b-43d6-b7c1-292605d7f4b6.png">
