### PR TITLE
Fix sidebar highlight for new AWS pages

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -41,8 +41,8 @@
         <p class="Docs__nav__section-subheading">Elastic CI Stack for AWS</p>
         <ul class="Docs__nav__sub-nav">
           <%= sidebar_link_to "Running Elastic CI Stack", 'agent/v3/elastic-ci-aws' %>
-          <%= sidebar_link_to "CloudFormation Service Role", 'agent/v3/elastic_ci_aws/cloudformation_service_role.md' %>
-          <%= sidebar_link_to "Using AWS Secrets Manager", 'agent/v3/aws/secrets_manager.md' %>
+          <%= sidebar_link_to "CloudFormation Service Role", 'agent/v3/elastic-ci-aws/cloudformation-service-role' %>
+          <%= sidebar_link_to "Using AWS Secrets Manager", 'agent/v3/aws/secrets-manager' %>
         </ul>
         <p class="Docs__nav__section-subheading">Agent Installers</p>
         <ul class="Docs__nav__sub-nav">


### PR DESCRIPTION
The docs I’ve added for AWS aren’t highlighting in the sidebar when you navigate to this, this fixes the link paths so that they show up highlighted:
- CloudFormation service role
- AWS Secrets Manager