### PR TITLE
Clarify the purpose of BUILDKITE_NO_COMMAND_EVAL

### DIFF
--- a/.alexrc.yml
+++ b/.alexrc.yml
@@ -1,4 +1,5 @@
 allow:
+  - actors
   - hooks
   - hook
   - execute

--- a/.alexrc.yml
+++ b/.alexrc.yml
@@ -1,5 +1,5 @@
 allow:
-  - actors
+  - actors-actresses
   - hooks
   - hook
   - execute

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -31,6 +31,7 @@ By default the agent allows you to run any command on the build server (for exam
 Once disabled your build steps will need to be checked into your repository as scripts, and the only way to pass arguments is using environment variables.
 
 <!-- vale off -->
+
 This option is intended to protect your infrastructure from a general Buildkite compromise that might attempt to send arbitrary commands to your agents. It is not designed, nor effective, at protecting against malicious actors with commit access to the repository.
 
 <!-- vale on -->

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -31,7 +31,6 @@ By default the agent allows you to run any command on the build server (for exam
 Once disabled your build steps will need to be checked into your repository as scripts, and the only way to pass arguments is using environment variables.
 
 <!-- vale off -->
-
 This option is intended to protect your infrastructure from a general Buildkite compromise that might attempt to send arbitrary commands to your agents. It is not designed, nor effective, at protecting against malicious actors with commit access to the repository.
 
 <!-- vale on -->

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -30,7 +30,9 @@ By default the agent allows you to run any command on the build server (for exam
 
 Once disabled your build steps will need to be checked into your repository as scripts, and the only way to pass arguments is using environment variables.
 
+<!-- vale off -->
 This option is intended to protect your infrastructure from a general Buildkite compromise that might attempt to send arbitrary commands to your agents. It is not designed, nor effective, at protecting against malicious actors with commit access to the repository.
+<!-- vale on -->
 
 Command line evaluation can be disabled by setting [`no-command-eval`](/docs/agent/v3/configuration#no-command-eval):
 

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -30,7 +30,7 @@ By default the agent allows you to run any command on the build server (for exam
 
 Once disabled your build steps will need to be checked into your repository as scripts, and the only way to pass arguments is using environment variables.
 
-This option is intended to protect your infrastructure from a general Buildkite compromise that might attempt to send arbitrary commands to your agents. It is designed, nor effective, at protecting against malicious actors with commit access to the repository.
+This option is intended to protect your infrastructure from a general Buildkite compromise that might attempt to send arbitrary commands to your agents. It is not designed, nor effective, at protecting against malicious actors with commit access to the repository.
 
 Command line evaluation can be disabled by setting [`no-command-eval`](/docs/agent/v3/configuration#no-command-eval):
 

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -30,11 +30,9 @@ By default the agent allows you to run any command on the build server (for exam
 
 Once disabled your build steps will need to be checked into your repository as scripts, and the only way to pass arguments is using environment variables.
 
-<!-- vale off -->
 
-This option is intended to protect your infrastructure from a general Buildkite compromise that might attempt to send arbitrary commands to your agents. It is not designed, nor effective, at protecting against malicious actors with commit access to the repository.
+This option is intended to protect your infrastructure from a scenario where Buildkite itself gets compromised, and subsequently sends malicious commands to your agents. It is not designed, nor effective at protecting against malicious actors with commit access to your repositories.
 
-<!-- vale on -->
 
 Command line evaluation can be disabled by setting [`no-command-eval`](/docs/agent/v3/configuration#no-command-eval):
 

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -30,6 +30,8 @@ By default the agent allows you to run any command on the build server (for exam
 
 Once disabled your build steps will need to be checked into your repository as scripts, and the only way to pass arguments is using environment variables.
 
+This option is intended to protect your infrastructure from a general Buildkite compromise that might attempt to send arbitrary commands to your agents. It is designed, nor effective, at protecting against malicious actors with commit access to the repository.
+
 Command line evaluation can be disabled by setting [`no-command-eval`](/docs/agent/v3/configuration#no-command-eval):
 
 * Environment variable: `BUILDKITE_NO_COMMAND_EVAL=1`

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -31,7 +31,9 @@ By default the agent allows you to run any command on the build server (for exam
 Once disabled your build steps will need to be checked into your repository as scripts, and the only way to pass arguments is using environment variables.
 
 <!-- vale off -->
+
 This option is intended to protect your infrastructure from a general Buildkite compromise that might attempt to send arbitrary commands to your agents. It is not designed, nor effective, at protecting against malicious actors with commit access to the repository.
+
 <!-- vale on -->
 
 Command line evaluation can be disabled by setting [`no-command-eval`](/docs/agent/v3/configuration#no-command-eval):


### PR DESCRIPTION
This clarifies the purpose of the `BUILDKITE_NO_COMMAND_EVAL` option.

It adds this section:

<img width="736" alt="Screen Shot 2021-11-29 at 12 04 33" src="https://user-images.githubusercontent.com/6128798/143807080-634da5ef-9fdb-4a01-aa5f-a026c380fed4.png">

