### PR TITLE
Deprecate apt-key

### DIFF
--- a/pages/agent/v2/debian.md.erb
+++ b/pages/agent/v2/debian.md.erb
@@ -79,7 +79,7 @@ sudo tail -f /var/log/buildkite-agent.log
 
 ## Updating keys installed using apt-key
 
-If you've previously installed keys using `apt-key`, move the Buidkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
+If you've previously installed keys using `apt-key`, move the Buildkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
 
 Update your Buildkite agent entries in `/etc/apt/sources.list.d/buildkite-agent.list` to:
 

--- a/pages/agent/v2/debian.md.erb
+++ b/pages/agent/v2/debian.md.erb
@@ -27,14 +27,19 @@ Next, ensure you have the `apt-transport-https` package installed for the HTTPS 
 sudo apt-get install -y apt-transport-https dirmngr
 ```
 
-Now you can add our signed apt repository:
+Nownload the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
 
 ```shell
-sudo apt-key adv --keyserver keys.openpgp.org --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
-echo "deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
+wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
-Then install the agent:
+Then add the signed source to your apt sources list:
+
+```shell
+echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
+```
+
+And install the Buildkite agent:
 
 ```shell
 sudo apt-get update && sudo apt-get install -y buildkite-agent
@@ -70,6 +75,16 @@ sudo tail -f /var/log/upstart/buildkite-agent.log
 
 # For Debian 7.x (using sysvinit)
 sudo tail -f /var/log/buildkite-agent.log
+```
+
+## Updating keys installed using apt-key
+
+If you've previously installed keys using `apt-key`, move the Buidkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
+
+Update your Buildkite agent entries in `/etc/apt/sources.list.d/buildkite-agent.list` to:
+
+```shell
+deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main
 ```
 
 ## SSH key configuration

--- a/pages/agent/v2/debian.md.erb
+++ b/pages/agent/v2/debian.md.erb
@@ -27,7 +27,7 @@ Next, ensure you have the `apt-transport-https` package installed for the HTTPS 
 sudo apt-get install -y apt-transport-https dirmngr
 ```
 
-Nownload the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
+Now download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
 
 ```shell
 wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg

--- a/pages/agent/v2/debian.md.erb
+++ b/pages/agent/v2/debian.md.erb
@@ -27,13 +27,13 @@ Next, ensure you have the `apt-transport-https` package installed for the HTTPS 
 sudo apt-get install -y apt-transport-https dirmngr
 ```
 
-Now download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
+Download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
 
 ```shell
 wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
-Then add the signed source to your apt sources list:
+Then add the signed source to your list of apt sources:
 
 ```shell
 echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list

--- a/pages/agent/v2/ubuntu.md.erb
+++ b/pages/agent/v2/ubuntu.md.erb
@@ -17,7 +17,7 @@ Download the Buildkite PGP key to a directory that is only writable by `root` (c
 wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
-Then add the signed source to your apt sources list:
+Then add the signed source to your list of apt sources:
 
 ```shell
 echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list

--- a/pages/agent/v2/ubuntu.md.erb
+++ b/pages/agent/v2/ubuntu.md.erb
@@ -11,14 +11,19 @@ The Buildkite Agent can be installed on Ubuntu versions 14.04 and above using ou
 
 ## Installation
 
-First, add our signed apt repository:
+ownload the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
 
 ```shell
-echo "deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
-Then install the agent:
+Then add the signed source to your apt sources list:
+
+```shell
+echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
+```
+
+And install the Buildkite agent:
 
 ```shell
 sudo apt-get update && sudo apt-get install -y buildkite-agent
@@ -48,6 +53,16 @@ journalctl -f -u buildkite-agent
 
 # Older Ubuntu (upstart)
 tail -f /var/log/upstart/buildkite-agent.log
+```
+
+## Updating keys installed using apt-key
+
+If you've previously installed keys using `apt-key`, move the Buidkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
+
+Update your Buildkite agent entries in `/etc/apt/sources.list.d/buildkite-agent.list` to:
+
+```shell
+deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main
 ```
 
 ## SSH key configuration

--- a/pages/agent/v2/ubuntu.md.erb
+++ b/pages/agent/v2/ubuntu.md.erb
@@ -57,7 +57,7 @@ tail -f /var/log/upstart/buildkite-agent.log
 
 ## Updating keys installed using apt-key
 
-If you've previously installed keys using `apt-key`, move the Buidkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
+If you've previously installed keys using `apt-key`, move the Buildkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
 
 Update your Buildkite agent entries in `/etc/apt/sources.list.d/buildkite-agent.list` to:
 

--- a/pages/agent/v2/ubuntu.md.erb
+++ b/pages/agent/v2/ubuntu.md.erb
@@ -11,7 +11,7 @@ The Buildkite Agent can be installed on Ubuntu versions 14.04 and above using ou
 
 ## Installation
 
-ownload the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
+Download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
 
 ```shell
 wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg

