### PR TITLE
Remove an extra character from attribute examples

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -125,7 +125,7 @@ _Optional attributes:_
     <td><code>label</code></td>
     <td>
       The label that will be displayed in the pipeline visualisation in Buildkite. Supports emoji.<br>
-      <em>Example:</em> <code>"\:hammer\: Tests" will be rendered as "🔨: Tests"</code><br></code><br>
+      <em>Example:</em> <code>"\:hammer\: Tests" will be rendered as "🔨 Tests"</code><br></code><br>
     </td>
   </tr>
   <tr>

--- a/pages/pipelines/group_step.md.erb
+++ b/pages/pipelines/group_step.md.erb
@@ -84,7 +84,7 @@ _Optional attributes:_
     <td><code>label</code></td>
     <td>
       The label that will be displayed in the pipeline visualisation in Buildkite (name of the group in the UI). Supports emoji.<br>
-      <em>Example:</em> <code>"\:hammer\: Tests" will be rendered as "🔨: Tests"</code><br>
+      <em>Example:</em> <code>"\:hammer\: Tests" will be rendered as "🔨 Tests"</code><br>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
Removed the extra colon from the group and command steps.