### PR TITLE
Clarify that `finished` is a querying shortcut, not a build state.

### DIFF
--- a/pages/pipelines/_build_states.md.erb
+++ b/pages/pipelines/_build_states.md.erb
@@ -1,2 +1,2 @@
 Build state can be one of `creating`, `scheduled`, `running`, `passed`, `failed`, `blocked`, `canceling`, `canceled`, `skipped`, `not_run`.
-You can query for `finished` for builds in one of the following states: `passed`, `failed`, `blocked`, or `canceled`.
+You can query for `finished` builds to return builds in any of the following states: `passed`, `failed`, `blocked`, or `canceled`.


### PR DESCRIPTION
I was looking to use the api to work with builds in particular states, but the presence of `"finished"` as a valid state was very confusing.