### PR TITLE
Extra detail on using a bootstrap script

### DIFF
--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -340,6 +340,11 @@ If the file is private, you also need to create an IAM policy to allow the insta
   "Statement": [
     {
       "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn\:aws\:iam:123456789:role/Elastic-Stack-IAM-Role"
+        ]
+      },
       "Action": [
         "s3:GetObject"
       ],
@@ -349,6 +354,8 @@ If the file is private, you also need to create an IAM policy to allow the insta
   ]
 }
 ```
+
+If you did not specify an `InstanceRoleName` when you created the stack, CloudFormation will automatically create an `IAMRole` for your stack. You can get the IAM role name and ARN from the Resources tab on the Stack details page.
 
 After creating the policy, you must specify the policy's ARN in the `ManagedPolicyARN` stack parameter.
 


### PR DESCRIPTION
We had a support ticket where we were informed that the details provided in the `Customizing Instances with a bootstrap script` is a bit confusing as it doesn't say where to get the ARN for the Instance role, or how to specify it when creating the IAM Policy.

Words may still need some tweaking to capture what I'm going for here, but my goal for this change is to make things easier to understand and get running for anybody trying to set up a bootstrap script and/or s3 bucket