### PR TITLE
Note on fixed state

### DIFF
--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -267,6 +267,9 @@ The below variables are supported by the `if` attribute:
 		<td><code>build.state</code></td>
 		<td><code>String</code></td>
 		<td>The state the current build is in<br><em>Available states:</em> <code> scheduled</code>, <code> running</code>, <code> passed</code>, <code> failed</code>, <code> blocked</code>, <code> canceling</code>, <code> canceled</code>, <code> skipped</code>, <code> not_run</code>, <code> fixed</code>, <code> finished</code></td>
+		<div class="Docs__wip-note">
+		<p>The <code>fixed</code> varible is not usable with conditionals at the moment - it is only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing.</p>
+	  </div>
 	</tr>
 	<tr>
 		<td><code>build.tag</code></td>

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -268,7 +268,7 @@ The below variables are supported by the `if` attribute:
 		<td><code>String</code></td>
 		<td>The state the current build is in<br><em>Available states:</em> <code> scheduled</code>, <code> running</code>, <code> passed</code>, <code> failed</code>, <code> blocked</code>, <code> canceling</code>, <code> canceled</code>, <code> skipped</code>, <code> not_run</code>, <code> fixed</code>, <code> finished</code></td>
 		<div class="Docs__wip-note">
-		<p>The <code>fixed</code> varible is not usable with conditionals at the moment - it is only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing.</p>
+		<p>The <code>fixed</code> variable is not usable with conditionals at the moment - it is only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing.</p>
 	  </div>
 	</tr>
 	<tr>

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -266,7 +266,7 @@ The below variables are supported by the `if` attribute:
 	<tr>
 		<td><code>build.state</code></td>
 		<td><code>String</code></td>
-		<td>The state the current build is in<br><em>Available states:</em> <code> scheduled</code>, <code> running</code>, <code> passed</code>, <code> failed</code>, <code> blocked</code>, <code> canceling</code>, <code> canceled</code>, <code> skipped</code>, <code> not_run</code>, <code> fixed</code> (only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing), <code> finished</code></td>
+		<td>The state the current build is in<br><em>Available states:</em> <code>scheduled</code>, <code>running</code>, <code>passed</code>, <code>failed</code>, <code>blocked</code>, <code>canceling</code>, <code>canceled</code>, <code>skipped</code>, <code>not_run</code>, <code>fixed</code>(only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing), <code>finished</code></td>
 	</tr>
 	<tr>
 		<td><code>build.tag</code></td>

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -266,10 +266,7 @@ The below variables are supported by the `if` attribute:
 	<tr>
 		<td><code>build.state</code></td>
 		<td><code>String</code></td>
-		<td>The state the current build is in<br><em>Available states:</em> <code> scheduled</code>, <code> running</code>, <code> passed</code>, <code> failed</code>, <code> blocked</code>, <code> canceling</code>, <code> canceled</code>, <code> skipped</code>, <code> not_run</code>, <code> fixed</code>, <code> finished</code></td>
-		  <div class="Docs__wip-note">
-		    <p>The <code>fixed</code> variable is not usable with conditionals at the moment - it is only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing.</p>
-	      </div>
+		<td>The state the current build is in<br><em>Available states:</em> <code> scheduled</code>, <code> running</code>, <code> passed</code>, <code> failed</code>, <code> blocked</code>, <code> canceling</code>, <code> canceled</code>, <code> skipped</code>, <code> not_run</code>, <code> fixed</code> (only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing), <code> finished</code></td>
 	</tr>
 	<tr>
 		<td><code>build.tag</code></td>

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -267,9 +267,9 @@ The below variables are supported by the `if` attribute:
 		<td><code>build.state</code></td>
 		<td><code>String</code></td>
 		<td>The state the current build is in<br><em>Available states:</em> <code> scheduled</code>, <code> running</code>, <code> passed</code>, <code> failed</code>, <code> blocked</code>, <code> canceling</code>, <code> canceled</code>, <code> skipped</code>, <code> not_run</code>, <code> fixed</code>, <code> finished</code></td>
-		<div class="Docs__wip-note">
-		<p>The <code>fixed</code> variable is not usable with conditionals at the moment - it is only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing.</p>
-	  </div>
+		  <div class="Docs__wip-note">
+		    <p>The <code>fixed</code> variable is not usable with conditionals at the moment - it is only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing.</p>
+	      </div>
 	</tr>
 	<tr>
 		<td><code>build.tag</code></td>


### PR DESCRIPTION
The "fixed state" is only supported for notification services  & means that a build passed, but the previous build on the same branch failed. Adding a note about it as a follow up to https://github.com/buildkite/docs/issues/1329