### PR TITLE
Update YAML heredoc in `notifications.md.erb`

### DIFF
--- a/pages/pipelines/notifications.md.erb
+++ b/pages/pipelines/notifications.md.erb
@@ -276,7 +276,7 @@ steps:
                    channels:
                      - "#general"
                    message: "Step1 has soft failed."
-        YAML
+      YAML
       fi
 ```
 {: codeblock-file="pipeline.yml"}


### PR DESCRIPTION
The misaligned `YAML` for the heredoc causes the example code to fail.

Fixing the alignment resolves the issue and the example build runs as expected.