### PR TITLE
Private S3 location for build log archives

### DIFF
--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -155,7 +155,7 @@ By default, build logs are stored in encrypted form in Buildkite's Amazon S3 buc
 To set up a private build log archive storage:
 
 1. Create an Amazon S3 bucket in *us-east-1* location (the only region currently supported).
-1. Provide read and write access permission policy for the Buildkite's AWS account `032379705303`. Here's an example policy:
+1. Provide *read* and *write* access permission policy for the Buildkite's AWS account `032379705303`. Here's an example policy that contains an Amazon S3 bucket configuration with Buildkite's account number in it. Configure your Amazon S3 bucket in a similar way:
 
 ```json
 {
@@ -211,4 +211,4 @@ To set up a private build log archive storage:
 }
 ```
 
-1. Reach out to [success@buildkite.com](mailto:success@buildkite.com) to complete the setup. You will need to provide the information about your S3 bucket.
+1. Reach out to [success@buildkite.com](mailto:success@buildkite.com) and provide the address of your Amazon S3 bucket. The Buildkite engineering team will continue the configuration to complete the setup.

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -146,10 +146,10 @@ For example, if you have environment variable `MY_SECRET="topsecret"`and you run
 
 ## Private build log archive storage
 
-By default, build logs are stored in encrypted form in Buildkite's Amazon S3 buckets. If you want to have an increased level of security, you can store the archived build logs in your private AWS S3 bucket.
+By default, build logs are stored in encrypted form in Buildkite's Amazon S3 buckets, but you can also store the archived build logs in your private AWS S3 bucket.
 
 <div class="Docs__note">
-<p>You need to be subscribed to the <a href="https://buildkite.com/pricing">Buildkite Enterprise</a> payment plan to use a private AWS S3 build log archive location.</p>
+<p>This feature is only available to <a href="https://buildkite.com/pricing">Buildkite Enterprise</a> users.</p>
 </div>
 
 To set up a private build log archive storage:

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -154,8 +154,10 @@ By default, build logs are stored in encrypted form in Buildkite's Amazon S3 buc
 
 To set up a private build log archive storage:
 
-1. Create an Amazon S3 bucket in *us-east-1* location (the only region currently supported).
-1. Provide *read* and *write* access permission policy for the Buildkite's AWS account `032379705303`. Here's an example policy that contains an Amazon S3 bucket configuration with Buildkite's account number in it. Configure your Amazon S3 bucket in a similar way:
+1. Create an Amazon S3 bucket in *us-east-1* location (the only region that is currently supported).
+1. Provide *read* and *write* access permission policy for the Buildkite's AWS account `032379705303`.
+
+Here's an example policy that contains an Amazon S3 bucket configuration with Buildkite's account number in it. Replace `my-bucket` and `my-prefix` placeholders with your Amazon S3 bucket information:
 
 ```json
 {

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -213,4 +213,4 @@ Here's an example policy that contains an Amazon S3 bucket configuration with Bu
 }
 ```
 
-3. Reach out to [success@buildkite.com](mailto:success@buildkite.com) and provide the address of your Amazon S3 bucket. The Buildkite engineering team will continue the configuration to complete the setup.
+After you have created and configured your Amazon S3 bucket, reach out to [success@buildkite.com](mailto:success@buildkite.com) and provide the address of your Amazon S3 bucket. The Buildkite engineering team will continue the configuration to complete the setup.

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -157,60 +157,60 @@ To set up a private build log archive storage:
 1. Create an Amazon S3 bucket in *us-east-1* location (the only region that is currently supported).
 2. Provide *read* and *write* access permission policy for the Buildkite's AWS account `032379705303`.
 
-   Here's an example policy that contains an Amazon S3 bucket configuration with Buildkite's account number in it. Replace `my-bucket` and `my-prefix` placeholders with your Amazon S3 bucket information:
+    Here's an example policy that contains an Amazon S3 bucket configuration with Buildkite's account number in it. Replace `my-bucket` and `my-prefix` placeholders with your Amazon S3 bucket information:
 
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "AllowBuildkiteToWriteObjectsInLogsPrefix",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn\:aws\:iam::032379705303:root"
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowBuildkiteToWriteObjectsInLogsPrefix",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn\:aws\:iam::032379705303:root"
+                },
+                "Action": "s3:PutObject",
+                "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*",
+                "Condition": {
+                    "StringEquals": {
+                        "s3:x-amz-acl": "bucket-owner-full-control"
+                    }
+                }
             },
