### PR TITLE
added reference to Job and Build states to the amazon eventbride page

### DIFF
--- a/pages/integrations/amazon_eventbridge.md.erb
+++ b/pages/integrations/amazon_eventbridge.md.erb
@@ -28,7 +28,7 @@ Once you’ve configured an Amazon EventBridge notification service in Buildkite
 </tbody>
 </table>
 
-See [Build States](/docs/pipelines/defining-steps#build-states) and [Job States](/docs/pipelines/defining-steps#job-states) to understand the sequence of these events.
+See [build states](/docs/pipelines/defining-steps#build-states) and [job states](/docs/pipelines/defining-steps#job-states) to learn more about the sequence of these events.
 
 ## Configuring
 

--- a/pages/integrations/amazon_eventbridge.md.erb
+++ b/pages/integrations/amazon_eventbridge.md.erb
@@ -28,6 +28,8 @@ Once you’ve configured an Amazon EventBridge notification service in Buildkite
 </tbody>
 </table>
 
+See [Build States](/docs/pipelines/defining-steps#build-states) and [Job States](/docs/pipelines/defining-steps#job-states) to understand the sequence of these events.
+
 ## Configuring
 
 In your Buildkite [Organization’s Notification Settings](https://buildkite.com/organizations/-/services), add an Amazon EventBridge notification service:


### PR DESCRIPTION
Added references to Build and Job states to the amazon eventbridge page

In the PR:
![image](https://user-images.githubusercontent.com/5114190/143377200-21878721-2efc-4d63-a9b0-c2005f02860f.png)
