### PR TITLE
Add a note about agent logs for linux install

### DIFF
--- a/pages/agent/v3/linux.md.erb
+++ b/pages/agent/v3/linux.md.erb
@@ -37,10 +37,9 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 * Agent Hooks: `~/.buildkite-agent/hooks`
 * Builds: `~/.buildkite-agent/builds`
 * SSH keys: `~/.ssh`
-
-<div class="Docs__note">
-<p>When an agent is started using `buildkite-agent start` command then agent logs will captured in stdout and are not persisted. When agent is started or managed through systemd then it captures stdout and will be available through command `journalctl -f -u buildkite-agent` </p>
-</div>
+* Logs, depending on your system:
+  * `journalctl -f -u buildkite-agent` (when started with `systemd`)
+  * logs only go to stdout and do not persist (when started with `buildkite-agent start`)
 
 ## Configuration
 

--- a/pages/agent/v3/linux.md.erb
+++ b/pages/agent/v3/linux.md.erb
@@ -39,7 +39,7 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 * SSH keys: `~/.ssh`
 
 <div class="Docs__note">
-<p>When an agent is started using `buildkite-agent start` command then agent logs will captured in stdout and are not persisted. When agent is started/managed through systemd then it captures stdout and makes it available in journalctl </p>
+<p>When an agent is started using `buildkite-agent start` command then agent logs will captured in stdout and are not persisted. When agent is started or managed through systemd then it captures stdout and will be available through command `journalctl -f -u buildkite-agent` </p>
 </div>
 
 ## Configuration

--- a/pages/agent/v3/linux.md.erb
+++ b/pages/agent/v3/linux.md.erb
@@ -38,8 +38,8 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 * Builds: `~/.buildkite-agent/builds`
 * SSH keys: `~/.ssh`
 * Logs, depending on your system:
-  * `journalctl -f -u buildkite-agent` (when started with `systemd`)
-  * logs only go to stdout and do not persist (when started with `buildkite-agent start`)
+  - `journalctl -f -u buildkite-agent` (when started with `systemd`)
+  - logs only go to stdout and do not persist (when started with `buildkite-agent start`)
 
 ## Configuration
 

--- a/pages/agent/v3/linux.md.erb
+++ b/pages/agent/v3/linux.md.erb
@@ -38,6 +38,10 @@ See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details
 * Builds: `~/.buildkite-agent/builds`
 * SSH keys: `~/.ssh`
 
+<div class="Docs__note">
+<p>When an agent is started using `buildkite-agent start` command then agent logs will captured in stdout and are not persisted. When agent is started/managed through systemd then it captures stdout and makes it available in journalctl </p>
+</div>
+
 ## Configuration
 
 The configuration file is located at `~/.buildkite-agent/buildkite-agent.cfg`. See the [configuration documentation](/docs/agent/v3/configuration) for an explanation of each configuration setting.


### PR DESCRIPTION
Currently in Linux installation steps documentation, in file locations we do not have any mention about agent logs so adding a note to explain how to access agent logs in such scenarios.