### PR TITLE
Note rspec running time in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If you have Ruby installed:
 # Install the dependencies
 bundle
 # Run the specs
+# This can take three or more minutes to finish
 bundle exec rspec
 # Start the app on http://localhost:3000/
 bin/rails server


### PR DESCRIPTION
Running `bundle exec rspec` for the first time takes a few minutes. It's a bit frustrating not knowing how long precisely you'll need to wait to get started. This edit to the README is meant to help alleviate that.

This is one of a few PRs or issues I mean to open from my first impressions write up. For instance, I'll open something to give the README [the ol' checklist treatment](https://github.com/ddbeck/readme-checklist).