### PR TITLE
increase the CPU and memory we have available on ECS/Fargate

### DIFF
--- a/deploy/task-definition-template.json
+++ b/deploy/task-definition-template.json
@@ -63,6 +63,6 @@
   "requiresCompatibilities": [
     "FARGATE"
   ],
-  "cpu": "512",
-  "memory": "1024"
+  "cpu": "1024",
+  "memory": "2048"
 }


### PR DESCRIPTION
I've noticed the steady state for the docs Fargate tasks has memory utilization on ~95%. That seems a little close to the wire, so I've doubled the available memory.

CPU utilization is mostly OK,  but we do get occasional spikes up nearly 100%. Docs are important, I reckon it's reasonable to give them a full core to work with in each task.

![Screenshot from 2021-09-09 21-41-05](https://user-images.githubusercontent.com/8132/132679426-31fd2b23-fd12-4533-9d97-75e7e2094544.png)

![Screenshot from 2021-09-09 21-41-54](https://user-images.githubusercontent.com/8132/132679536-57e095e5-5faa-4f66-9db8-d0564ab45935.png)
