### PR TITLE
Add Ruby to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Fix Heroku?
+ruby "2.7.5"
+
 source "https://rubygems.org"
 
 # Choo choo 🚝 (only include the Rails gems we need)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,5 +178,8 @@ DEPENDENCIES
   uglifier
   web-console
 
+RUBY VERSION
+   ruby 2.7.5p203
+
 BUNDLED WITH
    2.3.5


### PR DESCRIPTION
Heroku build previews were breaking because it wasn't using `.ruby-version`. This does mean we have two places to update the Ruby version though. :/