### PR TITLE
include `soft_failed` as an option in build.state

### DIFF
--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -271,7 +271,7 @@ The below variables are supported by the `if` attribute.
 	<tr>
 		<td><code>build.state</code></td>
 		<td><code>String</code></td>
-		<td>The state the current build is in<br><em>Available states:</em> <code>scheduled</code>, <code>running</code>, <code>passed</code>, <code>failed</code>, <code>blocked</code>, <code>canceling</code>, <code>canceled</code>, <code>skipped</code>, <code>not_run</code>, <code>fixed</code>(only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing), <code>finished</code></td>
+		<td>The state the current build is in<br><em>Available states:</em> <code>scheduled</code>, <code>running</code>, <code>passed</code>, <code>failed</code>, <code>soft_failed</code>, <code>blocked</code>, <code>canceling</code>, <code>canceled</code>, <code>skipped</code>, <code>not_run</code>, <code>fixed</code>(only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing), <code>finished</code></td>
 	</tr>
 	<tr>
 		<td><code>build.tag</code></td>


### PR DESCRIPTION
Update to include the `soft_failed` build state that is available to the `build.state` conditional.