### PR TITLE
Added real example path to powershell

### DIFF
--- a/pages/agent/v3/windows.md.erb
+++ b/pages/agent/v3/windows.md.erb
@@ -50,7 +50,8 @@ There are two options to be aware of for this initial setup:
 * You may need to use the `shell` configuration option. On Windows, Buildkite defaults to using Batch. If you want to use PowerShell or PowerShell Core, you must point Buildkite to the correct shell. For example, to use PowerShell:
 
     ```cfg
-    shell="<path-to-powershell-executable>"
+    #Provide the path to PowerShell executables
+    shell="C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
     ```
 
 <div class="Docs__note">


### PR DESCRIPTION
We had a ticket today asking for the format of the shell path. So updated the doc for future users.

Now:
![image](https://user-images.githubusercontent.com/5114190/151775256-12e66113-e938-4fe6-9abf-4df12ca40c3f.png)

In the PR: 
![image](https://user-images.githubusercontent.com/5114190/151775326-baf9b888-6b28-499b-9f17-1924347aa973.png)
