### PR TITLE
Small PagerDuty Change Events integration link improvements

### DIFF
--- a/pages/integrations/pagerduty.md.erb
+++ b/pages/integrations/pagerduty.md.erb
@@ -1,6 +1,6 @@
 # PagerDuty
 
-The [PagerDuty](http://pagerduty.com/) integration in Buildkite can send [change events](https://developer.pagerduty.com/docs/events-api-v2/send-change-events/) to PagerDuty when your builds finish.
+The [PagerDuty](http://pagerduty.com/) integration in Buildkite can send [Change Events](https://support.pagerduty.com/docs/change-events) to PagerDuty when your builds finish.
 
 <%= image "overview.png", width: 2202/2, height: 638/2, alt: "Screenshot of the recent events in PagerDuty" %>
 
@@ -60,4 +60,4 @@ notify:
 ```
 
 ## Support
-For those of you coming from [pagerduty.com](https://pagerduty.com) looking for assistance on this integration please reach out to us at hello@buildkite.com.
+For those of you coming from [pagerduty.com](https://pagerduty.com) looking for assistance on this integration please reach out to us at [support@buildkite.com](mailto:support@buildkite.com?subject=PagerDuty%20Change%20Events%20Integration).


### PR DESCRIPTION
Now that PagerDuty have [nicer Change Events docs](https://support.pagerduty.com/docs/change-events) we should link to it, so this updates our integration guide to use that, as well as updating our support email address.