### PR TITLE
Remove estimated time icon from the Deploying to Kubernetes page

### DIFF
--- a/pages/deployments/deploying_to_heroku.md.erb
+++ b/pages/deployments/deploying_to_heroku.md.erb
@@ -10,8 +10,6 @@ If you don’t use GitHub or need more control of deployments, this guide will r
 
 ## Setting up the Heroku Command Line Interface (CLI)
 
-<%= estimated_time "5-8 minutes" %>
-
 You can deploy to Heroku using the same `git push` command you’d run from your development machine.
 
 First step is installing the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-command-line) on your Buildkite agent machine. For example, this is how you’d do it on a linux agent machine:

--- a/pages/deployments/deploying_to_kubernetes.md.erb
+++ b/pages/deployments/deploying_to_kubernetes.md.erb
@@ -1,11 +1,11 @@
 # Deploying to Kubernetes
 
-<%= estimated_time "30 minutes" %>
+This tutorial demonstrates deploying to Kubernetes using Buildkite best
+practices.
 
 {:toc}
 
-This tutorial demonstrates deploying to Kubernetes using Buildkite best
-practices.  The tutorial uses one pipeline for tests and another for deploys.
+The tutorial uses one pipeline for tests and another for deploys.
 The test pipeline runs tests and push a Docker image to a registry. The deploy
 pipelines uses the `DOCKER_IMAGE` environment variable to create a [Kubernetes
 deployment][k8s_deployment] using `kubectl`. Then, you'll see how to link them


### PR DESCRIPTION
And provide a one-sentence explanation before the TOC.