### PR TITLE
Remove timeout always causes a build to fail

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -165,7 +165,7 @@ _Optional attributes:_
   <tr>
     <td><code>soft_fail</code></td>
     <td>
-      Allow specified non-zero exit statuses not to fail the build. Note that a timeout always causes a build to fail.
+      Allow specified non-zero exit statuses not to fail the build.
       Can be either an array of allowed soft failure exit statuses or <code>true</code> to make all exit statuses soft-fail.<br>
       <em>Example:</em> <code>true</code><br>
       <em>Example:</em><br>
@@ -321,7 +321,7 @@ _Optional Attributes_
     <td><code>exit_status</code></td>
     <td>
       Allow specified non-zero exit statuses not to fail the build.
-      Note that a timeout always causes a build to fail. <br>
+      <br>
       <em>Example:</em> <code>"*"</code><br>
       <em>Example:</em> <code>1</code>
     </td>


### PR DESCRIPTION
A customer raised this last week, this is true for dependencies but not for command step timeouts.