### PR TITLE
Add note about when conditionals are evaluated

### DIFF
--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -14,6 +14,11 @@ Define conditionals in the _Pipeline Settings_ for your repository provider to r
 
 Conditionals are supported in [Bitbucket](/docs/integrations/bitbucket), [Bitbucket Server](/docs/integrations/bitbucket-server), [GitHub](/docs/integrations/github), [GitHub Enterprise](/docs/integrations/github-enterprise) and [GitLab](/docs/integrations/gitlab) (including GitLab Community and GitLab Enterprise).
 
+<div class="Docs__note">
+  <h3>Evaluating conditionals</h3>
+  <p>Conditional expressions are evaluated at pipeline upload, not at step runtime.</p>
+</div>
+
 ## Conditionals in Steps
 
 Use the `if` attribute in your step definition to conditionally run a step.

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -12,7 +12,7 @@ Define conditionals in the _Pipeline Settings_ for your repository provider to r
 
 <%= image "conditionals.png", width: 864, height: 298, alt: "Conditional Filtering settings" %>
 
-Conditionals are supported in [Bitbucket](/docs/integrations/bitbucket), [Bitbucket Server](/docs/integrations/bitbucket-server), [GitHub](/docs/integrations/github), [GitHub Enterprise](/docs/integrations/github-enterprise) and [GitLab](/docs/integrations/gitlab) (including GitLab Community and GitLab Enterprise).
+Conditionals are supported in [Bitbucket](/docs/integrations/bitbucket), [Bitbucket Server](/docs/integrations/bitbucket-server), [GitHub](/docs/integrations/github), [GitHub Enterprise](/docs/integrations/github-enterprise), and [GitLab](/docs/integrations/gitlab) (including GitLab Community and GitLab Enterprise).
 
 <div class="Docs__note">
   <h3>Evaluating conditionals</h3>


### PR DESCRIPTION
This adds a note section to the conditional page to let users know conditionals are evaluated at pipeline upload time. 


Eg:
![Screen Shot 2021-11-25 at 09 53 38](https://user-images.githubusercontent.com/6128798/143361549-f2e85aea-fff8-4d3d-a0cd-f7bc5f3ad761.png)

I had a hard time trying to decide whether this is a note or just a normal paragraph or sentence somewhere else in the page. 

And also whether an example is useful. But I couldn't think of one either.

Let me know what you think and if it needs more/restructuring.