### PR TITLE
Upgrade Vale to v2.17.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,8 +32,8 @@ steps:
     steps:
       - label: ":lint-roller: Linting text and markdown"
         commands:
-          - wget https://github.com/errata-ai/vale/releases/download/v2.12.1/vale_2.12.1_Linux_64-bit.tar.gz
-          - tar --transform='s/vale/vale-bin/'  -xf 'vale_2.12.1_Linux_64-bit.tar.gz'
+          - wget https://github.com/errata-ai/vale/releases/download/v2.17.0/vale_2.17.0_Linux_64-bit.tar.gz
+          - tar --transform='s/vale/vale-bin/'  -xf 'vale_2.17.0_Linux_64-bit.tar.gz'
           - ./vale-bin --config .vale.ini pages
           - ./vale-bin --config .vale.snippets.ini pages/**/_*
 


### PR DESCRIPTION
This upgrades Vale to the latest version (the one that's likely to be available through your package manager) and fixes a bug that's blocking https://github.com/buildkite/docs/pull/1521.