### PR TITLE
Clarify top level env applies to further pipeline uploads

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -711,7 +711,7 @@ There are two places in a pipeline.yml file that you can set environment variabl
   1. In the `env` attribute of command and trigger steps.
   2. At the top of the yaml file, before you define your pipeline's steps.
 
-Defining an environment variable at the top of your yaml file will set that variable on each of the command steps in the pipeline, and is equivalent to setting the `env` attribute on every step.
+Defining an environment variable at the top of your yaml file will set that variable on each of the command steps in the pipeline, and is equivalent to setting the `env` attribute on every step. This includes further pipeline uploads through `buildkite-agent pipeline upload`.
 
 <div class="Docs__note">
   <p>Top level pipeline environment variables will override what is set in the <code>env</code> attribute of an individual step.</p>


### PR DESCRIPTION
This clarifies that top level YAML env vars apply to the entire pipeline, even further pipeline uploads not part of the original upload where the env is defined.

Before:

![Screen Shot 2021-11-23 at 14 36 56](https://user-images.githubusercontent.com/6128798/142980367-39b41be6-d2a2-4151-a958-be31ef40fca2.png)
After:
![Screen Shot 2021-11-23 at 14 35 18](https://user-images.githubusercontent.com/6128798/142980290-3705effe-6c01-4db2-98ed-81f1b4eac036.png)