### PR TITLE
Update group step documentation with `commands` use examples

### DIFF
--- a/pages/pipelines/group_step.md.erb
+++ b/pages/pipelines/group_step.md.erb
@@ -185,7 +185,6 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-Remember that a wait step placed inside a set of `commands` will be ignored because <code>wait</code> is not a command.
 
 ## Group merging
 

--- a/pages/pipelines/group_step.md.erb
+++ b/pages/pipelines/group_step.md.erb
@@ -48,7 +48,7 @@ _Required attributes:_
   <tr>
     <td><code>steps</code></td>
     <td>
-    A list of steps in the group; at least 1 step is required. Allowed step types: `wait`, `trigger`, `command`.<br>
+    A list of steps in the group; at least 1 step is required. Allowed step types: `wait`, `trigger`, `command`, `commands`.<br>
       <em>Type:</em> <code>array</code>
     </td>
   </tr>
@@ -168,17 +168,19 @@ steps:
   - group: "Group01"
     depends_on: "tests"
     steps:
-      - command: "a.sh"
-      - wait
-      - command: "b.sh"
+      - commands:
+        - "a.sh"
+        - wait
+        - "b.sh"
 
   - group: "Group02"
     depends_on: "tests"
     id: "toast"
     steps:
-      - command: "c.sh"
-      - wait
-      - command: "d.sh"
+      - commands:
+        - "c.sh"
+        - wait
+        - "d.sh"
 
   - command: "yay.sh"
     depends_on: "toast"

--- a/pages/pipelines/group_step.md.erb
+++ b/pages/pipelines/group_step.md.erb
@@ -127,7 +127,7 @@ _Optional attributes:_
 
 ## Parallel groups
 
-If you put two or more group steps in a YAML config file consecutively, they will run in parallel. For example:  
+If you put two or more group steps in a YAML config file consecutively, they will run in parallel. For example:
 
 ```yml
 # 1.sh and 3.sh will start at the same time.
@@ -168,24 +168,38 @@ steps:
   - group: "Group01"
     depends_on: "tests"
     steps:
-      - commands:
-        - "a.sh"
-        - wait
-        - "b.sh"
+      - command: "a.sh"
+      - wait
+      - command: "b.sh"
 
   - group: "Group02"
     depends_on: "tests"
     id: "toast"
     steps:
-      - commands:
-        - "c.sh"
-        - wait
-        - "d.sh"
+      - command: "c.sh"
+      - wait
+      - command: "d.sh"
 
   - command: "yay.sh"
     depends_on: "toast"
 ```
 {: codeblock-file="pipeline.yml"}
+
+Note that a wait step placed inside a set of `commands` will not work because `wait` does not belong to the [command step attributes](/docs/pipelines/command-step#command-step-attributes):
+
+```yml
+steps:
+  - group: "Group01"
+    depends_on: "tests"
+    steps:
+      - commands:
+        - "a.sh"
+        - wait
+        - "b.sh"
+```
+{: codeblock-file="pipeline.yml"}
+
+In the example above, the wait step between `a.sh` and `b.sh` will be ignored during deployment.
 
 ## Group merging
 

--- a/pages/pipelines/group_step.md.erb
+++ b/pages/pipelines/group_step.md.erb
@@ -185,21 +185,7 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-Note that a wait step placed inside a set of `commands` will not work because `wait` does not belong to the [command step attributes](/docs/pipelines/command-step#command-step-attributes):
-
-```yml
-steps:
-  - group: "Group01"
-    depends_on: "tests"
-    steps:
-      - commands:
-        - "a.sh"
-        - wait
-        - "b.sh"
-```
-{: codeblock-file="pipeline.yml"}
-
-In the example above, the wait step between `a.sh` and `b.sh` will be ignored during deployment.
+Remember that a wait step placed inside a set of `commands` will be ignored because <code>wait</code> is not a command.
 
 ## Group merging
 
@@ -215,7 +201,9 @@ For example, you have a YAML file:
 ```yml
 - group: "Setup"
   steps:
-    - command: "buildkite agent pipeline upload"
+    - commands:
+      - "buildkite agent pipeline upload"
+      - "abc.sh"
 ```
 {: codeblock-file="pipeline.yml"}
 
@@ -228,15 +216,17 @@ And this YAML file uploads a pipeline that has a group with the same name:
 ```
 {: codeblock-file="pipeline.yml"}
 
-These groups will be merged into one in the UI, and the `"docker build"` step will be added to the existing group.
+These groups will be merged into one in the UI, and the `docker build` step will be added to the existing group.
 
 ```yml
 - group: "Setup"
   steps:
-    - command: "buildkite agent pipeline upload"
+    - commands:
+      - "buildkite agent pipeline upload"
+      - "abc.sh"
 - group: "Setup"
   steps:
-      - command: "docker build"
+    - command: "docker build"
 ```
 {: codeblock-file="pipeline.yml"}
 
@@ -247,14 +237,14 @@ steps:
 - group: ~
   label: "linting"
   steps:
-    - name: ":rubocop: RuboCop"
+    - name: "\:rubocop\: RuboCop"
       command: "echo .buildkite/steps/rubocop"
-    - name: ":eslint: ESlint"
+    - name: "\:eslint\: ESlint"
       command: "echo .buildkite/steps/eslint"
 - group: ~
   label: "linting"
   steps:
-    - label: ":flowtype: Flow"
+    - label: "\:flowtype\: Flow"
       command: "echo .buildkite/steps/flow"
 ```
 {: codeblock-file="pipeline.yml"}

--- a/pages/pipelines/group_step.md.erb
+++ b/pages/pipelines/group_step.md.erb
@@ -48,7 +48,7 @@ _Required attributes:_
   <tr>
     <td><code>steps</code></td>
     <td>
-    A list of steps in the group; at least 1 step is required. Allowed step types: [`wait`](/docs/pipelines/wait-step), [`trigger`](/docs/pipelines/trigger-step), [`command`/`commands`](/docs/pipelines/command-step)`.<br>
+    A list of steps in the group; at least 1 step is required. Allowed step types: <a href="/docs/pipelines/wait-step"><code>wait</code></a>, <a href="/docs/pipelines/trigger-step"><code>trigger</code></a>, <a href="/docs/pipelines/command-step"><code>command</code>/<code>commands</code></a>.<br>
       <em>Type:</em> <code>array</code>
     </td>
   </tr>

--- a/pages/pipelines/group_step.md.erb
+++ b/pages/pipelines/group_step.md.erb
@@ -48,7 +48,7 @@ _Required attributes:_
   <tr>
     <td><code>steps</code></td>
     <td>
-    A list of steps in the group; at least 1 step is required. Allowed step types: `wait`, `trigger`, `command`, `commands`.<br>
+    A list of steps in the group; at least 1 step is required. Allowed step types: [`wait`](/docs/pipelines/wait-step), [`trigger`](/docs/pipelines/trigger-step), [`command`/`commands`](/docs/pipelines/command-step)`.<br>
       <em>Type:</em> <code>array</code>
     </td>
   </tr>


### PR DESCRIPTION
Following https://forum.buildkite.community/t/group-steps-missing-commands/1790, updating the example to reflect the fact that `commands` does work in group step.