### PR TITLE
remove reference to "finished" as a valid build.state

### DIFF
--- a/pages/pipelines/_job_states.md.erb
+++ b/pages/pipelines/_job_states.md.erb
@@ -1,1 +1,1 @@
-Job state can be one of `pending`, `waiting`, `waiting_failed`, `blocked`, `blocked_failed`, `unblocked`, `unblocked_failed`, `limiting`, `limited`, `scheduled`, `assigned`, `accepted`, `running`, `canceling`, `canceled`, `timing_out`, `timed_out`, `skipped`, or  `broken`.
+Job state can be one of `pending`, `waiting`, `waiting_failed`, `blocked`, `blocked_failed`, `unblocked`, `unblocked_failed`, `limiting`, `limited`, `scheduled`, `assigned`, `accepted`, `running`, `finished`, `canceling`, `canceled`, `timing_out`, `timed_out`, `skipped`, or `broken`.

--- a/pages/pipelines/_job_states.md.erb
+++ b/pages/pipelines/_job_states.md.erb
@@ -1,1 +1,1 @@
-Job state can be one of `pending`, `waiting`, `waiting_failed`, `blocked`, `blocked_failed`, `unblocked`, `unblocked_failed`, `limiting`, `limited`, `scheduled`, `assigned`, `accepted`, `running`, `finished`, `canceling`, `canceled`, `timing_out`, `timed_out`, `skipped`, or  `broken`.
+Job state can be one of `pending`, `waiting`, `waiting_failed`, `blocked`, `blocked_failed`, `unblocked`, `unblocked_failed`, `limiting`, `limited`, `scheduled`, `assigned`, `accepted`, `running`, `canceling`, `canceled`, `timing_out`, `timed_out`, `skipped`, or  `broken`.

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -266,7 +266,7 @@ The below variables are supported by the `if` attribute:
 	<tr>
 		<td><code>build.state</code></td>
 		<td><code>String</code></td>
-		<td>The state the current build is in<br><em>Available states:</em> <code>scheduled</code>, <code>running</code>, <code>passed</code>, <code>failed</code>, <code>blocked</code>, <code>canceling</code>, <code>canceled</code>, <code>skipped</code>, <code>not_run</code>, <code>fixed</code>(only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing), <code>finished</code></td>
+		<td>The state the current build is in<br><em>Available states:</em> <code>scheduled</code>, <code>running</code>, <code>passed</code>, <code>failed</code>, <code>blocked</code>, <code>canceling</code>, <code>canceled</code>, <code>skipped</code>, <code>not_run</code>, <code>fixed</code>(only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing)</td>
 	</tr>
 	<tr>
 		<td><code>build.tag</code></td>

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -266,7 +266,7 @@ The below variables are supported by the `if` attribute:
 	<tr>
 		<td><code>build.state</code></td>
 		<td><code>String</code></td>
-		<td>The state the current build is in<br><em>Available states:</em> <code>scheduled</code>, <code>running</code>, <code>passed</code>, <code>failed</code>, <code>blocked</code>, <code>canceling</code>, <code>canceled</code>, <code>skipped</code>, <code>not_run</code>, <code>fixed</code>(only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing)</td>
+		<td>The state the current build is in<br><em>Available states:</em><code>started</code>,<code>scheduled</code>, <code>running</code>, <code>passed</code>, <code>failed</code>, <code>blocked</code>, <code>canceling</code>, <code>canceled</code>, <code>skipped</code>, <code>not_run</code>, <code>fixed</code>(only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing)</td>
 	</tr>
 	<tr>
 		<td><code>build.tag</code></td>


### PR DESCRIPTION
`finished` is an alias for `passed` or `failed` builds, but it seems like it can't be referenced if the build never started (or perhaps some other change has occurred - not sure)

For example, if I create a notification trigger in my pipeline with the `if: build.state == 'finished'` I receive the following error on my pipeline upload step:

```
422 The `webhook` notification is invalid: `if` expression failed to parse: "finished" is not a valid `build.state` (line 1, column 16-25)
--
  | 🚨 Error: The command exited with status 1
  | user command error: exit status 1
```

So it makes sense to remove `finished` as the state from the valid states that can be referenced.