### PR TITLE
Prefix `brew install` with explicit `tap`

### DIFF
--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -9,7 +9,7 @@ The Buildkite Agent is supported on macOS 10.12 or newer using Homebrew or our i
 If you have <a href="http://brew.sh/">Homebrew</a> installed you can use our <a href="https://github.com/buildkite/homebrew-buildkite">buildkite formula repository</a> to install the agent:
 
 ```shell
-brew install buildkite/buildkite/buildkite-agent
+brew tap buildkite/buildkite && brew install buildkite-agent
 ```
 
 Then configure your [agent token](/docs/agent/v3/tokens):


### PR DESCRIPTION
If you run `brew install buildkite/buildkite/buildkite-agent` without having tapped `buildkite/buildkite` before, then you get a warning while Homebrew taps anyway. I've put an explicit `tap` command in to suppress this warning and to make it a little more clear that Buildkite's tooling is not part of the core Homebrew formulae.

Truthfully, I'm not sure this is a real suggestion, but it was the smallest thing I could think of to change so far and I'm really here just exercising the docs contribution workflow for @plaindocs.