### PR TITLE
Jobs REST API has retry_type attribute.

### DIFF
--- a/pages/apis/rest_api/jobs.md.erb
+++ b/pages/apis/rest_api/jobs.md.erb
@@ -37,6 +37,7 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
       "retried": "true",
       "retried_in_job_id": "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
       "retries_count": "1",
+      "retry_type": "automatic",
       "parallel_group_index": null,
       "parallel_group_total": null
     }


### PR DESCRIPTION
Jobs in the REST API (and also outbound webhooks) now have a new field:

```
"retry_type": "automatic" | "manual" | null
```

I don't think we have such granular field-level documentation that there's somewhere to add more details, but this PR at least adds it to the one example response that also has `"retried": "true"` etc.

The Job Webhook Events docs link back to this Jobs REST API doc for details, so nothing to update over there.