### PR TITLE
Capitalization fix

### DIFF
--- a/pages/tutorials/elastic_ci_stack_aws.md.erb
+++ b/pages/tutorials/elastic_ci_stack_aws.md.erb
@@ -12,7 +12,7 @@ Most Elastic CI Stack features are supported on both Linux and Windows.
 the following AMIs can be built and deployed to all the supported regions:
 
 * Amazon Linux 2 (64-bit x86)
-* Amazon Linux 2 (64-bit Arm)
+* Amazon Linux 2 (64-bit ARM)
 * Windows Server 2019 (64-bit x86)
 
 See this [overview page](/docs/agent/v3/elastic-ci-aws) for extensive information on compatibility, configuration, security, and other topics that will allow you to effectively use Elastic CI Stack for AWS.


### PR DESCRIPTION
Should help "ARM" show up in the search 🤞.