### PR TITLE
Remove incorrect env var reference

### DIFF
--- a/pages/test_analytics/ruby_collectors.md.erb
+++ b/pages/test_analytics/ruby_collectors.md.erb
@@ -64,7 +64,7 @@ Not all of these variables are set or available for each CI provider. For more d
 * [RSpec on other CI providers](#environment-variables-rspec-on-other-ci-providers)
 * For other CI providers and collectors see [Importing JUnit XML](/docs/test-analytics/importing-junit-xml) and [Importing JSON](/docs/test-analytics/importing-json)
 
-The only required environment variable is the unique key for the build that initiated the Test Analytics run (`BUILDKITE_ANALYTICS_KEY`), but some features of Test Analytics aren't available if the other environment variables are not set.
+The only required environment variable is the unique key for the build that initiated the Test Analytics run, but some features of Test Analytics aren't available if the other environment variables are not set.
 
 If you're not using CI, you can still use Test Analytics by running the RSpec collector, [JUnit import](/docs/test-analytics/importing-junit-xml), or [JSON import](/docs/test-analytics/importing-json) yourself to upload data to Test Analytics.
 
@@ -112,7 +112,7 @@ To pass a human-readable commit message through to Test Analytics, set the `BUIL
 
 ### RSpec on other CI providers
 
-If you're using other CI providers, you need to configure these environment variables yourself. The only required environment variable is the unique key for the build that initiated the Test Analytics run (`BUILDKITE_ANALYTICS_KEY`), but some features of Test Analytics aren't available if the other environment variables are not set:
+If you're using other CI providers, you need to configure these environment variables yourself. The only required environment variable is the unique key for the build that initiated the Test Analytics run, but some features of Test Analytics aren't available if the other environment variables are not set:
 
 | Variable                       | Description and source                                         |
 |--------------------------------|----------------------------------------------------------------|


### PR DESCRIPTION
Got more detail on our env vars via a comment in a different PR:

> This isn't quite right, and it's not the easiest thing to communicate 😅
> 
> On Buildkite they need to ensure BUILDKITE_BUILD_ID is passed through, or they can set BUILDKITE_ANALYTICS_KEY to something of their choosing. For the other supported platforms there's a similar thing going on.
> 
> Perhaps all that's needed is to drop the var in the brackets?
> 
> `<p>The only required environment variable is the unique key for the build that initiated the Test Analytics run, but some features will not work if the other environment variables are not set.</p>`

Might be that we also need to add different word to make the relationship between BUILD_ID and ANALYTICS_KEY clear, but for now, this PR makes the more straightforward part of this fix.
