### PR TITLE
Styling RH TOC to be more like sidebar menu

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -342,9 +342,9 @@ label[for='navicon'] span { // hide alt text
   }
 
   .Docs__toc {
-    font-size: 0.8em;
+    font-size: 16px;
     height: 95%;
-    padding-top: 3.7em;
+    padding-top: 3em;
     position: absolute;
     right: 0;
     top: 0;
@@ -353,6 +353,11 @@ label[for='navicon'] span { // hide alt text
       position: sticky;
       top: 3rem;
       width: 220px;
+    }
+
+    a {
+      color: #666;
+      text-decoration: none;
     }
   }
 }


### PR DESCRIPTION
This resolves DOC-221:
https://linear.app/buildkite/issue/DOC-221/toc-fixes

- Increased font-size to 16px
- Removed link underline
- Changed font colour to the same grey as the sidebar menu

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/3682/156113740-c92da5b1-3a41-4096-b86d-61ee20b5a3f4.png">
