### PR TITLE
Update documentation for building from tags

### DIFF
--- a/pages/integrations/github.md.erb
+++ b/pages/integrations/github.md.erb
@@ -82,7 +82,7 @@ If you want to run builds only on pull requests, set the _Branch Filter Pattern_
 
 ## Running builds on git tags
 
-Builds are only run for tags when a 'push' event is triggered, see [webhook-events-and-payloads](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#push), to enable this edit the GitHub settings for your Buildkite pipeline and choose the _Build Tags_ checkbox.
+Builds are only run for tags when a [`push` event is triggered](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#push). To enable builds for `push` events for git tags, edit the _GitHub settings_ for your Buildkite pipeline, and choose the _Build Tags_ checkbox.
 
 
 Before triggering builds for git tags from the [API](/docs/apis/rest-api/builds#create-a-build) or a [scheduled build](/docs/pipelines/scheduled-builds), make sure your agent is configured to fetch git tags: `BUILDKITE_GIT_FETCH_FLAGS="-v --prune --tags"`.

--- a/pages/integrations/github.md.erb
+++ b/pages/integrations/github.md.erb
@@ -82,7 +82,8 @@ If you want to run builds only on pull requests, set the _Branch Filter Pattern_
 
 ## Running builds on git tags
 
-To run builds for commit tags, edit the GitHub settings for your Buildkite pipeline and choose the _Build Tags_ checkbox.
+Builds are only run for tags when a 'push' event is triggered, see [webhook-events-and-payloads](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#push), to enable this edit the GitHub settings for your Buildkite pipeline and choose the _Build Tags_ checkbox.
+
 
 Before triggering builds for git tags from the [API](/docs/apis/rest-api/builds#create-a-build) or a [scheduled build](/docs/pipelines/scheduled-builds), make sure your agent is configured to fetch git tags: `BUILDKITE_GIT_FETCH_FLAGS="-v --prune --tags"`.
 


### PR DESCRIPTION
Much like this PR https://github.com/buildkite/docs/pull/1246, I have just tweaked the explanation slightly to be explicit about the event we trigger the build off as it came through as a question in support.

It does mention it in the pipeline, you can see the pick from the changelog https://buildkite.com/changelog/116-build-only-branches-tags-or-both, but I think it's worth making it a little clearer.

I think the wording will need some tweaking, I put in a ref to the Github docs. I will leave it in your capable hands

Looks like:

<img width="753" alt="Screen Shot 2022-05-11 at 12 00 41 pm" src="https://user-images.githubusercontent.com/585588/167757007-967a4098-276c-4239-9035-5ccbb72b3a9d.png">


