### PR TITLE
Clarification for manually cancelling steps and allow_failure dependencies

### DIFF
--- a/pages/pipelines/skipping.md.erb
+++ b/pages/pipelines/skipping.md.erb
@@ -33,6 +33,7 @@ You can also configure these options using the [REST API](/docs/apis/rest-api/pi
 ## Manually cancel jobs and skip to next step
 
 If your pipeline has multiple command steps, you can manually cancel a step, and Buildkite will proceed to the next step. This does not cause the build to fail.
+Note: Currently, if your pipeline has step dependencies with `allow_failure` enabled, the build will still fail if you cancel a step. 
 
 1. From your Buildkite dashboard, select your pipeline.
 2. Select the running build.


### PR DESCRIPTION
Currently, manually cancelling steps that are a part of `allow_failure` dependencies results in builds being marked as `Failed`, so this should add some clarification in the docs so future travellers can know and avoid some confusion.