### PR TITLE
WIP: Add POC for Beta styles

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -661,3 +661,31 @@ a.Docs__example-repo {
   }
 }
 
+body.beta {
+  .Docs__article h1,
+  .Docs__article .Docs__heading {
+    display: inline;
+    position: relative;
+
+    &:after {
+      background: rgba(255, 165, 0, 0.2);
+      border: 1px solid rgba(255, 165, 0, 0.2);
+      border-radius: 20px;
+      color: rgb(255, 165, 0);
+      content: 'Beta';
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.025rem;
+      line-height: 1;
+      padding: 3px 7px;
+      position: relative;
+      right: -8px;
+      text-transform: uppercase;
+      top: -3px;
+    }
+  }
+
+  .Docs__article h1:after {
+    top: -5px;
+  }
+}

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -661,6 +661,23 @@ a.Docs__example-repo {
   }
 }
 
+@mixin beta-pill {
+  background: rgba(255, 165, 0, 0.2);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 165, 0, 0.2);
+  color: rgb(255, 165, 0);
+  content: 'Beta';
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.025rem;
+  line-height: 1;
+  padding: 3px 7px;
+  position: relative;
+  right: -8px;
+  text-transform: uppercase;
+  top: -3px;
+}
+
 body.beta {
   .Docs__article h1,
   .Docs__article .Docs__heading {
@@ -668,24 +685,18 @@ body.beta {
     position: relative;
 
     &:after {
-      background: rgba(255, 165, 0, 0.2);
-      border: 1px solid rgba(255, 165, 0, 0.2);
-      border-radius: 20px;
-      color: rgb(255, 165, 0);
-      content: 'Beta';
-      font-size: 11px;
-      font-weight: 700;
-      letter-spacing: 0.025rem;
-      line-height: 1;
-      padding: 3px 7px;
-      position: relative;
-      right: -8px;
-      text-transform: uppercase;
-      top: -3px;
+      @include beta-pill;
     }
   }
 
   .Docs__article h1:after {
     top: -5px;
   }
+}
+
+.beta-link:after {
+  @include beta-pill;
+
+  font-size: 8px;
+  padding: 3px 5px;
 }

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -636,17 +636,28 @@ a.Docs__example-repo {
   }
 }
 
