### PR TITLE
Fix broken style guide English variants link

### DIFF
--- a/styleguide/STYLE.md
+++ b/styleguide/STYLE.md
@@ -19,7 +19,7 @@ We use American English, so our first-call dictionary is [Merriam Webster](https
 We also use [Vale](https://github.com/apps/vale-linter), our own [linter](https://github.com/buildkite/docs#linting) with a file that contains our own [custom list of words](https://github.com/buildkite/docs/blob/main/vale/vocab.txt) that may confuse the spellchecker, [filename linter](https://ls-lint.org/1.x/getting-started/introduction.html), and a [markdown linter](https://github.com/DavidAnson/markdownlint).
 
 ### English flavor
-Again, we use American English. We're also a highly multi-national team, so here is the list of the most notable [differences between American, British, and Australian English](http://linktranslation.com.au/the-differences-between-american-british-and-australian-english/) English to watch out for.
+Again, we use American English. We're also a highly multi-national team, so here is the list of the most notable [differences between American, British, and Australian English](http://web.archive.org/web/20180925084522/http://www.linktranslation.com.au/the-differences-between-american-british-and-australian-english/) English to watch out for.
 
 ### Commas
 Keep it clean and uncluttered. If the sentence can live without that comma - leave it out.


### PR DESCRIPTION
The link to the article about the differences between en-US, en-GB, and en-AU seems to have gone missing. I've replaced the link to the same article on the Wayback Machine.