### PR TITLE
💄 Better consistency and legibility for body text

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -389,6 +389,8 @@ label[for='navicon'] span { // hide alt text
 }
 
 .Docs__toc {
+  line-height: 1.3;
+
   p { margin-bottom: .5em; }
   .Docs__toc__list {
     margin-top: .5em;

--- a/app/assets/stylesheets/public/utils/_text_content.scss
+++ b/app/assets/stylesheets/public/utils/_text_content.scss
@@ -1,5 +1,6 @@
 .TextContent {
-  line-height: 1.3;
+  line-height: 1.4;
+
   h2, h3, h4, blockquote, pre, p, table { margin: 1em 0; }
   h2 { font-size: #{(24/18)}rem; margin-top: 1.5em; }
   li { margin: 0.5em 0 0.5em 1.8em; }

--- a/public/404.html
+++ b/public/404.html
@@ -244,7 +244,7 @@
         text-align: center;
         margin: 0 auto;
         margin-bottom: 50px;
-        line-height: 1.3;
+        line-height: 1.4;
         color: #666666;
         max-width: 30em;
       }


### PR DESCRIPTION
The app and marketing site uses `1.4` ratio for text line-height. I've also tweaked this on Docs for consistency. Furthermore, although subtle, `1.4` line-height is more legible as it gives the different lines of text more breathing room.

Example:

| Before | After |
| ------ | ----- |
| <img width="630" alt="Screen Shot 2022-05-16 at 5 18 12 pm" src="https://user-images.githubusercontent.com/7202667/168539408-36b93041-51fc-4dab-99bd-4e13da558f59.png"> | <img width="627" alt="Screen Shot 2022-05-16 at 5 18 19 pm" src="https://user-images.githubusercontent.com/7202667/168539450-fc1302c3-993e-4009-8a55-57c818ce46fc.png"> |
| <img width="616" alt="Screen Shot 2022-05-16 at 5 14 18 pm" src="https://user-images.githubusercontent.com/7202667/168538788-6fe49b5d-d44e-45db-83eb-382f0fb58702.png"> | <img width="613" alt="Screen Shot 2022-05-16 at 5 14 54 pm" src="https://user-images.githubusercontent.com/7202667/168538912-313ccca6-d165-4860-be8e-14d865c00499.png"> |

Note: I've kept the table of contents right nav at `1.2` as the width is quite narrow and tighter line-height looks better. Furthermore, some pages have really long right nav so I'd like to keep this shorter if possible. Will look into a better UX solutions for addressing navigations later.
