### PR TITLE
Apt sources require "dearmored" pubkeys

### DIFF
--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -11,7 +11,7 @@ First, add our signed apt repository. The default version of the agent is `stabl
 +Download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
 
 ```shell
-wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | tee /tmp/buildkite-agent-archive-keyring.gpg && sudo bash -c "cat /tmp/buildkite-agent-archive-keyring.gpg | gpg --dearmor > /usr/share/keyrings/buildkite-agent-archive-keyring.gpg"
 ```
 
 Then add the signed source to your list of apt sources:


### PR DESCRIPTION
* please see: https://wiki.debian.org/DebianRepository/UseThirdParty for more details on this practice. 
* in short, "The reason why we avoid ASCII-armored files is that they can only be used by SecureApt in version 1.4 or later (which appeared in stretch)." 
* you will see this practice in most other 3rd party sources being added. Check out signal app, docker, etc.