-            "Action": "s3:PutObject",
-            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*",
-            "Condition": {
-                "StringEquals": {
-                    "s3:x-amz-acl": "bucket-owner-full-control"
+            {
+                "Sid": "AllowBuildkiteToReadObjectsInLogsPrefix",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn\:aws\:iam::032379705303:root"
+                },
+                "Action": "s3:GetObject",
+                "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
+            },
+            {
+                "Sid": "AllowBuildkiteToDeleteObjectsInLogsPrefix",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn\:aws\:iam::032379705303:root"
+                },
+                "Action": "s3:DeleteObject",
+                "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
+            },
+            {
+                "Sid": "AllowBuildkiteToListBucketInLogsPrefix",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn:\aws\:iam::032379705303:root"
+                },
+                "Action": "s3:ListBucket",
+                "Resource": "arn\:aws\:s3:::my-bucket",
+                "Condition": {
+                    "StringLike": {
+                        "s3:prefix": "my-prefix/*"
+                    }
                 }
             }
-        },
-        {
-            "Sid": "AllowBuildkiteToReadObjectsInLogsPrefix",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn\:aws\:iam::032379705303:root"
-            },
-            "Action": "s3:GetObject",
-            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
-        },
-        {
-            "Sid": "AllowBuildkiteToDeleteObjectsInLogsPrefix",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn\:aws\:iam::032379705303:root"
-            },
-            "Action": "s3:DeleteObject",
-            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
-        },
-        {
-            "Sid": "AllowBuildkiteToListBucketInLogsPrefix",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:\aws\:iam::032379705303:root"
-            },
-            "Action": "s3:ListBucket",
-            "Resource": "arn\:aws\:s3:::my-bucket",
-            "Condition": {
-                "StringLike": {
-                    "s3:prefix": "my-prefix/*"
-                }
-            }
-        }
-    ]
-}
-```
+        ]
+    }
+    ```
 
 3. Reach out to [success@buildkite.com](mailto:success@buildkite.com) and provide the address of your Amazon S3 bucket. The Buildkite engineering team will continue the configuration to complete the setup.

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -167,10 +167,10 @@ Here's an example policy that contains an Amazon S3 bucket configuration with Bu
             "Sid": "AllowBuildkiteToWriteObjectsInLogsPrefix",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn\:aws:iam::032379705303:root"
+                "AWS": "arn\:aws\:iam::032379705303:root"
             },
             "Action": "s3:PutObject",
-            "Resource": "arn\:aws:s3:::my-bucket/my-prefix/*",
+            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*",
             "Condition": {
                 "StringEquals": {
                     "s3:x-amz-acl": "bucket-owner-full-control"
@@ -181,28 +181,28 @@ Here's an example policy that contains an Amazon S3 bucket configuration with Bu
             "Sid": "AllowBuildkiteToReadObjectsInLogsPrefix",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn\:aws:iam::032379705303:root"
+                "AWS": "arn\:aws\:iam::032379705303:root"
             },
             "Action": "s3:GetObject",
-            "Resource": "arn\:aws:s3:::my-bucket/my-prefix/*"
+            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
         },
         {
             "Sid": "AllowBuildkiteToDeleteObjectsInLogsPrefix",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn\:aws:iam::032379705303:root"
+                "AWS": "arn\:aws\:iam::032379705303:root"
             },
             "Action": "s3:DeleteObject",
-            "Resource": "arn\:aws:s3:::my-bucket/my-prefix/*"
+            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
         },
         {
             "Sid": "AllowBuildkiteToListBucketInLogsPrefix",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::032379705303:root"
+                "AWS": "arn:\aws\:iam::032379705303:root"
             },
             "Action": "s3:ListBucket",
