### PR TITLE
Added details on how to access buildkite-build-number when using YAML editor

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -622,9 +622,7 @@ You can define environment variables in your jobs in a few ways, depending on th
 
 Any environment variables set by Buildkite will be interpolated by the Agent.
 
-If you're using the YAML Steps editor to define your pipeline, only a subset of the environment variables are available at this level. Some variables, for example `BUILDKITE_BUILD_NUMBER`, cannot be supported in the YAML Step editor as the interpolation happens before the build is created.
-
-The following variables are available directly in the YAML Step editor:
+If you're using the YAML Steps editor to define your pipeline, only the following subset of the environment variables are available:
 
 * `BUILDKITE_BRANCH`
 * `BUILDKITE_TAG`
@@ -640,7 +638,11 @@ The following variables are available directly in the YAML Step editor:
 * `BUILDKITE_PULL_REQUEST_BASE_BRANCH`
 * `BUILDKITE_PULL_REQUEST_REPO`
 
-You can access the rest of the Buildkite [environment variables](/docs/pipelines/environment-variables#bk-env-vars) by using a `pipeline.yml` file. Either define your entire pipeline in the YAML file, or you do a [pipeline upload](/docs/agent/v3/cli-pipeline) part way through your build that adds only the steps that use environment variables. See the [dynamic pipelines](/docs/pipelines/defining-steps#dynamic-pipelines) docs for more information about adding steps with pipeline uploads.
+Some variables, for example `BUILDKITE_BUILD_NUMBER`, cannot be supported in the YAML Step editor as the interpolation happens before the build is created. In those cases, interpolate them at the [runtime](/docs/pipelines/environment-variables#runtime-variable-interpolation).
+
+Alternatively, You can also access the rest of the Buildkite [environment variables](/docs/pipelines/environment-variables#bk-env-vars) by using a `pipeline.yml` file. Either define your entire pipeline in the YAML file, or you do a [pipeline upload](/docs/agent/v3/cli-pipeline) part way through your build that adds only the steps that use environment variables. See the [dynamic pipelines](/docs/pipelines/defining-steps#dynamic-pipelines) docs for more information about adding steps with pipeline uploads.
+
+## Runtime variable interpolation
 
 When using environment variables that will be evaluated at run-time, make sure you escape the `$` character using `$$` or `\$`. For example:
 


### PR DESCRIPTION
BUILDKITE_BUILD_NUMBER can be accessed if interpolated at runtime when using YAML editor. Added this clarification to the doc and also updated the flow a little.
