### PR TITLE
Tiny consistency fix

### DIFF
--- a/pages/tutorials/getting_started.md.erb
+++ b/pages/tutorials/getting_started.md.erb
@@ -42,7 +42,7 @@ Congratulations, you have run your first Buildkite build! :tada:
 
 To invite your team so they can see your build, go to your organization’s *Settings*, and under *Users* you’ll be able to paste in their email addresses.
 
-## Using a private repository
+## Use a private repository
 
 When you create a new pipeline with a private repository URL you’ll be shown instructions for configuring your SCM’s webhooks (in GitHub, Bitbucket, etc). Once you’ve followed those instructions make sure your [agent’s SSH keys](/docs/agent/v3/ssh-keys) are configured, and you’ll be good to run a build of your private pipeline.
 


### PR DESCRIPTION
Using a private repository --> Use a private repository
For consistency's sake (Install, Add, Invite, Use in headings).

This fix was supposed to be merged alongside the Enterprise description but goes solo while that one is on hold.