### PR TITLE
Clarify `concurrency` must be used with `concurrency_group`

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -87,7 +87,7 @@ _Optional attributes:_
   <tr>
     <td><code>concurrency_group</code></td>
     <td>
-      A unique name for the concurrency group that you are creating with the <code>concurrency</code> attribute.<br>
+      A unique name for the concurrency group that you are creating. If you use this attribute, you must also define the <code>concurrency</code> attribute.<br>
       <em>Example:</em> <code>"my-app/deploy"</code>
     </td>
   </tr>


### PR DESCRIPTION
There has been some confusion about a default value for the `concurrency` attribute when trying to define a concurrency group. Both `concurrency` and `concurrency_group` must be specified for it to work, and there is no error if one is omitted. This attempts to clarify that.

Existing page: https://buildkite.com/docs/pipelines/command-step

Before:
![Screen Shot 2022-01-31 at 09 26 14](https://user-images.githubusercontent.com/6128798/151727183-0bd96ee0-4241-4fc3-8a17-9f78b947f558.png)

After:
![Screen Shot 2022-01-31 at 09 25 32](https://user-images.githubusercontent.com/6128798/151727190-3f27470f-9cf5-4fac-a3c4-9546e1225368.png)


Perhaps the API should enforce this but for now, a docs update would be good. I'm not sure if this change makes enough sense or whether we should add more to the `concurrency` row on this page to say something like: 

| There is no default value. You must specify a limit for concurrency limits to take effect.