--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -24,12 +24,19 @@ sudo apt-get install -y apt-transport-https dirmngr
 
 Now you can add our signed apt repository. The default version of the agent is `stable`, but you can get the beta version by using `unstable` instead of `stable` in the following command, or the agent built from the `main` branch of the repository by using `experimental` instead of `stable`.
 
+Download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
+
 ```shell
-sudo apt-key adv --keyserver keys.openpgp.org --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
-echo "deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
+wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
-Then install the agent:
+Then add the signed source to your apt sources list:
+
+```shell
+echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
+```
+
+And install the buildkite agent:
 
 ```shell
 sudo apt-get update && sudo apt-get install -y buildkite-agent
@@ -51,6 +58,16 @@ You can view the logs at:
 
 ```shell
 sudo journalctl -f -u buildkite-agent
+```
+
+## Updating keys installed using apt-key
+
+If you've previously installed keys using `apt-key`, move the Buidkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
+
+Update your Buildkite agent entries in `/etc/apt/sources.list.d/buildkite-agent.list` to:
+
+```shell
+deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main
 ```
 
 ## SSH Key Configuration

--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -62,7 +62,7 @@ sudo journalctl -f -u buildkite-agent
 
 ## Updating keys installed using apt-key
 
-If you've previously installed keys using `apt-key`, move the Buidkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
+If you've previously installed keys using `apt-key`, move the Buildkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
 
 Update your Buildkite agent entries in `/etc/apt/sources.list.d/buildkite-agent.list` to:
 

--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -36,7 +36,7 @@ Then add the signed source to your apt sources list:
 echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
 ```
 
-And install the buildkite agent:
+And install the Buildkite agent:
 
 ```shell
 sudo apt-get update && sudo apt-get install -y buildkite-agent

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -14,7 +14,7 @@ First, add our signed apt repository. The default version of the agent is `stabl
 wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
-Then add the signed source to your apt sources list:
+Then add the signed source to your list of apt sources:
 
 ```shell
 echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -46,7 +46,7 @@ journalctl -f -u buildkite-agent
 
 ## Updating keys installed using apt-key
 
-If you've previously installed keys using `apt-key`, move the Buidkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
+If you've previously installed keys using `apt-key`, move the Buildkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
 
 Update your Buildkite agent entries in `/etc/apt/sources.list.d/buildkite-agent.list` to:
 

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -8,12 +8,19 @@ The Buildkite Agent is supported on Ubuntu versions 18.04 and above using our si
 
 First, add our signed apt repository. The default version of the agent is `stable`, but you can get the beta version by using `unstable` instead of `stable` in the following command, or the agent built from the `main` branch of the repository by using `experimental` instead of `stable`.
 
++Download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
+
 ```shell
-echo "deb https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198
+wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
-Then install the agent:
+Then add the signed source to your apt sources list:
+
+```shell
+echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
+```
+
+And install the Buildkite agent:
 
 ```shell
 sudo apt-get update && sudo apt-get install -y buildkite-agent
@@ -35,6 +42,16 @@ You can view the logs at:
 
 ```shell
 journalctl -f -u buildkite-agent
+```
+
+## Updating keys installed using apt-key
+
+If you've previously installed keys using `apt-key`, move the Buidkite agent key from `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` to `/usr/share/keyrings/buildkite-agent-archive-keyring.gpg`, making sure that both that file and directory are only writable by `root`.
+
+Update your Buildkite agent entries in `/etc/apt/sources.list.d/buildkite-agent.list` to:
+
+```shell
+deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main
 ```
 
 ## SSH key configuration


### PR DESCRIPTION
@yob would you mind casting an eye on this when you have a moment (no rush)

Probably worth applying to the `Dockerfile` as well, what do you think? 

Context https://blog.cloudflare.com/dont-use-apt-key/