### PR TITLE
Prettify the link that was colliding with navbar

### DIFF
--- a/pages/integrations/cc_menu.md.erb
+++ b/pages/integrations/cc_menu.md.erb
@@ -6,13 +6,13 @@ Buildkite has support for the `cctray.xml` format, allowing you to feed your bui
 
 ## Feed URL
 
-You can access your organization’s `cc.xml` feed using the URL:
+You can access your organization's `cc.xml` feed using the URL:
 
 ```
 https://cc.buildkite.com/[organization-slug].xml?access_token=xxx
 ```
 
-You’ll need to <a href="<%= url_helpers.user_access_tokens_url %>" rel="nofollow">create an API Access Token</a> with scope `read_builds`.
+You'll need to <a href="<%= url_helpers.user_access_tokens_url %>" rel="nofollow">create an API Access Token</a> with scope `read_builds`.
 
 <%= image "ccmenu.png", width: 481, height: 490 %>
 
@@ -44,7 +44,7 @@ http://ccmenu.org/
 
 ## CCTray for Windows
 
-http://sourceforge.net/projects/ccnet/files/CruiseControl.NET%20Releases/CruiseControl.NET%201.8.5/
+[http://sourceforge.net/projects/ccnet/files/CruiseControl.NET](http://sourceforge.net/projects/ccnet/files/CruiseControl.NET%20Releases/CruiseControl.NET%201.8.5/)
 
 ## BuildNotify for Ubuntu
 

--- a/vale/vocab.txt
+++ b/vale/vocab.txt
@@ -65,6 +65,7 @@ boolean
 boomper
 buildkite
 buildscript
+ccnet
 chatbot
 chroot
 chroots


### PR DESCRIPTION
Let's merge this fix for the time being. The reason why CCTray refuses to cooperate is still unknown.