### PR TITLE
no-plugin-validation default value

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -319,8 +319,8 @@ _Optional attributes:_
     <tr id="no-plugin-validation">
       <th><code>no-plugin-validation</code></th>
       <td>
-        Do not validate plugin configuration and requirements.
-        <p class="Docs__api-param-eg"><em>Default:</em> <code>false</code></p>
+        Do not validate plugin configuration and requirements. By default the option is enabled, so the validation is not performed.
+        <p class="Docs__api-param-eg"><em>Default:</em> <code>true</code></p>
         <p class="Docs__api-param-eg"><em>Environment variable:</em> <code>BUILDKITE_NO_PLUGIN_VALIDATION</code></p>
       </td>
     </tr>


### PR DESCRIPTION
The default value for the configuration `no-plugin-validation` is actually [true](https://github.com/buildkite/agent/blob/5335389cb4649b86b6478ac542a40480500c6cca/clicommand/agent_start.go#L389). Change the default behavior on the agent would be more problematic than it seems, so we are updating the docs according in the meantime.
So if you actually want to have plugin validation you should specify `--no-plugin-validation=false` (the double-negative is confusing)

![plugin](https://user-images.githubusercontent.com/6607375/143502110-afbbffed-bd31-4d07-8de8-82519509d409.png)
