### PR TITLE
Reuse descriptions of agent events

### DIFF
--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -23,11 +23,7 @@ You can subscribe to one or more of the following events:
   <tr><th>job.started</th><td>A command step job has started running on an agent</td></tr>
   <tr><th>job.finished</th><td>A job has finished</td></tr>
   <tr><th>job.activated</th><td>A block step job has been unblocked using the web or API</td></tr>
-  <tr><th>agent.connected</th><td>An agent has connected</td></tr>
-  <tr><th>agent.lost</th><td>An agent has been marked as lost</td></tr>
-  <tr><th>agent.disconnected</th><td>An agent has disconnected</td></tr>
-  <tr><th>agent.stopping</th><td>An agent is stopping</td></tr>
-  <tr><th>agent.stopped</th><td>An agent has stopped</td></tr>
+  <%= render_markdown 'webhooks/agent_events_table' %>
 </tbody>
 </table>
 

--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -23,7 +23,7 @@ You can subscribe to one or more of the following events:
   <tr><th>job.started</th><td>A command step job has started running on an agent</td></tr>
   <tr><th>job.finished</th><td>A job has finished</td></tr>
   <tr><th>job.activated</th><td>A block step job has been unblocked using the web or API</td></tr>
-  <%= render_markdown 'webhooks/agent_events_table' %>
+  <%= render_markdown 'apis/webhooks/agent_events_table' %>
 </tbody>
 </table>
 

--- a/pages/apis/webhooks/_agent_events_table.md.erb
+++ b/pages/apis/webhooks/_agent_events_table.md.erb
@@ -1,5 +1,3 @@
-<table>
-<tbody>
   <tr>
     <th><code>agent.connected</code></th>
     <td>An agent has connected to the API</td>

--- a/pages/apis/webhooks/_agent_events_table.md.erb
+++ b/pages/apis/webhooks/_agent_events_table.md.erb
@@ -18,5 +18,3 @@
     <th><code>agent.stopped</code></th>
     <td>An agent has stopped. This happens when an agent is instructed to stop from the API. It can be graceful or forceful</td>
   </tr>
-</tbody>
-</table>

--- a/pages/apis/webhooks/_agent_events_table.md.erb
+++ b/pages/apis/webhooks/_agent_events_table.md.erb
@@ -1,0 +1,24 @@
+<table>
+<tbody>
+  <tr>
+    <th><code>agent.connected</code></th>
+    <td>An agent has connected to the API</td>
+  </tr>
+  <tr>
+    <th><code>agent.lost</code></th>
+    <td>An agent has been marked as lost. This happens when Buildkite stops receiving pings from the agent</td>
+  </tr>
+  <tr>
+    <th><code>agent.disconnected</code></th>
+    <td>An agent has disconnected. This happens when the agent shuts down and disconnects from the API</td>
+  </tr>
+  <tr>
+    <th><code>agent.stopping</code></th>
+    <td>An agent is stopping. This happens when an agent is instructed to stop from the API. It first transitions to stopping and finishes any current jobs</td>
+  </tr>
+  <tr>
+    <th><code>agent.stopped</code></th>
+    <td>An agent has stopped. This happens when an agent is instructed to stop from the API. It can be graceful or forceful</td>
+  </tr>
+</tbody>
+</table>

--- a/pages/apis/webhooks/agent_events.md.erb
+++ b/pages/apis/webhooks/agent_events.md.erb
@@ -4,7 +4,7 @@
 
 ## Events
 
-<%= render_markdown 'webhooks/agent_events_table' %>
+<%= render_markdown 'apis/webhooks/agent_events_table' %>
 
 ## Request body data
 

--- a/pages/apis/webhooks/agent_events.md.erb
+++ b/pages/apis/webhooks/agent_events.md.erb
@@ -4,7 +4,11 @@
 
 ## Events
 
+<table>
+<tbody>
 <%= render_markdown 'apis/webhooks/agent_events_table' %>
+</tbody>
+</table>
 
 ## Request body data
 

--- a/pages/apis/webhooks/agent_events.md.erb
+++ b/pages/apis/webhooks/agent_events.md.erb
@@ -4,30 +4,7 @@
 
 ## Events
 
-<table>
-<tbody>
-  <tr>
-    <th><code>agent.connected</code></th>
-    <td>An agent has connected to the API</td>
-  </tr>
-  <tr>
-    <th><code>agent.lost</code></th>
-    <td>An agent has been marked as lost. This happens when Buildkite stops receiving pings from the agent.</td>
-  </tr>
-  <tr>
-    <th><code>agent.disconnected</code></th>
-    <td>An agent has disconnected. This happens when the agent shuts down and disconnects from the API.</td>
-  </tr>
-  <tr>
-    <th><code>agent.stopping</code></th>
-    <td>An agent is stopping. This happens when an agent is instructed to stop from the API. It first transitions to stopping and finishes any current jobs.</td>
-  </tr>
-  <tr>
-    <th><code>agent.stopped</code></th>
-    <td>An agent has stopped. This happens when an agent is instructed to stop from the API. It can be graceful or forceful.</td>
-  </tr>
-</tbody>
-</table>
+<%= render_markdown 'webhooks/agent_events_table' %>
 
 ## Request body data
 

--- a/pages/integrations/amazon_eventbridge.md.erb
+++ b/pages/integrations/amazon_eventbridge.md.erb
@@ -20,11 +20,11 @@ Once you’ve configured an Amazon EventBridge notification service in Buildkite
   <tr><th><a href="#events-job-started">Job Started</a></th><td>A command step job has started running on an agent</td></tr>
   <tr><th><a href="#events-job-finished">Job Finished</a></th><td>A job has finished</td></tr>
   <tr><th><a href="#events-job-activated">Job Activated</a></th><td>A block step job has been unblocked using the web or API</td></tr>
-  <tr><th><a href="#events-agent-connected">Agent Connected</a></th><td>An agent has connected</td></tr>
-  <tr><th><a href="#events-agent-lost">Agent Lost</a></th><td>An agent has been marked as lost</td></tr>
-  <tr><th><a href="#events-agent-disconnected">Agent Disconnected</a></th><td>An agent has disconnected</td></tr>
-  <tr><th><a href="#events-agent-stopping">Agent Stopping</a></th><td>An agent is stopping</td></tr>
-  <tr><th><a href="#events-agent-stopped">Agent Stopped</a></th><td>An agent has stopped</td></tr>
+  <tr><th><a href="#events-agent-connected">Agent Connected</a></th><td>An agent has connected to the API</td></tr>
+  <tr><th><a href="#events-agent-lost">Agent Lost</a></th><td>An agent has been marked as lost. This happens when Buildkite stops receiving pings from the agent</td></tr>
+  <tr><th><a href="#events-agent-disconnected">Agent Disconnected</a></th><td>An agent has disconnected. This happens when the agent shuts down and disconnects from the API</td></tr>
+  <tr><th><a href="#events-agent-stopping">Agent Stopping</a></th><td>An agent is stopping. This happens when an agent is instructed to stop from the API. It first transitions to stopping and finishes any current jobs</td></tr>
+  <tr><th><a href="#events-agent-stopped">Agent Stopped</a></th><td>An agent has stopped. This happens when an agent is instructed to stop from the API. It can be graceful or forceful</td></tr>
 </tbody>
 </table>
 

--- a/vale/vocab.txt
+++ b/vale/vocab.txt
@@ -49,6 +49,7 @@ Xcode
 Zapier
 addr
 api
+apis
 architecting
 argumentless
 artifactory


### PR DESCRIPTION
Turns agent events into reusable snippet & updated the Amazon EventBridge documentation page.