### PR TITLE
Adding info about wait and block steps when they are placed together

### DIFF
--- a/pages/pipelines/_block_wait.md.erb
+++ b/pages/pipelines/_block_wait.md.erb
@@ -1,0 +1,34 @@
+## Block steps interacting with wait steps
+
+If a block step follows or precedes a wait step in your build, the wait step will be ignored and only the block step will run, like this example:
+
+```yml
+steps:
+  - command: ".buildkite/steps/yarn"
+  - wait: ~
+  - block: "unblock me"
+```
+{: codeblock-file="pipeline.yml"}
+
+But let's consider a different example. Now the wait step will be ignored, but the block step will not be executed because `continue_on_failure` is set to `true`.
+
+
+```yml
+steps:
+  - command: "exit -1"
+  - wait: ~
+    continue_on_failure: true
+  - block: "unblock me"
+```
+{: codeblock-file="pipeline.yml"}
+
+If you need to run a block step after a failed step, set [soft_fail](/docs/pipelines/dependencies#allowed-failure-and-soft-fail) on the failing step:
+
+```yml
+steps:
+  - command: "exit -1"
+    soft_fail:
+      - exit_status: "*"
+  - block: "unblock me"
+```
+{: codeblock-file="pipeline.yml"}

--- a/pages/pipelines/_block_wait.md.erb
+++ b/pages/pipelines/_block_wait.md.erb
@@ -1,6 +1,6 @@
 ## Block steps interacting with wait steps
 
-If a block step follows or precedes a wait step in your build, the wait step will be ignored and only the block step will run, like this example:
+If a block step follows or precedes a wait step in your build, the wait step will be ignored and only the block step will run, like in this example:
 
 ```yml
 steps:

--- a/pages/pipelines/_block_wait.md.erb
+++ b/pages/pipelines/_block_wait.md.erb
@@ -10,7 +10,7 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-But let's consider a different example. Now the wait step will be ignored, but the block step will not be executed because `continue_on_failure` is set to `true`.
+But let's consider a different example. Now the wait step (with `continue_on_failure: true`) will be ignored, but the block step will **also not run**, because the 'previous' command step failed.
 
 
 ```yml

--- a/pages/pipelines/_block_wait.md.erb
+++ b/pages/pipelines/_block_wait.md.erb
@@ -1,5 +1,3 @@
-## Block steps interacting with wait steps
-
 If a block step follows or precedes a wait step in your build, the wait step will be ignored and only the block step will run, like in this example:
 
 ```yml

--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -417,3 +417,5 @@ The command step added in the above example will upload the trigger step and add
 <%= image "block-trigger-pipeline.png", width: 2328/2, height: 952/2, alt: "Screenshot of pipeline showing the uploaded trigger step" %>
 
 In the pipeline you're triggering, you will be able to use the meta-data that you have passed through as if it was set during the triggered build.
+
+<%= render_markdown 'pipelines/block_wait' %>

--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -418,4 +418,6 @@ The command step added in the above example will upload the trigger step and add
 
 In the pipeline you're triggering, you will be able to use the meta-data that you have passed through as if it was set during the triggered build.
 
+## Block steps interacting with wait steps
+
 <%= render_markdown 'pipelines/block_wait' %>

--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -98,9 +98,9 @@ steps:
 
 The explicit null `~` character used in the above examples isn't required, but is recommended as a best practice. It ensures that nothing else is accidentally added to the `wait` before the `continue_on_failure` attribute.
 
-## Block step after the wait step
-  
-If a block step follows or precedes a wait step in the YAML config file, the wait step will be ignored and only the block step will run.
+## Block steps interacting with wait steps
+
+If a block step follows or precedes a wait step in your build, the wait step will be ignored and only the block step will run, like this example:
 
 ```yml
 steps:
@@ -110,7 +110,8 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-In this example, the wait step will be ignored. But let's consider a different example:
+But let's consider a different example. Now the wait step will be ignored, but the block step will not be executed because `continue_on_failure` is set to `true`.
+
 
 ```yml
 steps:
@@ -121,14 +122,12 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-Here the wait step will be ignored, but the block step will not be executed because `continue_on_failure` is set to true.
-
-If a block step has to be run after a failed step, a [soft_fail](/docs/pipelines/dependencies#allowed-failure-and-soft-fail) can be used:
+If you need to run a block step after a failed step, set [soft_fail](/docs/pipelines/dependencies#allowed-failure-and-soft-fail) on the failing step:
 
 ```yml
 steps:
   - command: "exit -1"
-    soft_fail: 
+    soft_fail:
       - exit_status: "*"
   - block: "unblock me"
 ```

--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -98,37 +98,4 @@ steps:
 
 The explicit null `~` character used in the above examples isn't required, but is recommended as a best practice. It ensures that nothing else is accidentally added to the `wait` before the `continue_on_failure` attribute.
 
-## Block steps interacting with wait steps
-
-If a block step follows or precedes a wait step in your build, the wait step will be ignored and only the block step will run, like this example:
-
-```yml
-steps:
-  - command: ".buildkite/steps/yarn"
-  - wait: ~
-  - block: "unblock me"
-```
-{: codeblock-file="pipeline.yml"}
-
-But let's consider a different example. Now the wait step will be ignored, but the block step will not be executed because `continue_on_failure` is set to `true`.
-
-
-```yml
-steps:
-  - command: "exit -1"
-  - wait: ~
-    continue_on_failure: true
-  - block: "unblock me"
-```
-{: codeblock-file="pipeline.yml"}
-
-If you need to run a block step after a failed step, set [soft_fail](/docs/pipelines/dependencies#allowed-failure-and-soft-fail) on the failing step:
-
-```yml
-steps:
-  - command: "exit -1"
-    soft_fail:
-      - exit_status: "*"
-  - block: "unblock me"
-```
-{: codeblock-file="pipeline.yml"}
+<%= render_markdown 'pipelines/block_wait' %>

--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -110,7 +110,7 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-In tis example, the wait step will be ignored. But let's consider a different example:
+In this example, the wait step will be ignored. But let's consider a different example:
 
 ```yml
 steps:

--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -98,9 +98,19 @@ steps:
 
 The explicit null `~` character used in the above examples isn't required, but is recommended as a best practice. It ensures that nothing else is accidentally added to the `wait` before the `continue_on_failure` attribute.
 
-## When wait and block steps are placed one after another
+## Block step after the wait step
   
-If a wait step is immediately surrounded by a block step, then the wait step would be ignored and only block step would be run.
+If a block step follows or precedes a wait step in the YAML config file, the wait step will be ignored and only the block step will run.
+
+```yml
+steps:
+  - command: ".buildkite/steps/yarn"
+  - wait: ~
+  - block: "unblock me"
+```
+{: codeblock-file="pipeline.yml"}
+
+In tis example, the wait step will be ignored. But let's consider a different example:
 
 ```yml
 steps:
@@ -111,9 +121,9 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-In the above case, though continue_on_failure is set to true, block step will not be executed. This is because, the wait step is ignored as its surrounded by (followed by or preceded by) a block step.
+Here the wait step will be ignored, but the block step will not be executed because `continue_on_failure` is set to true.
 
-If a block step has to be run after a failed step, a [soft_fail](/docs/pipelines/dependencies#allowed-failure-and-soft-fail) can be setup like below:
+If a block step has to be run after a failed step, a [soft_fail](/docs/pipelines/dependencies#allowed-failure-and-soft-fail) can be used:
 
 ```yml
 steps:

--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -97,3 +97,29 @@ steps:
 <%= image "continue-on-fail-example2.png", width: 1402/2, height: 417/2, alt: "Screenshot of a failed pipeline which did run the continue_on_failure wait steps" %>
 
 The explicit null `~` character used in the above examples isn't required, but is recommended as a best practice. It ensures that nothing else is accidentally added to the `wait` before the `continue_on_failure` attribute.
+
+## When wait and block steps are placed one after another
+  
+If a wait step is immediately surrounded by a block step, then the wait step would be ignored and only block step would be run.
+
+```yml
+steps:
+  - command: "exit -1"
+  - wait: ~
+    continue_on_failure: true
+  - block: "unblock me"
+```
+{: codeblock-file="pipeline.yml"}
+
+In the above case, though continue_on_failure is set to true, block step will not be executed. This is because, the wait step is ignored as its surrounded by (followed by or preceeded by) a block step. 
+
+If a block step has to be run after a failed step, a [soft_fail](/docs/pipelines/dependencies#allowed-failure-and-soft-fail) can be setup like below:
+
+```yml
+steps:
+  - command: "exit -1"
+    soft_fail: 
+      - exit_status: "*"
+  - block: "unblock me"
+```
+{: codeblock-file="pipeline.yml"}

--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -98,4 +98,6 @@ steps:
 
 The explicit null `~` character used in the above examples isn't required, but is recommended as a best practice. It ensures that nothing else is accidentally added to the `wait` before the `continue_on_failure` attribute.
 
+## Block steps interacting with wait steps
+
 <%= render_markdown 'pipelines/block_wait' %>

--- a/pages/pipelines/wait_step.md.erb
+++ b/pages/pipelines/wait_step.md.erb
@@ -111,7 +111,7 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-In the above case, though continue_on_failure is set to true, block step will not be executed. This is because, the wait step is ignored as its surrounded by (followed by or preceeded by) a block step. 
+In the above case, though continue_on_failure is set to true, block step will not be executed. This is because, the wait step is ignored as its surrounded by (followed by or preceded by) a block step.
 
 If a block step has to be run after a failed step, a [soft_fail](/docs/pipelines/dependencies#allowed-failure-and-soft-fail) can be setup like below:
 


### PR DESCRIPTION
Added about wait and block steps when they are placed one after another.

Issue context: When a wait step is surrounded by a block step, the wait step is ignored. This has been previously reported by our customers a few times. So updating in our docs, so it is obvious that it's a limitation.

Here is the most recent observation from our customer: https://secure.helpscout.net/conversation/1696682218/27449/

**The following section is added in the PR:**
![image](https://user-images.githubusercontent.com/5114190/142827015-f511c1e0-7fe2-4e7f-bc69-c61fc73f21e5.png)
