### PR TITLE
Remove old caching issue link from Elastic CI Stack docs

### DIFF
--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -413,8 +413,6 @@ steps:
     parallelism: 75
 ```
 
-See [Issue 81](https://github.com/buildkite/elastic-ci-stack-for-aws/issues/81) for ideas on other solutions (contributions are welcome).  
-
 ## Further references  
 
 To gain a better understanding of how Elastic CI Stack works and how to use it most effectively and securely, check out the following resources:   


### PR DESCRIPTION
The issue is old and stale, and I don't believe it's helping anyone.

We could definitely help people with more production-ready examples for getting common frameworks (e.g. Rails) cached correctly and building fast on the Elastic CI Stack. But the issue doesn't help in the meantime.