### PR TITLE
Clarify AMIs don’t have to be built

### DIFF
--- a/pages/tutorials/elastic_ci_stack_aws.md.erb
+++ b/pages/tutorials/elastic_ci_stack_aws.md.erb
@@ -9,7 +9,7 @@ The [Elastic CI Stack for AWS](https://github.com/buildkite/elastic-ci-stack-for
 ## Prerequisites and requirements  
  
 Most Elastic CI Stack features are supported on both Linux and Windows.
-the following AMIs can be built and deployed to all the supported regions:
+The following AMIs are available in all the supported regions:
 
 * Amazon Linux 2 (64-bit x86)
 * Amazon Linux 2 (64-bit ARM)


### PR DESCRIPTION
We build these AMI and mark them as public for customers to boot instances with.