### PR TITLE
Added about 'Supported variables' for 'if' attribute

### DIFF
--- a/pages/pipelines/notifications.md.erb
+++ b/pages/pipelines/notifications.md.erb
@@ -38,7 +38,7 @@ notify:
 ```
 {: codeblock-file="pipeline.yml"}
 
-See [Build States](#build-states) for possible values for the build state.
+See [Supported Variables](/docs/pipelines/conditionals#supported-variables) for more conditional variables that can be used in `if` attribute.
 
 <section class="Docs__troubleshooting-note">
   <p>To trigger conditional notifications to a Slack channel, you will first need to configure <a href="/docs/integrations/slack#conditional-notifications">Conditional notifications for Slack</a>.
@@ -251,7 +251,7 @@ notify:
 ```
 {: codeblock-file="pipeline.yml"}
 
-See [Build States](#build-states) for possible values for the build state.
+See [Supported Variables](/docs/pipelines/conditionals#supported-variables) for more conditional variables that can be used in `if` attribute.
 
 Slack notifications happen at the following [event](/docs/apis/webhooks#events):
 

--- a/pages/pipelines/notifications.md.erb
+++ b/pages/pipelines/notifications.md.erb
@@ -38,7 +38,7 @@ notify:
 ```
 {: codeblock-file="pipeline.yml"}
 
-See [Supported Variables](/docs/pipelines/conditionals#supported-variables) for more conditional variables that can be used in `if` attribute.
+See [Supported Variables](/docs/pipelines/conditionals#supported-variables) for more conditional variables that can be used in the `if` attribute.
 
 <section class="Docs__troubleshooting-note">
   <p>To trigger conditional notifications to a Slack channel, you will first need to configure <a href="/docs/integrations/slack#conditional-notifications">Conditional notifications for Slack</a>.
@@ -251,7 +251,7 @@ notify:
 ```
 {: codeblock-file="pipeline.yml"}
 
-See [Supported Variables](/docs/pipelines/conditionals#supported-variables) for more conditional variables that can be used in `if` attribute.
+See [Supported Variables](/docs/pipelines/conditionals#supported-variables) for more conditional variables that can be used in the `if` attribute.
 
 Slack notifications happen at the following [event](/docs/apis/webhooks#events):
 

--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -46,6 +46,11 @@ _Optional attributes:_
   </tr>
 </table>
 
+<div class="Docs__troubleshooting-note">
+  <h3>When Wait and Block steps are placed one after another</h3>
+  <p>If a wait step is immediately surrounded by a block step, then the wait step would be ignored and only block step would be run.</p>
+</div>
+
 ## Continuing on failure
 
 You can also configure the wait step to continue even if the previous steps failed. If steps failed, the build will be marked as failed only after any steps after the `wait` with `continue_on_failure: true` have completed.

--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -46,11 +46,6 @@ _Optional attributes:_
   </tr>
 </table>
 
-<div class="Docs__troubleshooting-note">
-  <h3>When Wait and Block steps are placed one after another</h3>
-  <p>If a wait step is immediately surrounded by a block step, then the wait step would be ignored and only block step would be run.</p>
-</div>
-
 ## Continuing on failure
 
 You can also configure the wait step to continue even if the previous steps failed. If steps failed, the build will be marked as failed only after any steps after the `wait` with `continue_on_failure: true` have completed.


### PR DESCRIPTION
Removed the statement about 'build.state' (as it was focussed on one particular if-condition) and replaced it with a statement about all supported variables for the 'if' attribute.

This is for: https://trello.com/c/BdNUeiy6/406-from-helpscout-general-zsperske-hello-im-wondering-if-it-is-possible-to-set-up-email-notifications-when

**Now:**
![image](https://user-images.githubusercontent.com/5114190/142794033-a0432d2f-3368-4e6c-98d9-d0a20adbf7f5.png)

**In the PR:** 
![image](https://user-images.githubusercontent.com/5114190/142794068-b9d2579f-fdf3-4f1c-a87d-ae56b1e77d01.png)
