### PR TITLE
docs: add link to basscss color classes

### DIFF
--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -60,6 +60,7 @@ We accept the following parts of version 8.0 of Basscss within annotations:
 
 * [Align](http://basscss.com/#basscss-align)
 * [Border](http://basscss.com/#basscss-border)
+* [Colors](https://basscss.com/v7/docs/colors/)
 * [Flexbox](http://basscss.com/#basscss-flexbox)
   - All except `sm-flex`, `md-flex` and `lg-flex`
 * [Margin](http://basscss.com/#basscss-margin)


### PR DESCRIPTION
Adds a link to the Basscss colour utility classes, as these can be used in annotations (and on first pass, I missed these)

Related [Slack thread](https://buildkite-community.slack.com/archives/C02T53V9H/p1648255244980119) for context.