### PR TITLE
Fix Authorization header for Agent API

### DIFF
--- a/pages/apis/agent_api.md.erb
+++ b/pages/apis/agent_api.md.erb
@@ -25,7 +25,7 @@ curl https://agent.buildkite.com
 
 Unlike the [Buildkite REST API](/docs/apis/rest-api), which uses an [API Access token](/docs/apis/rest-api#authentication), the Agent REST API uses an [Agent registration token](/docs/agent/v3/tokens) for authentication.
 
-To authenticate using an Agent registration token, set the `Authorization` HTTP header to the word `Bearer`, followed by a space, followed by the access token. For example:
+To authenticate using an Agent registration token, set the `Authorization` HTTP header to the word `Token`, followed by a space, followed by the access token. For example:
 
 ```bash
 curl -H "Authorization: Token $TOKEN" https://agent.buildkite.com/v3/metrics


### PR DESCRIPTION
Agent API uses HTTP Authorization header with "Token" instead of "Bearer". This PR fixes this in the agent API docs