### PR TITLE
fixed state not available in conditionals

### DIFF
--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -271,7 +271,7 @@ The below variables are supported by the `if` attribute.
 	<tr>
 		<td><code>build.state</code></td>
 		<td><code>String</code></td>
-		<td>The state the current build is in<br><em>Available states:</em> <code>scheduled</code>, <code>running</code>, <code>passed</code>, <code>failed</code>, <code>soft_failed</code>, <code>blocked</code>, <code>canceling</code>, <code>canceled</code>, <code>skipped</code>, <code>not_run</code>, <code>fixed</code>(only supported for <a href="/docs/pipelines/notifications#conditional-notifications">notification services</a> to indicate that a build on the same branch passed after failing), <code>finished</code></td>
+		<td>The state the current build is in<br><em>Available states:</em> <code>scheduled</code>, <code>running</code>, <code>passed</code>, <code>failed</code>, <code>soft_failed</code>, <code>blocked</code>, <code>canceling</code>, <code>canceled</code>, <code>skipped</code>, <code>not_run</code>, <code>finished</code></td>
 	</tr>
 	<tr>
 		<td><code>build.tag</code></td>


### PR DESCRIPTION
`fixed` state is not available on conditionals. We have the concept of "fixed" on Notifications (to indicate that a build on the same branch passed after failing), but only through this page:

<img width="194" alt="notification-service" src="https://user-images.githubusercontent.com/6607375/159100505-d0ac6c5b-2de5-46e0-93d8-e3112ea654ac.png">


You can't use `build.state = 'fixed'` 