-            "Resource": "arn\:aws:s3:::my-bucket",
+            "Resource": "arn\:aws\:s3:::my-bucket",
             "Condition": {
                 "StringLike": {
                     "s3:prefix": "my-prefix/*"

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -159,58 +159,58 @@ To set up a private build log archive storage:
 
    Here's an example policy that contains an Amazon S3 bucket configuration with Buildkite's account number in it. Replace `my-bucket` and `my-prefix` placeholders with your Amazon S3 bucket information:
 
-    ```json
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Sid": "AllowBuildkiteToWriteObjectsInLogsPrefix",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "arn\:aws\:iam::032379705303:root"
-                },
-                "Action": "s3:PutObject",
-                "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*",
-                "Condition": {
-                    "StringEquals": {
-                        "s3:x-amz-acl": "bucket-owner-full-control"
-                    }
-                }
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowBuildkiteToWriteObjectsInLogsPrefix",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn\:aws\:iam::032379705303:root"
             },
-            {
-                "Sid": "AllowBuildkiteToReadObjectsInLogsPrefix",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "arn\:aws\:iam::032379705303:root"
-                },
-                "Action": "s3:GetObject",
-                "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
-            },
-            {
-                "Sid": "AllowBuildkiteToDeleteObjectsInLogsPrefix",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "arn\:aws\:iam::032379705303:root"
-                },
-                "Action": "s3:DeleteObject",
-                "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
-            },
-            {
-                "Sid": "AllowBuildkiteToListBucketInLogsPrefix",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "arn:\aws\:iam::032379705303:root"
-                },
-                "Action": "s3:ListBucket",
-                "Resource": "arn\:aws\:s3:::my-bucket",
-                "Condition": {
-                    "StringLike": {
-                        "s3:prefix": "my-prefix/*"
-                    }
+            "Action": "s3:PutObject",
+            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control"
                 }
             }
-        ]
-    }
-    ```
+        },
+        {
+            "Sid": "AllowBuildkiteToReadObjectsInLogsPrefix",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn\:aws\:iam::032379705303:root"
+            },
+            "Action": "s3:GetObject",
+            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
+        },
+        {
+            "Sid": "AllowBuildkiteToDeleteObjectsInLogsPrefix",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn\:aws\:iam::032379705303:root"
+            },
+            "Action": "s3:DeleteObject",
+            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
+        },
+        {
+            "Sid": "AllowBuildkiteToListBucketInLogsPrefix",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:\aws\:iam::032379705303:root"
+            },
+            "Action": "s3:ListBucket",
+            "Resource": "arn\:aws\:s3:::my-bucket",
+            "Condition": {
+                "StringLike": {
+                    "s3:prefix": "my-prefix/*"
+                }
+            }
+        }
+    ]
+}
+```
 
 3. Reach out to [success@buildkite.com](mailto:success@buildkite.com) and provide the address of your Amazon S3 bucket. The Buildkite engineering team will continue the configuration to complete the setup.

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -167,10 +167,10 @@ Here's an example policy that contains an Amazon S3 bucket configuration with Bu
             "Sid": "AllowBuildkiteToWriteObjectsInLogsPrefix",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::032379705303:root"
+                "AWS": "arn\:aws:iam::032379705303:root"
             },
             "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::my-bucket/my-prefix/*",
+            "Resource": "arn\:aws:s3:::my-bucket/my-prefix/*",
             "Condition": {
                 "StringEquals": {
                     "s3:x-amz-acl": "bucket-owner-full-control"
@@ -181,19 +181,19 @@ Here's an example policy that contains an Amazon S3 bucket configuration with Bu
             "Sid": "AllowBuildkiteToReadObjectsInLogsPrefix",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::032379705303:root"
+                "AWS": "arn\:aws:iam::032379705303:root"
             },
             "Action": "s3:GetObject",
-            "Resource": "arn:aws:s3:::my-bucket/my-prefix/*"
+            "Resource": "arn\:aws:s3:::my-bucket/my-prefix/*"
         },
         {
             "Sid": "AllowBuildkiteToDeleteObjectsInLogsPrefix",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::032379705303:root"
+                "AWS": "arn\:aws:iam::032379705303:root"
             },
             "Action": "s3:DeleteObject",
-            "Resource": "arn:aws:s3:::my-bucket/my-prefix/*"
+            "Resource": "arn\:aws:s3:::my-bucket/my-prefix/*"
         },
         {
             "Sid": "AllowBuildkiteToListBucketInLogsPrefix",
@@ -202,7 +202,7 @@ Here's an example policy that contains an Amazon S3 bucket configuration with Bu
                 "AWS": "arn:aws:iam::032379705303:root"
             },
             "Action": "s3:ListBucket",
-            "Resource": "arn:aws:s3:::my-bucket",
+            "Resource": "arn\:aws:s3:::my-bucket",
             "Condition": {
                 "StringLike": {
                     "s3:prefix": "my-prefix/*"

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -119,7 +119,7 @@ Make sure to set the `-o pipefail` option in your buildscript as above, otherwis
 
 <%= image("xcpretty.png", alt: "Screenshot of xcpretty output", size: '656x316') %>
 
-## Encryption and security  
+## Encryption and security
 
 Buildkite has zero access to your source code in the pipelines and only receives and stores the log output of the builds and build artifacts in encrypted form.
 
@@ -143,3 +143,72 @@ For example, if you have environment variable `MY_SECRET="topsecret"`and you run
 <h3 class="Docs__note__heading">Setting environment variables</h3>
 <p>Note that if you <emphasis>set</emphasis> or <emphasis>interpolate</emphasis> a secret environment variable in your <code>pipeline.yml</code> it is not redacted, but doing that is <a href="/docs/pipelines/secrets#anti-pattern-storing-secrets-in-your-pipeline-dot-yml">not recommended</a>.</p>
 </div>
+
+## Private build log archive storage
+
+By default, build logs are stored in encrypted form in Buildkite's Amazon S3 buckets. If you want to have an increased level of security, you can store the archived build logs in your private AWS S3 bucket.
+
+<div class="Docs__note">
+<p>You need to be subscribed to the <a href="https://buildkite.com/pricing">Buildkite Enterprise</a> payment plan to use a private AWS S3 build log archive location.</p>
+</div>
+
+To set up a private build log archive storage:
+
+1. Create an Amazon S3 bucket in *us-east-1* location (the only region currently supported).
+1. Provide read and write access permission policy for the Buildkite's AWS account `032379705303`. Here's an example policy:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowBuildkiteToWriteObjectsInLogsPrefix",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::032379705303:root"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::my-bucket/my-prefix/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        },
+        {
+            "Sid": "AllowBuildkiteToReadObjectsInLogsPrefix",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::032379705303:root"
+            },
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::my-bucket/my-prefix/*"
+        },
+        {
+            "Sid": "AllowBuildkiteToDeleteObjectsInLogsPrefix",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::032379705303:root"
+            },
+            "Action": "s3:DeleteObject",
+            "Resource": "arn:aws:s3:::my-bucket/my-prefix/*"
+        },
+        {
+            "Sid": "AllowBuildkiteToListBucketInLogsPrefix",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::032379705303:root"
+            },
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::my-bucket",
+            "Condition": {
+                "StringLike": {
+                    "s3:prefix": "my-prefix/*"
+                }
+            }
+        }
+    ]
+}
+```
+
+1. Reach out to [success@buildkite.com](mailto:success@buildkite.com) to complete the setup. You will need to provide the information about your S3 bucket.

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -157,60 +157,60 @@ To set up a private build log archive storage:
 1. Create an Amazon S3 bucket in *us-east-1* location (the only region that is currently supported).
 2. Provide *read* and *write* access permission policy for the Buildkite's AWS account `032379705303`.
 
