### PR TITLE
Add instruction to disable the screen saver and system sleep

### DIFF
--- a/pages/agent/v3/aws.md.erb
+++ b/pages/agent/v3/aws.md.erb
@@ -61,6 +61,8 @@ can access the instance.
 	1. Sign in as the `ec2-user`
 	1. Enable *Automatic login* for the `ec2-user` in *System Preferences* > *Users & Accounts* > *Login Options*
 	1. Disable *Require password* in *System Preferences* > *Security & Privacy* > *General*
+	1. Set system sleep in *System Preferences* > *Energy Saver* > *Turn display off after* to *Never*
+	1. Disable the screen saver in *System Preferences* > *Desktop & Screen Saver* > *Show screen saver after*
 1. Follow the [macOS Installation Guide](/docs/agent/v3/macos#installation)
 instructions to install the Buildkite agent using Homebrew and configure
 starting on login.

--- a/pages/agent/v3/elastic_mac_aws/autoscaling_mac_metal.md.erb
+++ b/pages/agent/v3/elastic_mac_aws/autoscaling_mac_metal.md.erb
@@ -70,6 +70,7 @@ can access the instance.
 	1. Sign in as the `ec2-user`
 	1. Enable *Automatic login* for the `ec2-user` in *System Preferences* > *Users & Accounts* > *Login Options*
 	1. Disable *Require password* in *System Preferences* > *Security & Privacy* > *General*
+	1. Disable the screen saver in *System Preferences* > *Desktop & Screen Saver* > *Show screen saver after*
 1. Install your required version of Xcode, and ensure you launch Xcode at least
 once so you are presented with the EULA prompt.
 1. Using the AWS EC2 Console, create an AMI from your instance.


### PR DESCRIPTION
This was missing from the elastic-mac and non-elastic-mac docs. Disabling system sleep shouldn’t be required in elastic-mac with https://github.com/buildkite/elastic-mac-for-aws/pull/2.