### PR TITLE
Update Gemfile to read version from `.ruby-version`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN echo "--- :package: Installing system deps" \
 WORKDIR /app
 
 # Install deps
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock .ruby-version ./
 RUN echo "--- :bundler: Installing ruby gems" \
     && bundle config set --local without "$([ "$RAILS_ENV" = "production" ] && echo 'development test')" \
     && bundle install --jobs $(nproc) --retry 3

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Fix Heroku?
-ruby "2.7.5"
+# Heroku likes the version here; we like only updating one place
+ruby File.read(".ruby-version").strip
 
 source "https://rubygems.org"
 


### PR DESCRIPTION
Heroku wants it in the Gemfile, we want it in `.ruby-version` and to only update it in one place.