### PR TITLE
Add link to GraphQL cookbook from GraphQL overview page

### DIFF
--- a/pages/apis/graphql_api.md.erb
+++ b/pages/apis/graphql_api.md.erb
@@ -121,5 +121,5 @@ The Buildkite GraphQL API adheres to the [Relay Specification](https://relay.dev
 Further resources for learning more about GraphQL:
 
 * Our [Getting Started with GraphQL Queries and Mutations](https://buildkite.com/blog/getting-started-with-graphql-queries-and-mutations) tutorial
-* Our [GraphQL API Cookbook](/docs/apis/graphql/graphql_cookbook) page full of common queries and mutations
+* Our [GraphQL API Cookbook](/docs/apis/graphql/graphql-cookbook) page full of common queries and mutations
 * [graphql.org/learn](https://graphql.org/learn/) — The Learn section of the official GraphQL website

--- a/pages/apis/graphql_api.md.erb
+++ b/pages/apis/graphql_api.md.erb
@@ -121,4 +121,5 @@ The Buildkite GraphQL API adheres to the [Relay Specification](https://relay.dev
 Further resources for learning more about GraphQL:
 
 * Our [Getting Started with GraphQL Queries and Mutations](https://buildkite.com/blog/getting-started-with-graphql-queries-and-mutations) tutorial
+* Our [GraphQL API Cookbook](/docs/apis/graphql/graphql_cookbook) page full of common queries and mutations
 * [graphql.org/learn](https://graphql.org/learn/) — The Learn section of the official GraphQL website


### PR DESCRIPTION
This adds a link to the cookbook from the overview page.

Something weird is happening when I try build and test this - even though it just worked last week. I'll try get back to that to figure it out soon