### PR TITLE
Clarify pull request repo protocols vary

### DIFF
--- a/pages/agent/v3/windows.md.erb
+++ b/pages/agent/v3/windows.md.erb
@@ -102,3 +102,7 @@ To install the agent on WSL2, follow the [generic Linux installation guide](/doc
 <div class="Docs__note">
 <p>Using WSL2 causes unusual behavior during pipeline upload. Refer to <a href="https://buildkite.com/docs/pipelines/defining-steps#step-defaults-pipeline-dot-yml-file">Defining steps: pipeline.yml file</a> for details.</p>
 </div>
+
+## Security considerations
+
+The agent will run scripts from the hooks directory, and will checkout and run scripts from code repositories. Please consider the filesystem permissions for these directories carefully, especially when operating in a multi-user environment.

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -386,7 +386,9 @@ Example: `"master"`, or `""` if not a pull request.
 
 The repository URL of the pull request. The value cannot be modified.
 
-Example: `"git://github.com/acme-inc/my-project.git"`, or `""` if not a pull request.
+This could be any compatible protocol, including Git, HTTPS, and SSH, and varies by repository provider.
+
+Example: `"git://github.com/acme-inc/my-project.git"`, `"https://github.acme.net/super-team/great-project.git"`, or `""` if not a pull request.
 
 <h3 class="h3-caps">BUILDKITE_REBUILT_FROM_BUILD_ID</h3>
 


### PR DESCRIPTION
GitHub have [deprecated the unauthenticated git protocol](https://github.blog/2021-09-01-improving-git-protocol-security-github/) and have switched to https, but we still supply git:// URIs to the `$BUILDKITE_PULL_REQUEST_REPO` environment variable. We're deprecating that, and so need to update the docs for the variable. I've included a note that anything using the value should be able to handle any protocol.

Fixes PIP-619