### PR TITLE
Move insertion order section out from environment section

### DIFF
--- a/pages/agent/v3/cli_pipeline.md.erb
+++ b/pages/agent/v3/cli_pipeline.md.erb
@@ -19,6 +19,11 @@ The pipeline can be written as YAML or JSON, but YAML is more common for its rea
 * `steps` - A list of [build pipeline steps](/docs/pipelines/defining-steps)
 
 
+## Insertion order
+
+Steps are inserted immediately following the job performing the pipeline upload. Note that if you perform multiple uploads from a single step, they can appear to be in reverse order, because the later uploads are inserted earlier in the pipeline.
+
+
 ## Environment variable substitution
 
 The `pipeline upload` command supports environment variable substitution using the syntax `$VAR` and `${VAR}`.
@@ -43,10 +48,6 @@ If you want an environment variable to be evaluated at run-time (for example, us
   env:
     SERVER: "server-a"
 ```
-
-### Insertion order
-
-Steps are inserted immediately following the job performing the pipeline upload. Note that if you perform multiple uploads from a single step, they can appear to be in reverse order, because the later uploads are inserted earlier in the pipeline.
 
 ### Escaping the `$` character
 


### PR DESCRIPTION
The insertion order section applies to the pipeline upload command and not to the environment subsection so I have moved it out and increased its header.

Docs page: https://buildkite.com/docs/agent/v3/cli-pipeline#environment-variable-substitution-insertion-order

Before:
![Screen Shot 2022-02-02 at 10 08 14](https://user-images.githubusercontent.com/6128798/152082392-b2c51688-e7b0-4a3f-9090-39f6dbb1e5d2.png)

After:
![Screen Shot 2022-02-02 at 10 08 27](https://user-images.githubusercontent.com/6128798/152082410-968cb1be-7934-40a0-8864-401a22d07db5.png)

