### PR TITLE
Correct "Javascript" to "JavaScript"

### DIFF
--- a/pages/apis/webhooks/integrations.md.erb
+++ b/pages/apis/webhooks/integrations.md.erb
@@ -15,7 +15,7 @@ There are many ways to integrate webhooks with AWS Lambda. The following reposit
 
 ## Google Cloud Functions
 
-[Google Cloud Functions](https://cloud.google.com/functions) are a Google Cloud service for hosted Javascript execution, and also supports exposing functions using URLs. See the [Calling Cloud Functions documentation](https://cloud.google.com/functions/calling) for how to expose them, and their [Hello World walkthrough](https://cloud.google.com/functions/walkthroughs) for getting started.
+[Google Cloud Functions](https://cloud.google.com/functions) are a Google Cloud service for hosted JavaScript execution, and also supports exposing functions using URLs. See the [Calling Cloud Functions documentation](https://cloud.google.com/functions/calling) for how to expose them, and their [Hello World walkthrough](https://cloud.google.com/functions/walkthroughs) for getting started.
 
 ## IronWorker
 

--- a/vale/vocab.txt
+++ b/vale/vocab.txt
@@ -27,7 +27,6 @@ GitLab
 Gradle
 Hashicorp
 Inlining
-Javascript
 Memcache
 Minitest
 Namespace


### PR DESCRIPTION
JavaScript is, regretfully, Pascal case. `vocab.txt` contains the exceptional "Javascript" for one instance in the docs, so I've fixed that and dropped the exception.

Discovered in the course of #1526.