### PR TITLE
Remove deprecated bundler option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ WORKDIR /app
 # Install deps
 COPY Gemfile Gemfile.lock ./
 RUN echo "--- :bundler: Installing ruby gems" \
-    && bundle install --jobs $(nproc) --retry 3 --without "$([ "$RAILS_ENV" = "production" ] && echo 'development test')"
+    && bundle config set --local without "$([ "$RAILS_ENV" = "production" ] && echo 'development test')" \
+    && bundle install --jobs $(nproc) --retry 3
 
 COPY package.json package-lock.json ./
 RUN echo "--- :npm: Installing npm deps" \


### PR DESCRIPTION
I _think_ this does the right thing.

With the original code:

![image](https://user-images.githubusercontent.com/95874/143657414-16014bc2-91a2-4fd9-860b-d19d3b257a70.png)

And with the PR:

![image](https://user-images.githubusercontent.com/95874/143657517-cbf2c4fa-84f6-47d4-80a9-54ad405b0fb3.png)