-.Docs__heading:hover {
+.Docs__heading {
   position: relative;
+
   .Docs__heading__anchor {
-    font-size: 0;
-    line-height: 0;
+    text-decoration: none;
+
+    &:hover,
+    &:active,
+    &:focus {
+      color: black;
+    }
   }
-  .Docs__heading__anchor:before {
+
+  &:hover:before {
     content: '#';
     color: #666;
     font-size: 1rem;
     font-weight: normal;
     margin-left: .5rem;
+    position: absolute;
+    left: -25px;
+    top: 5px;
   }
 }
+

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,4 +21,11 @@ class PagesController < ApplicationController
 
     # Otherwise, render the page (the default)
   end
+
+  private
+
+  def beta?
+    @page && @page.beta?
+  end
+  helper_method :beta?
 end

--- a/app/models/beta_pages.rb
+++ b/app/models/beta_pages.rb
@@ -1,0 +1,8 @@
+class BetaPages
+  def self.all
+    [
+      'test-analytics',
+      'test-analytics/integrations'
+    ]
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -88,6 +88,10 @@ class Page
     @name = name
   end
 
+  def beta?
+    BetaPages.all.include? @name
+  end
+
   def exists?
     filename.present?
   end

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -83,9 +83,9 @@ class Page::Renderer
     # Second, we make them all linkable and give them the right classes.
     headings.each do |node|
       node['class'] = 'Docs__heading'
-      node.add_child(<<~HTML)
-        <a href="##{node['id']}" aria-hidden="true" class="Docs__heading__anchor"></a>
-      HTML
+      link = "<a class='Docs__heading__anchor' href='##{node['id']}'></a>"
+
+      node.children.wrap(link)
     end
 
     doc

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -229,7 +229,9 @@
       </div>
 
       <div class="Docs__nav__section-container <%= "current expanded" if current_section == 'test-analytics' %>" data-docs-path="test-analytics">
-        <p class="Docs__nav__section-heading">Test Analytics</p>
+        <p class="Docs__nav__section-heading">
+          <span class="beta-link">Test Analytics</span>
+        </p>
         <div class="Docs__nav__section-content">
           <ul class="Docs__nav__sub-nav">
             <%= sidebar_link_to "Overview", 'test-analytics' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,7 @@
       <meta name="robots" content="noindex, nofollow">
     <% end %>
   </head>
-  <body>
+  <body <%= beta? ? 'class=beta' : ''-%>>
     <header class="SiteHeader">
       <div class="SiteHeader__inner PageContainer">
         <h1 class="SiteHeader__logo">

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -117,7 +117,7 @@
     <div class="HomepageCategory">
       <h2>
         <%= image_tag("icons/test-analytics.svg", alt: "") %>
-        <a href="/docs/test-analytics">Test Analytics</a>
+        <a class="beta-link" href="/docs/test-analytics">Test Analytics</a>
       </h2>
       <span>Find and fix flaky tests</span>
       <ul>

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -4,13 +4,12 @@ RSpec.describe Page::Renderer do
   it "renders basic markdown" do
     md = <<~MD
       # Page title
-
       Some description
     MD
 
     html = <<~HTML
       <h1>Page title</h1>
-      
+
       <p>Some description</p>
     HTML
 
@@ -46,23 +45,17 @@ RSpec.describe Page::Renderer do
           </div>
         </div>
 
-        <h2 id="section-1" class="Docs__heading">Section 1<a href="#section-1" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h2>
+        <h2 id="section-1" class="Docs__heading"><a class="Docs__heading__anchor" href="#section-1">Section 1</a></h2>
 
-        <h3 id="section-1-subsection-1-dot-1" class="Docs__heading">Subsection 1.1<a href="#section-1-subsection-1-dot-1" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h3>
+        <h3 id="section-1-subsection-1-dot-1" class="Docs__heading"><a class="Docs__heading__anchor" href="#section-1-subsection-1-dot-1">Subsection 1.1</a></h3>
 
-        <h3 id="section-1-subsection-1-dot-2" class="Docs__heading">Subsection 1.2<a href="#section-1-subsection-1-dot-2" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h3>
+        <h3 id="section-1-subsection-1-dot-2" class="Docs__heading"><a class="Docs__heading__anchor" href="#section-1-subsection-1-dot-2">Subsection 1.2</a></h3>
 
-        <h2 id="section-2" class="Docs__heading">Section 2<a href="#section-2" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h2>
+        <h2 id="section-2" class="Docs__heading"><a class="Docs__heading__anchor" href="#section-2">Section 2</a></h2>
 
-        <h3 id="section-2-subsection-2-dot-1" class="Docs__heading">Subsection 2.1<a href="#section-2-subsection-2-dot-1" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h3>
+        <h3 id="section-2-subsection-2-dot-1" class="Docs__heading"><a class="Docs__heading__anchor" href="#section-2-subsection-2-dot-1">Subsection 2.1</a></h3>
 
-        <h3 id="section-2-subsection-2-dot-2" class="Docs__heading">Subsection 2.2<a href="#section-2-subsection-2-dot-2" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h3>
+        <h3 id="section-2-subsection-2-dot-2" class="Docs__heading"><a class="Docs__heading__anchor" href="#section-2-subsection-2-dot-2">Subsection 2.2</a></h3>
       HTML
 
       expect(Page::Renderer.render(md).strip).to eql(html.strip)
@@ -92,8 +85,7 @@ RSpec.describe Page::Renderer do
           </div>
         </div>
         
-        <h2 id="section" class="Docs__heading">Section<a href="#section" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h2>
+        <h2 id="section" class="Docs__heading"><a class="Docs__heading__anchor" href="#section">Section</a></h2>
         
         <section>
           <hgroup>
@@ -114,25 +106,21 @@ RSpec.describe Page::Renderer do
         ### Subsection
 
         ## A Title
-        
+
         ### Subsection With Custom Id
         {: id="custom-id"}
         MD
 
       html = <<~HTML
-        <h2 id="short-id" class="Docs__heading">A Super Long Section Title<a href="#short-id" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h2>
-        
-        
-        
-        <h3 id="short-id-subsection" class="Docs__heading">Subsection<a href="#short-id-subsection" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h3>
+        <h2 id="short-id" class="Docs__heading"><a class="Docs__heading__anchor" href="#short-id">A Super Long Section Title</a></h2>
 
-        <h2 id="a-title" class="Docs__heading">A Title<a href="#a-title" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h2>
-        
-        <h3 id="custom-id" class="Docs__heading">Subsection With Custom Id<a href="#custom-id" aria-hidden="true" class="Docs__heading__anchor"></a>
-        </h3>
+
+
+        <h3 id="short-id-subsection" class="Docs__heading"><a class="Docs__heading__anchor" href="#short-id-subsection">Subsection</a></h3>
+
+        <h2 id="a-title" class="Docs__heading"><a class="Docs__heading__anchor" href="#a-title">A Title</a></h2>
+
+        <h3 id="custom-id" class="Docs__heading"><a class="Docs__heading__anchor" href="#custom-id">Subsection With Custom Id</a></h3>
       HTML
 
       expect(Page::Renderer.render(md).strip).to eql(html.strip)
@@ -191,8 +179,7 @@ RSpec.describe Page::Renderer do
     MD
 
     html = <<~HTML
-      <h2 id="some-id" class="Docs__heading">This is a section<a href="#some-id" aria-hidden="true" class="Docs__heading__anchor"></a>
-      </h2>
+      <h2 id="some-id" class="Docs__heading"><a class="Docs__heading__anchor" href="#some-id">This is a section</a></h2>
     HTML
 
     expect(Page::Renderer.render(md).strip).to eql(html.strip)

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Page do
+  describe "#beta?" do
+    context "when page's path is defined in the BETA_PAGES constant" do
+      it "returns true" do
+        allow(BetaPages).to receive(:all).and_return(["apis/agent-api"])
+        page = Page.new(double, "apis/agent-api")
+
+        expect(page).to be_beta
+      end
+    end
+
+    context "when page's path is not defined in the BETA_PAGES constant" do
+      it "returns false" do
+        allow(BetaPages).to receive(:all).and_return([])
+        page = Page.new(double, "apis/agent-api")
+
+        expect(page).not_to be_beta
+      end
+    end
+  end
+end

--- a/styleguide/STYLE.md
+++ b/styleguide/STYLE.md
@@ -38,7 +38,7 @@ More info on writing about pronouns and in the [Microsoft Style Guide](https://d
 ### Talking about YAML
 
 * Attributes not parameters. For example, "Add the `notify` attribute".
-* When discussing nesting/indenting, first attributes (attributes not nested under any other are "top level".
+* When discussing nesting/indenting, first attributes (attributes not nested under any other) are "top level".
 
 ## Style and formatting
 This section covers the matters that go beyond language and provides guidelines for consistency and a unified look.
@@ -109,11 +109,11 @@ P.S. Remember that, ironically enough, in Markdown, line breaks demand exactly t
 | Word                      | Usage                                                                                            |
 |---------------------------|--------------------------------------------------------------------------------------------------|
 | The Buildkite Agent/agent | When referring to the running process/piece of software as a whole                               |
-| buildkite-agent           | When referring to the cli tool, visually should be presented in a code block                     |
+| `buildkite-agent`         | When referring to the CLI tool, visually should be presented in a code block                     |
 | Sign up/log in            | The action of signing up                                                                         |
 | Signup/login              | When referring to a page that enables signing up or to the signup process                        |
-| Time out/timeout          | Time out is a verb, timeout is a noun |
-| API, SSO, SAML            | Always capitalized |
+| Time out/timeout          | Time out is a verb, timeout is a noun                                                            |
+| API, SSO, SAML            | Always capitalized                                                                               |
 | GitHub                    | Always capitalized, with an uppercase H in the middle                                            |
 | Two-factor authentication | In a sentence two-factor authentication, in a title Two-Factor Authentication, in short form 2FA |
 | Single sign-on            | In a sentence single sign-on, in a title Single Sign-On, in short form SSO                       |
@@ -182,7 +182,7 @@ steps:
         command: ".buildkite/steps/brakeman"
 ```
 
-Will be renered as:
+Will be rendered as:
 
 ```yml
 steps:

--- a/styleguide/STYLE.md
+++ b/styleguide/STYLE.md
@@ -274,6 +274,21 @@ So a link to `_agent_events_table.md.erb` stored within `webhooks` sub-folder in
 We have a few custom scripts for adding useful elements that are missing in Markdown.
 To save yourself a few unnecessary rounds of edits in the future, remember that if you see a fragment written in HTML, links within such fragment should also follow the HTML syntax and not markdown (more on this in [Note blocks](#note-blocks)).
 
+#### Beta flags
+To mark a content page in the site as being in beta, add its relative path *after* `docs` to the `app/models/beta_pages.rb` file.
+
+For example:
+```
+[
+  'test-analytics',
+  'test-analytics/integrations'
+]
+```
+
+Any file listed there will automatically pick up the beta styling.
+
+Adding the class `beta-link` to any HTML link will display the beta flag on that link. This is intended for use in the sidebar navigation and homepage and will not work in Markdown.
+
 #### Table of contents
 To generate a table of contents from all your \##\-level headings, use `{:toc}`.
 Make sure there are no spaces after the `{:toc}` - spaces immediately after this custom element are known to break the script.


### PR DESCRIPTION
This resolves DOC-92:
https://linear.app/buildkite/issue/DOC-92/make-a-stripped-down-beta-page-template-theme

Add docs MD files as usual and add the path in `app/models/beta_pages.rb`. Any path there will have `beta?` true when rendered, allowing us to add content or styles to consistently indicate the BETA state. 

Promoting a doc from BETA is done by removing its path from the list.

The homepage and sidebar both require a `beta-link` class added directly to the link. In the sidebar, this can work for either a whole section (like Test Analytics) or an individual link. I recommend always rolling up to the nearest parent to avoid having a bunch of the BETA pills as much as possible.

BETA flag can be seen on https://docs-review-pr-1411.herokuapp.com/docs/test-analytics

<img width="1416" alt="image" src="https://user-images.githubusercontent.com/3682/163770122-8551175b-3f8e-4fe4-a943-05f2d01d3ec8.png">


## TODO:
- [x] Make BETA clear on page in useful styles
- [x] Remove test BETA page(s) from the model
- [ ] Automatically add BETA flag to menu items?
