### PR TITLE
Fix wrong escape of the colon in example policy

### DIFF
--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -199,7 +199,7 @@ To set up a private build log archive storage:
                 "Sid": "AllowBuildkiteToListBucketInLogsPrefix",
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "arn:\aws\:iam::032379705303:root"
+                    "AWS": "arn\:aws\:iam::032379705303:root"
                 },
                 "Action": "s3:ListBucket",
                 "Resource": "arn\:aws\:s3:::my-bucket",


### PR DESCRIPTION
This made the example policy wrong:

![CleanShot 2022-02-15 at 10 41 40@2x](https://user-images.githubusercontent.com/1000669/153976655-2fe35608-40c2-440f-8fff-ba186e32ca98.png)

https://buildkite.com/docs/pipelines/managing-log-output#private-build-log-archive-storage

verified fixed: https://docs-review-pr-1377.herokuapp.com/docs/pipelines/managing-log-output#private-build-log-archive-storage