### PR TITLE
Remove the "in-progress" note from Okta SSO

### DIFF
--- a/pages/integrations/sso/okta.md.erb
+++ b/pages/integrations/sso/okta.md.erb
@@ -2,13 +2,11 @@
 
 To add Okta as an SSO provider for your Buildkite organization, you need admin privileges for both Okta and Buildkite.
 
+## Setting up SSO with SAML
+
 To set up Single Sign-On, follow the [SAML configuration guide](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Buildkite.html).
 
 ## Using SCIM to provision and manage users
-
-<div class="Docs__note">
-  <p>This integration with Okta is currently available only to a limited number of customers. Contact support@buildkite.com to learn more.</p>
-</div>
 
 ### Supported SCIM Features
 


### PR DESCRIPTION
The Okta SSO code stuffs are ready to be announced and our "in-progress" note on the guide can be removed 🎉 I've also popped an extra heading in there so that the SAML part of it is a bit more noticable.