-Here's an example policy that contains an Amazon S3 bucket configuration with Buildkite's account number in it. Replace `my-bucket` and `my-prefix` placeholders with your Amazon S3 bucket information:
+   Here's an example policy that contains an Amazon S3 bucket configuration with Buildkite's account number in it. Replace `my-bucket` and `my-prefix` placeholders with your Amazon S3 bucket information:
 
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "AllowBuildkiteToWriteObjectsInLogsPrefix",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn\:aws\:iam::032379705303:root"
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowBuildkiteToWriteObjectsInLogsPrefix",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn\:aws\:iam::032379705303:root"
+                },
+                "Action": "s3:PutObject",
+                "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*",
+                "Condition": {
+                    "StringEquals": {
+                        "s3:x-amz-acl": "bucket-owner-full-control"
+                    }
+                }
             },
-            "Action": "s3:PutObject",
-            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*",
-            "Condition": {
-                "StringEquals": {
-                    "s3:x-amz-acl": "bucket-owner-full-control"
+            {
+                "Sid": "AllowBuildkiteToReadObjectsInLogsPrefix",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn\:aws\:iam::032379705303:root"
+                },
+                "Action": "s3:GetObject",
+                "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
+            },
+            {
+                "Sid": "AllowBuildkiteToDeleteObjectsInLogsPrefix",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn\:aws\:iam::032379705303:root"
+                },
+                "Action": "s3:DeleteObject",
+                "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
+            },
+            {
+                "Sid": "AllowBuildkiteToListBucketInLogsPrefix",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn:\aws\:iam::032379705303:root"
+                },
+                "Action": "s3:ListBucket",
+                "Resource": "arn\:aws\:s3:::my-bucket",
+                "Condition": {
+                    "StringLike": {
+                        "s3:prefix": "my-prefix/*"
+                    }
                 }
             }
