### PR TITLE
BUILDKITE_ARTIFACT_UPLOAD_DESTINATION example path more structured.

### DIFF
--- a/pages/agent/v2/cli_artifact.md.erb
+++ b/pages/agent/v2/cli_artifact.md.erb
@@ -251,7 +251,7 @@ Options:
 You can use the `buildkite-agent artifact` command to store artifacts in your own private Amazon S3 bucket. To do so, you’ll need to export the following environment variables using an [environment hook](/docs/agent/v2/hooks) (this can not be set via the Buildkite web interface, API, or during pipeline upload):
 
 ```bash
-export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID"
+export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="s3://name-of-your-s3-bucket/$BUILDKITE_PIPELINE_ID/$BUILDKITE_BUILD_ID/$BUILDKITE_JOB_ID"
 export BUILDKITE_S3_DEFAULT_REGION="eu-central-1" # default: us-east-1
 ```
 

--- a/pages/agent/v2/gcloud.md.erb
+++ b/pages/agent/v2/gcloud.md.erb
@@ -229,7 +229,7 @@ See [our Docker setup instructions](/docs/agent/v2/docker) for more details on c
 You can upload the [artifacts](/docs/builds/artifacts) created by your builds to your own [Google Cloud Storage](https://cloud.google.com/storage) bucket. Configure the agent to target your bucket by exporting the following environment variables using an [environment agent hook](/docs/agent/v2/hooks) (this can not be set via the Buildkite web interface, API, or during pipeline upload):
 
 ```shell
-export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="gs://my-bucket/$BUILDKITE_JOB_ID"
+export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="gs://my-bucket/$BUILDKITE_PIPELINE_ID/$BUILDKITE_BUILD_ID/$BUILDKITE_JOB_ID"
 ```
 
 Make sure the agent has permission to create new objects. If running on Google Compute Engine or Google Container Engine you can grant Storage Write permission to the instance or cluster, or restrict access more specifically using [a service account](https://cloud.google.com/compute/docs/access/service-accounts).

--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -155,7 +155,7 @@ your [agent `hooks-path` directory](/docs/agent/v3/hooks#hook-locations-agent-ho
 ensures they are applied to all jobs:
 
 ```bash
-export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID"
+export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="s3://name-of-your-s3-bucket/$BUILDKITE_PIPELINE_ID/$BUILDKITE_BUILD_ID/$BUILDKITE_JOB_ID"
 export BUILDKITE_S3_DEFAULT_REGION="eu-central-1" # default: us-east-1
 ```
 

--- a/pages/agent/v3/gcloud.md.erb
+++ b/pages/agent/v3/gcloud.md.erb
@@ -246,7 +246,7 @@ See [our Docker setup instructions](/docs/agent/v3/docker) for more details on c
 You can upload the [artifacts](/docs/builds/artifacts) created by your builds to your own [Google Cloud Storage](https://cloud.google.com/storage) bucket. Configure the agent to target your bucket by exporting the following environment variables using an [environment agent hook](/docs/agent/v3/hooks) (this can not be set via the Buildkite web interface, API, or during pipeline upload):
 
 ```shell
-export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="gs://my-bucket/$BUILDKITE_JOB_ID"
+export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="gs://my-bucket/$BUILDKITE_PIPELINE_ID/$BUILDKITE_BUILD_ID/$BUILDKITE_JOB_ID"
 ```
 
 Make sure the agent has permission to create new objects. If the agent is running on Google Compute Engine or Google Container Engine you can grant Storage Write permission to the instance or cluster, or restrict access more specifically using [a service account](https://cloud.google.com/compute/docs/access/service-accounts).

--- a/pages/agent/v3/help/_bootstrap.md
+++ b/pages/agent/v3/help/_bootstrap.md
@@ -41,7 +41,7 @@ See https://buildkite.com/docs/agent/v3/hooks for more details.
 * `--pipeline value` - The slug of the pipeline that the job is a part of [`$BUILDKITE_PIPELINE_SLUG`]
 * `--pipeline-provider value` - The id of the SCM provider that the repository is hosted on [`$BUILDKITE_PIPELINE_PROVIDER`]
 * `--artifact-upload-paths value` - Paths to files to automatically upload at the end of a job [`$BUILDKITE_ARTIFACT_PATHS`]
-* `--artifact-upload-destination value` - A custom location to upload artifact paths to (i.e. s3://my-custom-bucket) [`$BUILDKITE_ARTIFACT_UPLOAD_DESTINATION`]
+* `--artifact-upload-destination value` - A custom location to upload artifact paths to (i.e. s3://my-custom-bucket/and/prefix) [`$BUILDKITE_ARTIFACT_UPLOAD_DESTINATION`]
 * `--clean-checkout` - Whether or not the bootstrap should remove the existing repository before running the command [`$BUILDKITE_CLEAN_CHECKOUT`]
 * `--git-clone-flags value` - Flags to pass to "git clone" command (default: "-v") [`$BUILDKITE_GIT_CLONE_FLAGS`]
 * `--git-clone-mirror-flags value` - Flags to pass to "git clone" command when mirroring (default: "-v") [`$BUILDKITE_GIT_CLONE_MIRROR_FLAGS`]

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -80,7 +80,7 @@ Example: `"tmp/capybara/**/*;coverage/**/*"`
 
 The path where artifacts will be uploaded. This variable is read by the `buildkite-agent artifact upload` command, and during the artifact upload phase of [command steps](/docs/pipelines/command-step#command-step-attributes). It can only be set by exporting the environment variable in the `environment`, `pre-checkout` or `pre-command` hooks.
 
-Example: `"s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID"`
+Example: `"s3://name-of-your-s3-bucket/$BUILDKITE_PIPELINE_ID/$BUILDKITE_BUILD_ID/$BUILDKITE_JOB_ID"`
 
 <h3 class="h3-caps">BUILDKITE_BIN_PATH</h3>
 


### PR DESCRIPTION
We previously recommended (by way of example) `/$BUILDKITE_JOB_ID` as the prefix within the customer-hosted artifact bucket, which means a top-level prefix is created for each job, with the artifact files therein.

For Buildkite-hosted storage, we nest jobs inside builds inside pipelines inside organizations. This makes the bucket far easier to navigate, which becomes important when (a) there's millions of objects, and (b) everything is an opaque UUID.

This PR changes the documentation to recommend a similar hierarchy to the one we use on our end, but without the top-level Organization, which is omitted mostly because that environment variable doesn't exist in jobs, so can't be used by a hook:

```sh
/$BUILDKITE_PIPELINE_ID/$BUILDKITE_BUILD_ID/$BUILDKITE_JOB_ID
```

As a result, customers will be able to use Pipeline and Build as means to navigate / query / maintain their bucket, e.g. setting pipeline-specific lifecycle policies.