### PR TITLE
Tidying up nested lists for uniform styling and whitespace

### DIFF
--- a/app/assets/stylesheets/public/utils/_text_content.scss
+++ b/app/assets/stylesheets/public/utils/_text_content.scss
@@ -2,9 +2,26 @@
   line-height: 1.3;
   h2, h3, h4, blockquote, pre, p { margin: 1em 0; }
   h2 { font-size: #{(24/18)}rem; margin-top: 1.5em; }
-  li { margin: 0.5em 0 0.5em 2em; }
-  ul > li { list-style: disc; }
-  ol > li { list-style: decimal; }
+  li { margin: 0.5em 0 0.5em 1.8em; }
+  ol > li {
+    list-style: decimal;
+
+    ol > li {
+      list-style: lower-alpha;
+
+      ol > li {
+        list-style: lower-roman;
+        margin-left: 2em;
+      }
+    }
+  }
+
+  ul li {
+    list-style: disc;
+    margin-left: 1em;
+  }
+  li ul,
+  li p { margin-bottom: 0.5em; }
 
   .two-column-list {
     display: grid;
@@ -28,7 +45,6 @@
     grid-template-columns: repeat(3, 1fr);
   }
 
-  li li { margin-left: 1em; }
   hr { border: none; border-bottom: 1px solid #ddd; }
   a {
     @extend .Link--on-white;


### PR DESCRIPTION
Nested ordered lists in Markdown weren't numbered. And the whitespace was inconsistent beween ordered and unordered lists when nesting. This PR corrects both.

Mobile list styles are unaffected (as in they're consistent with these changes).

## Page showing the changes for `ol`, `ul`, `li`, and for `p` and `ul` inside lists (with faked third-level ordered nesting so you can see it)
![Screenshot 2021-09-20 at 23-15-52 Single Sign-On with Azure Active Directory (Azure AD)](https://user-images.githubusercontent.com/3682/134009268-4d43f96e-2d71-4101-bb5c-644897e27fe4.png)

## Page showing `ul` nested in `ul`
![AWS-secrets-manager](https://user-images.githubusercontent.com/3682/133881562-fd8700ab-2e5b-4a7c-b134-94f401a6d4fd.png)


