### PR TITLE
Fixing `em` render issue for OKTA SSO SAML table

### DIFF
--- a/pages/integrations/sso/_saml_user_attributes.md.erb
+++ b/pages/integrations/sso/_saml_user_attributes.md.erb
@@ -41,8 +41,8 @@ Buildkite accepts a subset of the SAML attributes from identity providers. The a
             <code>teams</code>
         </td>
         <td>
-            A comma separated list of team UUIDs. A team's UUID can be found on the _Team Settings_ page in Buildkite.<br>
-            <em>Example:</em> <code>a1aaaa1a-b2bb-cccc-d4dd-aa2aaa6aaaaa,b5bbbbbb-3aaa-dd1d-aaa1-eee4eee6eeee</code>
+          A comma separated list of team UUIDs. A team's UUID can be found on the <em>Team Settings</em> page in Buildkite.<br>
+          <em>Example:</em> <code>a1aaaa1a-b2bb-cccc-d4dd-aa2aaa6aaaaa,b5bbbbbb-3aaa-dd1d-aaa1-eee4eee6eeee</code>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
This resolves [DOC-286](https://linear.app/buildkite/issue/DOC-286):
https://linear.app/buildkite/issue/DOC-286/render-issue-for-team-settings-reference-in-saml-attributes-table