### PR TITLE
Update running multiple agents on MacOS

### DIFF
--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -86,7 +86,7 @@ tail -f ~/.buildkite-agent/log/buildkite-agent.log
 
 Launching and managing multiple agents can be done using `launchd`.
 
-If you need the same configuration on each agent, configure a `launchd` service to use the `--spawn` flag on the `buildkite-agent` command.
+If you need the same configuration on each agent, configure a `launchd` service to use the `--spawn` flag on the `buildkite-agent` command or you can configure this in the buildkite-agent.cfg file.
 
 Using the existing agent `plist`, add the spawn flag to the `ProgramArguments` and change the number to how many agents you want to run.
 

--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -86,7 +86,7 @@ tail -f ~/.buildkite-agent/log/buildkite-agent.log
 
 Launching and managing multiple agents can be done using `launchd`.
 
-If you need the same configuration on each agent, configure a `launchd` service to use the `--spawn` flag on the `buildkite-agent` command or you can configure this in the buildkite-agent.cfg file.
+If you need the same configuration on each agent, either configure the `launchd` service to use the [`--spawn` flag](/docs/agent/v3/cli-start#options) on the `buildkite-agent`, or the [`spawn` setting](/docs/agent/v3/configuration#spawn)` in the `buildkite-agent.cfg` file.
 
 Using the existing agent `plist`, add the spawn flag to the `ProgramArguments` and change the number to how many agents you want to run.
 

--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -86,7 +86,7 @@ tail -f ~/.buildkite-agent/log/buildkite-agent.log
 
 Launching and managing multiple agents can be done using `launchd`.
 
-If you need the same configuration on each agent, either configure the `launchd` service to use the [`--spawn` flag](/docs/agent/v3/cli-start#options) on the `buildkite-agent`, or the [`spawn` setting](/docs/agent/v3/configuration#spawn)` in the `buildkite-agent.cfg` file.
+If you need the same configuration on each agent, either configure the `launchd` service to use the [`--spawn` flag](/docs/agent/v3/cli-start#options) on the `buildkite-agent`, or the [`spawn` setting](/docs/agent/v3/configuration#spawn) in the `buildkite-agent.cfg` file.
 
 Using the existing agent `plist`, add the spawn flag to the `ProgramArguments` and change the number to how many agents you want to run.
 


### PR DESCRIPTION
Add option of using `buildkite-agent.cfg` file to launch multiple agents on MacOS (already mentioned for the others SO).

![mac](https://user-images.githubusercontent.com/6607375/141598797-ef0dabb0-5d71-49ec-ba14-4f220350249a.png)
