### PR TITLE
elastic_ci_aws: `BootstrapScriptUrl` needn't be S3!

### DIFF
--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -332,7 +332,7 @@ To debug an agent:
 
 You can customize your stack's instances by using the `BootstrapScriptUrl` stack parameter to run a Bash script on instance boot. To set up a bootstrap script,  set the `BootstrapScriptUrl` parameter to one of the following:
 
-* An S3 bucket containing the script, for example `s3://my_bucket_name/my_bootstrap.sh` 
+* An S3 bucket containing the script, for example `s3://my_bucket_name/my_bootstrap.sh`
 * A URL such as `https://www.example.com/config/bootstrap.sh`
 * A local file name `file:///usr/local/bin/my_bootstrap.sh` (this is particularly useful if you're customising the AMI and are able to include a bootstrap script that way).
 

--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -330,7 +330,7 @@ To debug an agent:
 
 ## Customizing instances with a bootstrap script
 
-You can customize your stack's instances by using the `BootstrapScriptUrl` stack parameter to run a Bash script on instance boot. To set up a bootstrap script, create an S3 bucket with the script, and set the `BootstrapScriptUrl` parameter, for example `s3://my_bucket_name/my_bootstrap.sh`.
+You can customize your stack's instances by using the `BootstrapScriptUrl` stack parameter to run a Bash script on instance boot. To set up a bootstrap script, create an S3 bucket with the script, and set the `BootstrapScriptUrl` parameter, for example `s3://my_bucket_name/my_bootstrap.sh`.  Note that you can also provide a URL such as `https://www.example.com/config/bootstrap.sh`, or even a local filename `file:///usr/local/bin/my_bootstrap.sh` (this is particularly useful if you're customising the AMI and are able to include a bootstrap script that way).
 
 If the file is private, you also need to create an IAM policy to allow the instances to read the file, for example:
 

--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -330,7 +330,11 @@ To debug an agent:
 
 ## Customizing instances with a bootstrap script
 
-You can customize your stack's instances by using the `BootstrapScriptUrl` stack parameter to run a Bash script on instance boot. To set up a bootstrap script, create an S3 bucket with the script, and set the `BootstrapScriptUrl` parameter, for example `s3://my_bucket_name/my_bootstrap.sh`.  Note that you can also provide a URL such as `https://www.example.com/config/bootstrap.sh`, or even a local filename `file:///usr/local/bin/my_bootstrap.sh` (this is particularly useful if you're customising the AMI and are able to include a bootstrap script that way).
+You can customize your stack's instances by using the `BootstrapScriptUrl` stack parameter to run a Bash script on instance boot. To set up a bootstrap script,  set the `BootstrapScriptUrl` parameter to one of the following:
+
+* An S3 bucket containing the script, for example `s3://my_bucket_name/my_bootstrap.sh` 
+* A URL such as `https://www.example.com/config/bootstrap.sh`
+* A local file name `file:///usr/local/bin/my_bootstrap.sh` (this is particularly useful if you're customising the AMI and are able to include a bootstrap script that way).
 
 If the file is private, you also need to create an IAM policy to allow the instances to read the file, for example:
 


### PR DESCRIPTION
I was amazed to learn this when i dug into it.  It turns out that you can reference a local file as your bootstrap script - it doesn't have to live in S3! It's currently poorly documented, but the way Buildkite grabs the bootstrap script (this happens [here](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/7104fe450cb5a22414ee5bbb4ed8e7fe0e65d3a2/packer/linux/conf/bin/bk-install-elastic-stack.sh#L201-L205)) is to use `aws s3 cp`, except if it's not an `s3://` URL, it'll call `curl` ([here](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/7104fe450cb5a22414ee5bbb4ed8e7fe0e65d3a2/packer/linux/conf/bin/bk-fetch.sh#L12)), which can be convinced to just cat out a local file.