### PR TITLE
ssh key location clarification

### DIFF
--- a/pages/agent/v3/_ssh_key_with_buildkite_agent_user.md.erb
+++ b/pages/agent/v3/_ssh_key_with_buildkite_agent_user.md.erb
@@ -2,7 +2,6 @@ SSH keys should be copied to (or generated into) `/var/lib/buildkite-agent/.ssh/
 
 ```bash
 $ sudo su buildkite-agent
-$ mkdir -p ~/.ssh && cd ~/.ssh
 $ mkdir -p (echo ~/.buildkite-agent)/.ssh #ssh-key should be present inside buildkite-agent installation location which is /var/lib/buildkite-agent/ in this case
 $ cd (echo ~/.buildkite-agent)/.ssh
 $ ssh-keygen -t rsa -b 4096 -C "build@myorg.com"

--- a/pages/agent/v3/_ssh_key_with_buildkite_agent_user.md.erb
+++ b/pages/agent/v3/_ssh_key_with_buildkite_agent_user.md.erb
@@ -3,5 +3,7 @@ SSH keys should be copied to (or generated into) `/var/lib/buildkite-agent/.ssh/
 ```bash
 $ sudo su buildkite-agent
 $ mkdir -p ~/.ssh && cd ~/.ssh
+$ mkdir -p (echo ~/.buildkite-agent)/.ssh #ssh-key should be present inside buildkite-agent installation location which is /var/lib/buildkite-agent/ in this case
+$ cd (echo ~/.buildkite-agent)/.ssh
 $ ssh-keygen -t rsa -b 4096 -C "build@myorg.com"
 ```

--- a/pages/agent/v3/freebsd.md.erb
+++ b/pages/agent/v3/freebsd.md.erb
@@ -39,10 +39,11 @@ Alternatively you can follow the [manual installation instructions](installation
 
 ## SSH key configuration
 
-SSH keys should be copied to (or generated into) `~/.ssh/` for the user the agent is running as. For example, to generate a new private key which you can add to your source code host:
+SSH keys should be copied to (or generated into) `.ssh/` folder inside the buildkite-agent installation location. For example, to generate a new private key which you can add to your source code host:
 
 ```bash
-$ mkdir -p ~/.ssh && cd ~/.ssh
+$ mkdir -p (echo ~/.buildkite-agent)/.ssh #ssh-key should be present inside buildkite-agent installation location
+$ cd (echo ~/.buildkite-agent)/.ssh
 $ ssh-keygen -t rsa -b 4096 -C "build@myorg.com"
 ```
 

--- a/pages/agent/v3/linux.md.erb
+++ b/pages/agent/v3/linux.md.erb
@@ -22,10 +22,11 @@ Alternatively you can follow the [manual installation instructions](installation
 
 ## SSH key configuration
 
-SSH keys should be copied to (or generated into) `~/.ssh/` for the user the agent is running as. For example, to generate a new private key which you can add to your source code host:
+SSH keys should be copied to (or generated into) `.ssh/` folder inside the buildkite-agent installation location. For example, to generate a new private key which you can add to your source code host:
 
 ```bash
-$ mkdir -p ~/.ssh && cd ~/.ssh
+$ mkdir -p (echo ~/.buildkite-agent)/.ssh #ssh-key should be present inside buildkite-agent installation location
+$ cd (echo ~/.buildkite-agent)/.ssh
 $ ssh-keygen -t rsa -b 4096 -C "build@myorg.com"
 ```
 

--- a/pages/agent/v3/ssh_keys.md.erb
+++ b/pages/agent/v3/ssh_keys.md.erb
@@ -6,7 +6,7 @@ If your agent needs to clone your repositories using git and SSH, you'll need to
 
 ## Finding your SSH key directory
 
-When the Buildkite Agent runs any git operations, SSH will look for keys in `~/.ssh` under whichever user the agent runs as. Each platform’s [agent installation documentation](/docs/agent/v3/installation) specifies the exact location of this directory.
+When the Buildkite Agent runs any git operations, SSH will look for keys in .ssh folder inside the buildkite-agent installed location. For example, if the agent is installed on /home/ec2-user/.buildkite-agent/, it will look for keys in /home/ec2-user/.buildkite-agent/.ssh. Each platform’s [agent installation documentation](/docs/agent/v3/installation) specifies the exact location of this directory.
 
 ## Debugging SSH key issues
 
@@ -22,7 +22,8 @@ The following shows an example of creating a new “machine user” SSH key for 
 
 ```bash
 $ sudo su buildkite-agent # or whichever user your agent runs as
-$ mkdir -p ~/.ssh && cd ~/.ssh
+$ mkdir -p (echo ~/.buildkite-agent)/.ssh
+$ cd (echo ~/.buildkite-agent)/.ssh
 $ ssh-keygen -t rsa -b 4096 -C "dev+build@myorg.com"
 Generating public/private rsa key pair.
 Enter file in which to save the key (/var/lib/buildkite-agent/.ssh/id_rsa):


### PR DESCRIPTION
Doc says to generate the ssh key on the logged-in user's root folder instead of where the buildkite-agent is installed. So modified those examples to point to buildkite-agent installation location.

Below are the 2 places where I did the change. Others are just copied from here.

<img width="1478" alt="image" src="https://user-images.githubusercontent.com/5114190/160426574-481714b6-7c88-42dc-b3bd-dc90d33fbe3c.png">

<img width="1482" alt="image" src="https://user-images.githubusercontent.com/5114190/160426622-ea8eac29-7036-427a-b1da-a55b0f062ab1.png">


These are the places affected by the above change:
https://buildkite.com/docs/agent/v3/ssh-keys#finding-your-ssh-key-directory
https://buildkite.com/docs/agent/v3/ssh-keys#creating-a-single-ssh-key
https://buildkite.com/docs/agent/v3/ubuntu#ssh-key-configuration
https://buildkite.com/docs/agent/v3/debian#ssh-key-configuration
https://buildkite.com/docs/agent/v3/redhat#ssh-key-configuration
https://buildkite.com/docs/agent/v3/freebsd#ssh-key-configuration
https://buildkite.com/docs/agent/v3/linux#ssh-key-configuration