### PR TITLE
About executing step conditionally based on the result of another step

### DIFF
--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -59,9 +59,9 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-As `'if'` conditions are evaluated at the time of the pipeline upload, its not possible to use a `if` attribute to conditionally run a step based on the result of another step.
+Since `'if'` conditions are evaluated at the time of the pipeline upload, it's not possible to use the `if` attribute to conditionally run a step based on the result of another step.
 
-So in order to run a step based on the result of another step, we upload a new pipeline based on a `if` condition set up in command step like below:
+In order to run a step based on the result of another step, upload a new pipeline based on the `if` condition set up in the [command step](/docs/pipelines/command-step) like in the example below:
 
 ```yml
 steps:

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -59,26 +59,25 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-Since `'if'` conditions are evaluated at the time of the pipeline upload, it's not possible to use the `if` attribute to conditionally run a step based on the result of another step.
+Since `if` conditions are evaluated at the time of the pipeline upload, it's not possible to use the `if` attribute to conditionally run a step based on the result of another step.
 
-In order to run a step based on the result of another step, upload a new pipeline based on the `if` condition set up in the [command step](/docs/pipelines/command-step) like in the example below:
+To run a step based on the result of another step, upload a new pipeline based on the `if` condition set up in the [command step](/docs/pipelines/command-step) like in the example below:
 
 ```yml
 steps:
-  - label: "Sanity check"
-    command: ./scripts/sanity_tests.sh
-    key: "sanity-check"
-  - label: "Run regression only if sanity check is passed"
-    depends_on: "sanity-check"
+  - label: "Validation check"
+    command: ./scripts/validation_tests.sh
+    key: "validation-check"
+  - label: "Run regression only if validation check is passed"
+    depends_on: "validation-check"
     command: |
-      if [ $$(buildkite-agent step get "outcome" --step "sanity-check") == "passed" ]; then
+      if [ $$(buildkite-agent step get "outcome" --step "validation-check") == "passed" ]; then
          cat <<- YAML | buildkite-agent pipeline upload
          steps:
            - label: "Run Regression"
              command: ./scripts/regression_tests.sh
       YAML
       fi
-```
 {: codeblock-file="pipeline.yml"}
 
 ## Supported syntax

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -59,7 +59,7 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-As `'if'` conditions are evaluated at the time of the pipeline upload, its not possible to use a `if` attribute of a command step to conditionally run a step based on the result of another step.
+As `'if'` conditions are evaluated at the time of the pipeline upload, its not possible to use a `if` attribute to conditionally run a step based on the result of another step.
 
 So in order to run a step based on the result of another step, we upload a new pipeline based on a `if` condition set up in command step like below:
 

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -59,9 +59,9 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-As `'if'` conditions are evaluated at the time of the pipeline upload, its not possible to use a `if` attribute of a command step to conditionally run a step based on the result of another step. 
+As `'if'` conditions are evaluated at the time of the pipeline upload, its not possible to use a `if` attribute of a command step to conditionally run a step based on the result of another step.
 
-So in order to run a step based on the result of another step, we upload a new pipeline based on a `if` condition set up in command step like below: 
+So in order to run a step based on the result of another step, we upload a new pipeline based on a `if` condition set up in command step like below:
 
 ```yml
 steps:

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -59,6 +59,28 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
+As `'if'` conditions are evaluated at the time of the pipeline upload, its not possible to use a `if` attribute of a command step to conditionally run a step based on the result of another step. 
+
+So in order to run a step based on the result of another step, we upload a new pipeline based on a `if` condition set up in command step like below: 
+
+```yml
+steps:
+  - label: "Sanity check"
+    command: ./scripts/sanity_tests.sh
+    key: "sanity-check"
+  - label: "Run regression only if sanity check is passed"
+    depends_on: "sanity-check"
+    command: |
+      if [ $$(buildkite-agent step get "outcome" --step "sanity-check") == "passed" ]; then
+         cat <<- YAML | buildkite-agent pipeline upload
+         steps:
+           - label: "Run Regression"
+             command: ./scripts/regression_tests.sh
+      YAML
+      fi
+```
+{: codeblock-file="pipeline.yml"}
+
 ## Supported syntax
 
 The below expressions are supported by the `if` attribute:

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -78,6 +78,7 @@ steps:
              command: ./scripts/regression_tests.sh
       YAML
       fi
+```
 {: codeblock-file="pipeline.yml"}
 
 ## Supported syntax


### PR DESCRIPTION
We always get questions around executing a step conditionally based on the result of another step. This is not directly possible using the if-conditionals. But we do achieve this by checking the result of the previous step in an ‘if’ condition **within a ‘command’ step** and then adding the other steps into the pipeline.

Please change the words/phrases as needed :)

Added the following in the PR:

![image](https://user-images.githubusercontent.com/5114190/143840036-3c091495-7e3f-4589-94db-d454e91871aa.png)
