### PR TITLE
Add documentation for quirks when building tags

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -163,6 +163,7 @@ _Optional attributes:_
       <th><code>git-fetch-flags</code></th>
       <td>
         Flags to pass to the <code>git fetch</code> command.
+        Also check <a href="/docs/integrations/github#running-builds-on-tags">Running builds on tags</a> if you are triggering against a tag.
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"-v --prune"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_FETCH_FLAGS</code></p>
       </td>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -163,7 +163,7 @@ _Optional attributes:_
       <th><code>git-fetch-flags</code></th>
       <td>
         Flags to pass to the <code>git fetch</code> command.
-        Before running builds on tags, make sure your agent is <a href="/docs/integrations/github#running-builds-on-tags">fetching git tags</a> .
+        Before running builds on tags, make sure your agent is <a href="/docs/integrations/github#running-builds-on-git-tags">fetching git tags</a> .
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"-v --prune"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_FETCH_FLAGS</code></p>
       </td>

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -163,7 +163,7 @@ _Optional attributes:_
       <th><code>git-fetch-flags</code></th>
       <td>
         Flags to pass to the <code>git fetch</code> command.
-        Also check <a href="/docs/integrations/github#running-builds-on-tags">Running builds on tags</a> if you are triggering against a tag.
+        Before running builds on tags, make sure your agent is <a href="/docs/integrations/github#running-builds-on-tags">fetching git tags</a> .
         <p class="Docs__api-param-eg"><em>Default:</em> <code>"-v --prune"</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_GIT_FETCH_FLAGS</code></p>
       </td>

--- a/pages/apis/rest_api/builds.md.erb
+++ b/pages/apis/rest_api/builds.md.erb
@@ -410,7 +410,7 @@ Required [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>
-  <tr><th><code>commit</code></th><td>Ref, SHA or tag to be built.<br><em>Example:</em> <code>"HEAD"</code><br><em>Note:</em>Before running builds on tags, make sure your agent is <a href="/docs/integrations/github#running-builds-on-tags">fetching git tags</a> .
+  <tr><th><code>commit</code></th><td>Ref, SHA or tag to be built.<br><em>Example:</em> <code>"HEAD"</code><br><em>Note:</em>Before running builds on tags, make sure your agent is <a href="/docs/integrations/github#running-builds-on-git-tags">fetching git tags</a> .
 </td></tr>
   <tr><th><code>branch</code></th><td>Branch the commit belongs to. This allows you to take advantage of your pipeline and step-level branch filtering rules.<br><em>Example:</em> <code>"master"</code></td></tr>
 </tbody>

--- a/pages/apis/rest_api/builds.md.erb
+++ b/pages/apis/rest_api/builds.md.erb
@@ -410,7 +410,7 @@ Required [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>
-  <tr><th><code>commit</code></th><td>Ref, SHA or tag to be built.<br><em>Example:</em> <code>"HEAD"</code></td></tr>
+  <tr><th><code>commit</code></th><td>Ref, SHA or tag to be built.<br><em>Example:</em> <code>"HEAD"</code><br><em>Note:</em> Check <a href="/docs/integrations/github#running-builds-on-tags">Running builds on tags</a> if you are triggering against a tag</td></tr>
   <tr><th><code>branch</code></th><td>Branch the commit belongs to. This allows you to take advantage of your pipeline and step-level branch filtering rules.<br><em>Example:</em> <code>"master"</code></td></tr>
 </tbody>
 </table>

--- a/pages/apis/rest_api/builds.md.erb
+++ b/pages/apis/rest_api/builds.md.erb
@@ -410,7 +410,8 @@ Required [request body properties](/docs/api#request-body-properties):
 
 <table>
 <tbody>
-  <tr><th><code>commit</code></th><td>Ref, SHA or tag to be built.<br><em>Example:</em> <code>"HEAD"</code><br><em>Note:</em> Check <a href="/docs/integrations/github#running-builds-on-tags">Running builds on tags</a> if you are triggering against a tag</td></tr>
+  <tr><th><code>commit</code></th><td>Ref, SHA or tag to be built.<br><em>Example:</em> <code>"HEAD"</code><br><em>Note:</em>Before running builds on tags, make sure your agent is <a href="/docs/integrations/github#running-builds-on-tags">fetching git tags</a> .
+</td></tr>
   <tr><th><code>branch</code></th><td>Branch the commit belongs to. This allows you to take advantage of your pipeline and step-level branch filtering rules.<br><em>Example:</em> <code>"master"</code></td></tr>
 </tbody>
 </table>

--- a/pages/integrations/github.md.erb
+++ b/pages/integrations/github.md.erb
@@ -85,11 +85,11 @@ Optionally, select one or more of the following:
 
 If you want to run builds only on pull requests, set the _Branch Filter Pattern_ in the pipeline to a branch name that will never occur (such as "this-branch-will-never-occur"). Pull request builds ignore the _Branch Filter Pattern_, and all pushes to other branches that don't match the pattern are ignored.
 
-## Running builds on tags
+## Running builds on git tags
 
 To run builds for commit tags, edit the GitHub settings for your Buildkite pipeline and choose the _Build Tags_ checkbox.
 
-If you are triggering builds from the [API](/docs/apis/rest-api/builds#create-a-build) or a [schedule](/docs/pipelines/scheduled-builds), you will need to update your agent environment variable like so `BUILDKITE_GIT_FETCH_FLAGS="-v --prune --tags"` in order to fetch tags.
+Before triggering builds for git tags from the [API](/docs/apis/rest-api/builds#create-a-build) or a [scheduled build](/docs/pipelines/scheduled-builds), make sure your agent is configured to fetch git tags: `BUILDKITE_GIT_FETCH_FLAGS="-v --prune --tags"`.
 
 ## Noreply email handling
 

--- a/pages/integrations/github.md.erb
+++ b/pages/integrations/github.md.erb
@@ -85,6 +85,12 @@ Optionally, select one or more of the following:
 
 If you want to run builds only on pull requests, set the _Branch Filter Pattern_ in the pipeline to a branch name that will never occur (such as "this-branch-will-never-occur"). Pull request builds ignore the _Branch Filter Pattern_, and all pushes to other branches that don't match the pattern are ignored.
 
+## Running builds on tags
+
+To run builds for commit tags, edit the GitHub settings for your Buildkite pipeline and choose the _Build Tags_ checkbox.
+
+If you are triggering builds from the [API](/docs/apis/rest-api/builds#create-a-build) or a [schedule](/docs/pipelines/scheduled-builds), you will need to update your agent environment variable like so `BUILDKITE_GIT_FETCH_FLAGS="-v --prune --tags"` in order to fetch tags.
+
 ## Noreply email handling
 
 When you [connect your GitHub account to Buildkite](#connecting-buildkite-and-github) the email address associated with the GitHub account is added to your Buildkite account. If you've got GitHub set not to display your email, `[username]@users.noreply.github.com` or the more recent `[username+id]@users.noreply.github.com` is added instead. The email address of a commit is one of the ways Buildkite matches webhook builds to users.


### PR DESCRIPTION
This adds a section about a quirk when triggering builds against tags through the API or a schedule (anything but a webhook from GitHub).

The section looks like:
![2021-11-12_09:57:18](https://user-images.githubusercontent.com/6128798/141395696-2aa89830-21d8-4095-9688-981558e3a9dc.png)

I also updated the agent configuration page in the `BUILDKITE_GIT_FETCH_FLAGS` section to link to this page and the same from the API page for creating a build section