### PR TITLE
Added details about not-run build state

### DIFF
--- a/pages/pipelines/_build_states.md.erb
+++ b/pages/pipelines/_build_states.md.erb
@@ -6,5 +6,5 @@ You can query for `finished` builds to return builds in any of the following sta
 </section>
 
 <section class="Docs__note">
-<p>When all the steps in a build are skipped (either by using skip attribute or by using `if` condition), the build state will be marked as ‘not_run’. </p>
+<p>When all the steps in a build are skipped (either by using skip attribute or by using `if` condition), the build state will be marked as ‘not_run’.</p>
 </section>

--- a/pages/pipelines/_build_states.md.erb
+++ b/pages/pipelines/_build_states.md.erb
@@ -4,3 +4,7 @@ You can query for `finished` builds to return builds in any of the following sta
 <section class="Docs__troubleshooting-note">
 <p>When a <a href="/docs/pipelines/trigger-step">triggered build</a> fails, the step that triggered it will be stuck in the <code>running</code> state forever.</p>
 </section>
+
+<section class="Docs__note">
+<p>When all the steps in a build are skipped (either by using skip attribute or by using `if` condition), the build state will be marked as ‘not_run’. </p>
+</section>


### PR DESCRIPTION

Currently, it is not obvious when a build would go to  _**not-run**_  build state. So added this little detail.

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/5114190/161709187-835a69af-83e3-4725-ba35-22f41bed3315.png">
