### PR TITLE
updated group merging info

### DIFF
--- a/pages/pipelines/group_step.md.erb
+++ b/pages/pipelines/group_step.md.erb
@@ -158,7 +158,7 @@ steps:
 
 ## Group merging
 
-If you upload a pipeline from another pipeline whose `group` or `label` same as the current pipeline, then groups will be merged together in the Buildkite UI.
+If you upload a pipeline that has a `group` or `label` that matches a `group` or `label` in the current pipeline, those groups will be merged together in the Buildkite UI.
 
 <section class="Docs__note">
   <h3>You can't define the same key twice</h3>

--- a/pages/pipelines/group_step.md.erb
+++ b/pages/pipelines/group_step.md.erb
@@ -158,7 +158,7 @@ steps:
 
 ## Group merging
 
-If you upload a pipeline that has a `group` or `label` already present in your YAML configuration file, the groups will be merged together in the Buildkite UI.
+If you upload a pipeline from another pipeline whose `group` or `label` same as the current pipeline, then groups will be merged together in the Buildkite UI.
 
 <section class="Docs__note">
   <h3>You can't define the same key twice</h3>


### PR DESCRIPTION
Doc says "If you upload a pipeline that has a group or label already present in your YAML configuration file, the groups will be merged together in the Buildkite UI"

But group merge happens only when the group name in the child pipeline is same as the group name that uploaded this pipeline and not when this group is already present.

So updated the doc as below. Please feel free to change the words for anything better :)

Now:
![image](https://user-images.githubusercontent.com/5114190/150441912-27638492-418b-45b6-b6c6-f7d32bdfbdce.png)


In the PR: 
![image](https://user-images.githubusercontent.com/5114190/150441875-f27cd5a2-1602-4074-86be-bb8431fecc97.png)
