### PR TITLE
add example usage for wrapping shell commands in set

### DIFF
--- a/pages/pipelines/writing_build_scripts.md.erb
+++ b/pages/pipelines/writing_build_scripts.md.erb
@@ -49,7 +49,7 @@ For a full list of options, see the [Bash Reference Manual](https://www.gnu.org/
 
 <section class="Docs__troubleshooting-note">
   <h3>Unbound variable errors</h3>
-  <p>Note that while enabling the <code>u</code> option is generally a good default to use for all build scripts, it can cause some tools like <a href="https://rvm.io">rvm</a> to fail with “unbound variable” errors. If you encounter errors, you can either remove <code>u</code> from the list of options, or you can surround the command causing the error with <code>set +u</code> and <code>set -u</code> to temporarily disable the option. In some cases, you may need to run the tool itself wrapped in <code>set +u</code> and <code>set -u</code> For example: <code>set +u; rvm xxx; set -u</code></p>
+  <p>Note that while enabling the <code>u</code> option is generally a good default to use for all build scripts, it can cause some tools like <a href="https://rvm.io">rvm</a> to fail with “unbound variable” errors. If you encounter errors, you can either remove <code>u</code> from the list of options, or run the tool causing the error wrapped in <code>set +u</code> and <code>set -u</code> to remove the option just for that command. For example: <code>set +u; rvm xxx; set -u</code>.</p>
 </section>
 
 ## Capturing exit status

--- a/pages/pipelines/writing_build_scripts.md.erb
+++ b/pages/pipelines/writing_build_scripts.md.erb
@@ -49,7 +49,7 @@ For a full list of options, see the [Bash Reference Manual](https://www.gnu.org/
 
 <section class="Docs__troubleshooting-note">
   <h3>Unbound variable errors</h3>
-  <p>Note that while enabling the <code>u</code> option is generally a good default to use for all build scripts, it can cause some tools like <a href="https://rvm.io">rvm</a> to fail with “unbound variable” errors. If you encounter errors, you can either remove <code>u</code> from the list of options, or you can surround the command causing the error with <code>set +u</code> and <code>set -u</code> to temporarily disable the option.</p>
+  <p>Note that while enabling the <code>u</code> option is generally a good default to use for all build scripts, it can cause some tools like <a href="https://rvm.io">rvm</a> to fail with “unbound variable” errors. If you encounter errors, you can either remove <code>u</code> from the list of options, or you can surround the command causing the error with <code>set +u</code> and <code>set -u</code> to temporarily disable the option. In some cases, you may need to run the tool itself wrapped in <code>set +u</code> and <code>set -u</code> For example: <code>set +u; rvm xxx; set -u</code></p>
 </section>
 
 ## Capturing exit status


### PR DESCRIPTION
Brief one-liner example added to the `Unbound variable errors` warning message to show an example of usage to https://buildkite.com/docs/pipelines/writing-build-scripts#configuring-bash


Current:
![image](https://user-images.githubusercontent.com/19416785/143615960-46302657-ff9b-4eac-bbe5-485800182a76.png)

Updated:
![image](https://user-images.githubusercontent.com/19416785/143616030-995fd810-eddb-41d9-a38e-66e0cc762d45.png)
