### PR TITLE
Clarification about scheduled_at

### DIFF
--- a/pages/pipelines/managing_priorities.md.erb
+++ b/pages/pipelines/managing_priorities.md.erb
@@ -3,7 +3,7 @@
 Jobs are dispatched (taken from the queue and assigned to agents) in the following order
 
 1. Job priority in descending order, highest number to lowest (`priority`)
-1. Date and time scheduled in ascending order, oldest to most recent (`scheduled_at`). Note that jobs inherit `scheduled_at` from pipeline upload jobs, meaning jobs that are uploaded by a pipeline in an older build will be dispatched before builds created after that.
+1. Date and time scheduled in ascending order, oldest to most recent (`scheduled_at`). Note that jobs inherit `scheduled_at` from pipeline upload jobs, meaning jobs that are uploaded by a pipeline in an older build will be dispatched before builds created after that, and the value of `scheduled_at` is internal and cannot be modified.
 1. Upload order in pipeline, first to last.
 1. Internal id in ascending order, used as a tie breaker if all other value are the same, meaning older jobs will be dispatched first.
 

--- a/pages/pipelines/managing_priorities.md.erb
+++ b/pages/pipelines/managing_priorities.md.erb
@@ -3,7 +3,7 @@
 Jobs are dispatched (taken from the queue and assigned to agents) in the following order
 
 1. Job priority in descending order, highest number to lowest (`priority`)
-1. Date and time scheduled in ascending order, oldest to most recent (`scheduled_at`). Note that jobs inherit `scheduled_at` from pipeline upload jobs, meaning jobs that are uploaded by a pipeline in an older build will be dispatched before builds created after that, and the value of `scheduled_at` is internal and cannot be modified.
+1. Date and time scheduled in ascending order, oldest to most recent (`scheduled_at`). Note that jobs inherit `scheduled_at` from pipeline upload jobs, meaning jobs that are uploaded by a pipeline in an older build will be dispatched before builds created after that, and the value of `scheduled_at` cannot be modified.
 1. Upload order in pipeline, first to last.
 1. Internal id in ascending order, used as a tie breaker if all other value are the same, meaning older jobs will be dispatched first.
 


### PR DESCRIPTION
Add a note that the value of `scheduled_at` in Job Prioritization that cannot be changed.

![scheduled_at](https://user-images.githubusercontent.com/6607375/143917869-251a867f-3654-4df6-8f67-424210f3f16c.png)
