### PR TITLE
Add group_step to the quick reference controller

### DIFF
--- a/app/controllers/quick_reference_controller.rb
+++ b/app/controllers/quick_reference_controller.rb
@@ -8,7 +8,8 @@ class QuickReferenceController < ApplicationController
     'pipelines/wait_step',
     'pipelines/block_step',
     'pipelines/input_step',
-    'pipelines/trigger_step'
+    'pipelines/trigger_step',
+    'pipelines/group_step'
   ].freeze
 
   NOTIFICATION_PAGES = [


### PR DESCRIPTION
The sidebar content for the in-product Steps Editor (shown below) is sourced from the docs app, with the root pages specified in `app/controllers/quick_reference_controller.rb`.

This adds the new `group_step` type to the list of top-level pages, it renders successfully at `/docs/quick-reference/pipelines.json`, though some of the content might need an additional set of eyes (ie, the description looks more verbose than for other step types)

![image](https://user-images.githubusercontent.com/2824446/152478442-e7911e3e-0388-4061-aa2d-c77855207355.png)
