### PR TITLE
Copyedit and link update about Ruby env vars

### DIFF
--- a/pages/test_analytics/ruby_collectors.md.erb
+++ b/pages/test_analytics/ruby_collectors.md.erb
@@ -56,7 +56,7 @@ Once you're done, in your Test Analytics dashboard, you'll see analytics of test
 
 Test Analytics uses environment variables to populate test information. Regardless of the CI provider you use to run your builds, you need to make sure that environment variables are available to the RSpec collector or import API. You also need to make sure that the environment variables are passed through to a container if your builds are running in containers.
 
-Not all of these variables are set or available for each CI provider, for more details on specific integrations and providers see:
+Not all of these variables are set or available for each CI provider. For more details on specific integrations and providers see:
 
 * [RSpec on Buildkite](#environment-variables-rspec-on-buildkite)
 * [RSpec on CircleCI](#environment-variables-rspec-on-circleci)
@@ -64,7 +64,7 @@ Not all of these variables are set or available for each CI provider, for more d
 * [RSpec on other CI providers](#environment-variables-rspec-on-other-ci-providers)
 * For other CI providers and collectors see [Importing JUnit XML](/docs/test-analytics/importing-junit-xml) and [Importing JSON](/docs/test-analytics/importing-json)
 
-The only required environment variable is the unique key for the build that initiated the Test Analytics run (`BUILDKITE_ANALYTICS_KEY`).
+The only required environment variable is the unique key for the build that initiated the Test Analytics run (`BUILDKITE_ANALYTICS_KEY`), but some features of Test Analytics aren't available if the other environment variables are not set.
 
 If you're not using CI, you can still use Test Analytics by running the RSpec collector, [JUnit import](/docs/test-analytics/importing-junit-xml), or [JSON import](/docs/test-analytics/importing-json) yourself to upload data to Test Analytics.
 

--- a/pages/test_analytics/ruby_collectors.md.erb
+++ b/pages/test_analytics/ruby_collectors.md.erb
@@ -47,7 +47,7 @@ If you're already using RSpec for your tests, add the `rspec-buildkite-analytics
     $ git push
     ```
 
-5. Make sure that the Test Analytics [environment variables](#environment-variables-rspec-on-buildkite) are set so that the RSpec collector can use them in your Test Analytics dashboard.
+5. Make sure that the Test Analytics [environment variables](#environment-variables) are set so that the RSpec collector can use them in your Test Analytics dashboard.
 
 
 Once you're done, in your Test Analytics dashboard, you'll see analytics of test executions on all branches that include this code.
@@ -74,13 +74,13 @@ The following variables are set automatically when the RSpec collector is runnin
 
 | Variable                       | Description and source                                                   |
 |--------------------------------|--------------------------------------------------------------------------|
-| `key`        | a unique key for the build that initiated the Test Analytics run<br />`BUILDKITE_BUILD_ID` |
-| `url`        | URL that links to the build <br /> `BUILDKITE_BUILD_URL`                                   |
-| `branch`     | the branch or reference that this run is for<br />`BUILDKITE_BRANCH`                       |
-| `commit_sha  | the commit sha for the head of the branch<br />`BUILDKITE_COMMIT`                          |
-| `number`     | the build number of the build<br />`BUILDKITE_BUILD_NUMBER`                                |
-| `job_id`     | the id of a job within the build<br />`BUILDKITE_JOB_ID`                                   |
-| `message`    | the commit message for the head of the branch<br />`BUILDKITE_JOB_ID`                      |
+| `key`         | a unique key for the build that initiated the Test Analytics run<br />`BUILDKITE_BUILD_ID` |
+| `url`         | URL that links to the build <br /> `BUILDKITE_BUILD_URL`                                   |
+| `branch`      | the branch or reference that this run is for<br />`BUILDKITE_BRANCH`                       |
+| `commit_sha`  | the commit sha for the head of the branch<br />`BUILDKITE_COMMIT`                          |
+| `number`      | the build number of the build<br />`BUILDKITE_BUILD_NUMBER`                                |
+| `job_id`      | the id of a job within the build<br />`BUILDKITE_JOB_ID`                                   |
+| `message`     | the commit message for the head of the branch<br />`BUILDKITE_JOB_ID`                      |
 
 ### RSpec on CircleCI
 


### PR DESCRIPTION
This PR:

- Adds a missing ` tick (and then evens up the table view to compensate)
- Changes the link that jumps people to info about env vars because it's the intro part that people seem to be missing as they set up Test Analytics
- Pulls our note about some parts of Test Analytics not working without passing through all the env vars up earlier in the explainer to hopefully help make that clearer