### PR TITLE
Note about default expanded group

### DIFF
--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -24,7 +24,7 @@ If you want to have the group open by default, use `+++` instead:
 echo "+++ A section of the build"
 ```
 
-If no group is explicitly expanded (`+++`), then the last collapsed regular group (`---`) gets expanded instead. By default, the last group it's going to be expanded.
+If no group is explicitly expanded (`+++`), then the last collapsed regular group (`---`) gets expanded instead. If you really want all groups to be collapsed, add an empty expanded group (`+++`).
 
 If you'd like to open the previously defined group, use `^^^ +++`. This is useful if a command within a group fails, and you'd like to have the group already open when you view the log.
 

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -24,6 +24,8 @@ If you want to have the group open by default, use `+++` instead:
 echo "+++ A section of the build"
 ```
 
+If no group is explicitly expanded (`+++`), then the last collapsed regular group (`---`) gets expanded instead. By default, the last group it's going to be expanded.
+
 If you'd like to open the previously defined group, use `^^^ +++`. This is useful if a command within a group fails, and you'd like to have the group already open when you view the log.
 
 ```bash


### PR DESCRIPTION
I added a note that by default the last group it's going to be expanded (always)
I didn't mention a workaround for this, but if someone wants that **all** groups to be collapsed, an option is to add a new group that does nothing.

![default](https://user-images.githubusercontent.com/6607375/143922647-4d8279f0-41e4-4da5-9ba4-1f0023b7f0bc.png)
