### PR TITLE
Replace i.e. with e.g. in most cases

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,7 +13,7 @@ class PagesController < ApplicationController
 
     # For the homepage, render with a custom layout that doesn't include the sidebar etc
 
-    # If there's another more correct version of the URL (i.e. we changed `_`
+    # If there's another more correct version of the URL (e.g. we changed `_`
     # to `-`), then redirect them to where they should be.
     unless @page.is_canonical?
       redirect_to "/docs/#{@page.canonical_url}", status: :moved_permanently

--- a/pages/agent/v2/osx.md.erb
+++ b/pages/agent/v2/osx.md.erb
@@ -27,7 +27,7 @@ If you don't use Homebrew you should follow the [Linux](/docs/agent/v2/linux) in
 
 ## SSH Key Configuration
 
-SSH keys should be copied to (or generated into) the `.ssh` directory in the users’s home directory (i.e. `/Users/some-user/.ssh`). For example, to generate a new private key which you can add to your source code host:
+SSH keys should be copied to (or generated into) the `.ssh` directory in the users’s home directory (e.g. `/Users/alice/.ssh`). For example, to generate a new private key which you can add to your source code host:
 
 ```bash
 $ mkdir -p ~/.ssh && cd ~/.ssh

--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -271,7 +271,7 @@ An example of how to set this up:
 
 1. Create a Docker Hub repository for pushing images to
 1. Update the pipeline’s `env` hook in your secrets bucket to perform a `docker login`
-1. Create a builder stack with its own queue (i.e. `elastic-builders`)
+1. Create a builder stack with its own queue (e.g. `elastic-builders`)
 
 Here is an example build pipeline based on a production Rails application:
 

--- a/pages/agent/v3/help/_bootstrap.md
+++ b/pages/agent/v3/help/_bootstrap.md
@@ -41,7 +41,7 @@ See https://buildkite.com/docs/agent/v3/hooks for more details.
 * `--pipeline value` - The slug of the pipeline that the job is a part of [`$BUILDKITE_PIPELINE_SLUG`]
 * `--pipeline-provider value` - The id of the SCM provider that the repository is hosted on [`$BUILDKITE_PIPELINE_PROVIDER`]
 * `--artifact-upload-paths value` - Paths to files to automatically upload at the end of a job [`$BUILDKITE_ARTIFACT_PATHS`]
-* `--artifact-upload-destination value` - A custom location to upload artifact paths to (i.e. s3://my-custom-bucket) [`$BUILDKITE_ARTIFACT_UPLOAD_DESTINATION`]
+* `--artifact-upload-destination value` - A custom location to upload artifact paths to (e.g. s3://my-custom-bucket) [`$BUILDKITE_ARTIFACT_UPLOAD_DESTINATION`]
 * `--clean-checkout` - Whether or not the bootstrap should remove the existing repository before running the command [`$BUILDKITE_CLEAN_CHECKOUT`]
 * `--git-clone-flags value` - Flags to pass to "git clone" command (default: "-v") [`$BUILDKITE_GIT_CLONE_FLAGS`]
 * `--git-clone-mirror-flags value` - Flags to pass to "git clone" command when mirroring (default: "-v") [`$BUILDKITE_GIT_CLONE_MIRROR_FLAGS`]

--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -22,7 +22,7 @@ If you don't use Homebrew you should follow the [Linux](/docs/agent/v3/linux) in
 
 ## SSH Key Configuration
 
-SSH keys should be copied to (or generated into) the `.ssh` directory in the users’s home directory (i.e. `/Users/some-user/.ssh`). For example, to generate a new private key which you can add to your source code host:
+SSH keys should be copied to (or generated into) the `.ssh` directory in the users’s home directory (e.g. `/Users/alice/.ssh`). For example, to generate a new private key which you can add to your source code host:
 
 ```bash
 $ mkdir -p ~/.ssh && cd ~/.ssh

--- a/pages/deployments/deploying_to_kubernetes.md.erb
+++ b/pages/deployments/deploying_to_kubernetes.md.erb
@@ -203,7 +203,7 @@ Kubernetes. Practically speaking there are some things to do next.
 - Try a [block step](https://buildkite.com/docs/pipelines/block-step) before the
   trigger to enforce manual deploys.
 - Use [Github's Deployment API](https://buildkite.com/blog/github-deployments)
-  to trigger deployments from external tooling (i.e. ChatOps)
+  to trigger deployments from external tooling (e.g. ChatOps)
 - Expose the application to the internet with [Kubernetes
   Service](https://kubernetes.io/docs/concepts/services-networking/service/).
 - Replace the `envsubst` implementation with something like [kustomize](https://kustomize.io/)

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -695,7 +695,7 @@ Separate to the job's base environment, your `buildkite-agent` process has an en
 
 - operating system environment variables
 - any variables you set on your agent when you started it
-- any environment variables that were inherited from how you started the process (i.e. systemd sets some env vars for you)
+- any environment variables that were inherited from how you started the process (e.g. systemd sets some env vars for you)
 
 For a list of variables and configuration flags you can set on your agent, see the Buildkite Agent’s [start command documentation](/docs/agent/v3/cli-start).
 


### PR DESCRIPTION
Most of our usage of “i.e.” is to give a specific example, not a generally applicable clarification or restatement in different words, so I believe “e.g.” would be more suitable.

I make no claims of being a grammar/writing expert, so please correct me if I'm wrong.