-        },
-        {
-            "Sid": "AllowBuildkiteToReadObjectsInLogsPrefix",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn\:aws\:iam::032379705303:root"
-            },
-            "Action": "s3:GetObject",
-            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
-        },
-        {
-            "Sid": "AllowBuildkiteToDeleteObjectsInLogsPrefix",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn\:aws\:iam::032379705303:root"
-            },
-            "Action": "s3:DeleteObject",
-            "Resource": "arn\:aws\:s3:::my-bucket/my-prefix/*"
-        },
-        {
-            "Sid": "AllowBuildkiteToListBucketInLogsPrefix",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:\aws\:iam::032379705303:root"
-            },
-            "Action": "s3:ListBucket",
-            "Resource": "arn\:aws\:s3:::my-bucket",
-            "Condition": {
-                "StringLike": {
-                    "s3:prefix": "my-prefix/*"
-                }
-            }
-        }
-    ]
-}
-```
+        ]
+    }
+    ```
 
-After you have created and configured your Amazon S3 bucket, reach out to [success@buildkite.com](mailto:success@buildkite.com) and provide the address of your Amazon S3 bucket. The Buildkite engineering team will continue the configuration to complete the setup.
+3. Reach out to [success@buildkite.com](mailto:success@buildkite.com) and provide the address of your Amazon S3 bucket. The Buildkite engineering team will continue the configuration to complete the setup.

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -155,7 +155,7 @@ By default, build logs are stored in encrypted form in Buildkite's Amazon S3 buc
 To set up a private build log archive storage:
 
 1. Create an Amazon S3 bucket in *us-east-1* location (the only region that is currently supported).
-1. Provide *read* and *write* access permission policy for the Buildkite's AWS account `032379705303`.
+2. Provide *read* and *write* access permission policy for the Buildkite's AWS account `032379705303`.
 
 Here's an example policy that contains an Amazon S3 bucket configuration with Buildkite's account number in it. Replace `my-bucket` and `my-prefix` placeholders with your Amazon S3 bucket information:
 
@@ -213,4 +213,4 @@ Here's an example policy that contains an Amazon S3 bucket configuration with Bu
 }
 ```
 
-1. Reach out to [success@buildkite.com](mailto:success@buildkite.com) and provide the address of your Amazon S3 bucket. The Buildkite engineering team will continue the configuration to complete the setup.
+3. Reach out to [success@buildkite.com](mailto:success@buildkite.com) and provide the address of your Amazon S3 bucket. The Buildkite engineering team will continue the configuration to complete the setup.


### PR DESCRIPTION
This adds instruction on how to enable a private location for build log archives in AWS S3. Only applicable to Enterprise users. 