### PR TITLE
Add words about enterprise-only to SCIM guides

### DIFF
--- a/pages/integrations/sso/azure_ad.md.erb
+++ b/pages/integrations/sso/azure_ad.md.erb
@@ -61,11 +61,7 @@ Once you've [performed a test login](#step-4-perform-a-test-login) you can enabl
 
 ## Using SCIM to provision and manage users
 
-Using the SCIM provisioning settings in Azure AD, Buildkite Enterprise customers can automatically add and remove user accounts from their Buildkite organization.
-
-<div class="Docs__note">
-  <p>This integration with Azure AD is currently available only to a limited number of customers. Contact support@buildkite.com to learn more.</p>
-</div>
+Enterprise customers can automatically add and remove user accounts from their Buildkite organization using the SCIM provisioning settings in Azure AD.
 
 ### Supported SCIM Features
 

--- a/pages/integrations/sso/okta.md.erb
+++ b/pages/integrations/sso/okta.md.erb
@@ -8,10 +8,16 @@ To set up Single Sign-On, follow the [SAML configuration guide](https://saml-doc
 
 ## Using SCIM to provision and manage users
 
+Enterprise customers can optionally enable automatic deprovisioning for their Buildkite users.
+
 ### Supported SCIM Features
 
-* Create Users (note that users added to Okta won't be billed for until they have signed up with Buildkite)
+* Create Users
 * Deactivate Users (Deprovisioning)
+
+<div class="Docs__note">
+  <p>You will not be billed for users that you add to your Okta Buildkite app until they have signed in to you Buildkite organization.</p>
+</div>
 
 ### Configuration instructions
 


### PR DESCRIPTION
Adding/updating the words about the Enterprise account gating for the SCIM providers - Okta and AzureAD.

I've also moved the note under the Okta Supported Features into its own note block.