### PR TITLE
Update margins on Experiment Feature blocks inside attribute tables

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -393,7 +393,6 @@ label[for='navicon'] span { // hide alt text
   }
 
   td p:first-child { margin-top: 0; }
-  td p:last-child { margin-bottom: 0; }
 
   .Docs__attribute__link {
     color: #ccc;
@@ -429,6 +428,10 @@ label[for='navicon'] span { // hide alt text
 
   .Docs__attribute__default {
     font-size: 0.8em;
+  }
+
+  .Docs__wip-note {
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
This also changes the margin behaviour on last-child `p` elements in
attribute tables.

This fixes DOC-236: https://linear.app/buildkite/issue/DOC-236/experiment-feature-margins-too-large-inside-tables

## Current version in production
![image](https://user-images.githubusercontent.com/3682/152232741-8546026d-eeeb-40a2-9613-a902d5fc996f.png)

## This version
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/3682/152232862-137d1291-11eb-40da-bcd2-490f1736830f.png">

