### PR TITLE
add various combinations of "skip ci" that are accepted by Buildkite

### DIFF
--- a/pages/pipelines/skipping.md.erb
+++ b/pages/pipelines/skipping.md.erb
@@ -45,7 +45,7 @@ To manually cancel a job:
 
 ## Ignore a commit
 
-Some code changes, such as editing a Readme, may not require a Buildkite build. If you want Buildkite to ignore a commit, add `[ci skip]` or `[skip ci]` anywhere in the commit message.
+Some code changes, such as editing a Readme, may not require a Buildkite build. If you want Buildkite to ignore a commit, add `[ci skip]`,`[skip ci]`, `[ci-skip]`, or `[skip-ci]` anywhere in the commit message.
 
 For example, the following commit message will cause Buildkite to ignore the commit and not create a corresponding build:
 


### PR DESCRIPTION
Some customers are not aware that we support a few different forms of `skip ci` to tell Buildkite to not create a build on a commit, such as:

```
[skip-ci]
[ci-skip]
[ci skip]
[skip ci]
```

It'd be great if we could add that extra bit of clarification for future travellers!