### PR TITLE
DOC-180: Add hamburger menu for small screens

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -16,6 +16,67 @@ $color-green: rgb(3, 165, 98);
   @media (max-width: $Docs__bp_stacked) { font-size: 2rem; }
 }
 
+/* Navicon for small screens (hamburger menu) */
+#navicon {visibility: hidden;}
+
+@media (max-width: $Docs__bp_stacked) {
+
+  /* hamburger */
+  label[for='navicon'],
+  label[for='navicon']:before,
+  label[for='navicon']:after {
+    background: #1f1f1f;
+    border-radius: 5px;
+    cursor: pointer;
+    height: 0.2rem;
+    position: absolute;
+    transition: 0.3s;
+    width: 0.9rem;
+    z-index: 10;
+  }
+
+  label[for='navicon'] {
+    right: 2rem;
+    top: 2rem;
+
+    span { // hide alt text
+      left: -10rem;
+      position: absolute;
+      top: -10rem;
+    }
+  }
+
+  label[for='navicon']:before {
+    content: "";
+    transform: translateY(-0.3rem);
+    transition: 0.5s;
+  }
+
+  label[for='navicon']:after {
+    content: "";
+    transform: translateY(0.3rem);
+    transition: 0.5s;
+  }
+
+  #navicon:checked + label[for='navicon'] {
+    /* displays menu */
+    & ~ .Docs__nav {
+      display: block;
+    }
+
+    /* close menu icon */
+    width: 0;
+
+    &:before {
+      transform: rotate(45deg) translateX(-0.5rem) translateY(0.5rem);
+    }
+
+    &:after {
+      transform: rotate(-45deg) translateX(-0.5rem) translateY(-0.5rem);
+    }
+  }
+}
+
 .Docs__nav {
   flex: 2;
   margin-top: 0.4em;
@@ -23,6 +84,7 @@ $color-green: rgb(3, 165, 98);
   position: relative;
 
   @media (max-width: $Docs__bp_stacked) {
+    display: none; // hides menu into navicon on small screens
     margin: 0 -20px 40px -20px;
     padding-right: 0;
   }

--- a/app/assets/stylesheets/public/_site_header.scss
+++ b/app/assets/stylesheets/public/_site_header.scss
@@ -55,7 +55,7 @@ $SiteHeader__bp_wrap_search: 600px;
   flex: 0 0 auto;
   line-height: $SiteHeaderLogoHeight;
   display: inline-block;
-  margin-right: 1em;
+  margin-right: 3em;
   margin-bottom: .5em;
 }
 

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,4 +1,8 @@
 <% current_section = request.original_fullpath.split('/')[2] %>
+
+<input type="checkbox" id="navicon" />
+<label for="navicon"><span>Display menu</span></label>
+
 <nav class="Docs__nav">
   <div class="Docs__nav__sections">
     <div class="Docs__nav__section-container <%= "current expanded" if current_section == 'tutorials' %>" data-docs-path="tutorials">
@@ -272,7 +276,7 @@
         let v2section = document.querySelector(`.Docs__nav__section-container[data-docs-path='agent-v2']`);
         v2section.classList.add("hidden");
       }
-      
+
       let sectionHeaders = document.getElementsByClassName('Docs__nav__section-heading');
       for (let sectionHeader of sectionHeaders) {
         sectionHeader.onclick = function() {
@@ -294,6 +298,6 @@
         for (let expandedSectionContainer of expandedSectionContainers) {
           expandedSectionContainer.classList.remove('expanded');
         }
-      }      
+      }
   })();
 <% end %>


### PR DESCRIPTION
This fixes DOC-180: https://linear.app/buildkite/issue/DOC-180/hide-site-menu-on-mobile

![navicon](https://user-images.githubusercontent.com/3682/146255699-b56f9989-febe-4dfe-ab77-05465e7bee60.gif)

Let me know how you feel about thickness of the lines, the animation, and the speed of transition.

I've deliberately not done any extra styling to the menu as yet to keep this small, but we can always adjust the look of it too.