### PR TITLE
Correct the env for `no-local-hooks` option

### DIFF
--- a/data/agent_attributes.yaml
+++ b/data/agent_attributes.yaml
@@ -188,7 +188,7 @@ attributes:
   desc: | 
       Disable HTTP2 when communicating with the Agent API.
 - name: no-local-hooks
-  env_var: BUILDKITE_AGENT_NO_LOCAL_HOOKS
+  env_var: BUILDKITE_NO_LOCAL_HOOKS
   default_value: "false"
   required: false
   desc: | 


### PR DESCRIPTION
We reference `BUILDKITE_AGENT_NO_LOCAL_HOOKS` in the `no-local-hooks` [configuration setting](https://buildkite.com/docs/agent/v3/configuration#no-local-hooks), however the [agent is looking for `BUILDKITE_NO_LOCAL_HOOKS`](https://github.com/buildkite/agent/blob/f7d57d748ac9fdac4084338546a21b03efde21e7/bootstrap/bootstrap.go#L345)