### PR TITLE
Add usage link for buildkite-agent step

### DIFF
--- a/pages/agent/v3.md.erb
+++ b/pages/agent/v3.md.erb
@@ -38,6 +38,7 @@ Available commands are:
   <a href="/docs/agent/v3/cli-meta-data">meta-data</a>  Get/set data from Buildkite jobs
   <a href="/docs/agent/v3/cli-pipeline">pipeline</a>   Make changes to the pipeline of the currently running build
   <a href="/docs/agent/v3/cli-bootstrap">bootstrap</a>  Run a Buildkite job locally
+  <a href="/docs/agent/v3/cli-step">step</a>  Retrieve and update the attributes of steps
   help       Shows a list of commands or help for one command
 
 Use "buildkite-agent [command] --help" for more information about a command.


### PR DESCRIPTION
Adds a link to https://buildkite.com/docs/agent/v3/cli-step in https://buildkite.com/docs/agent/v3#usage. This link is in the left sidebar but was missing from the main `Usage` section.