### PR TITLE
Fix outstanding Vale warnings

### DIFF
--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -15,7 +15,7 @@ debug=true
 ```
 {: codeblock-file="/buildkite/buildkite-agent.cfg"}
 
-You can find the location of your configuration file in your platform’s installation documentation. You can also set it using the `--config` command line argument or via the `BUILDKITE_AGENT_CONFIG` environment variable.
+You can find the location of your configuration file in your platform’s installation documentation. You can also set it using the `--config` command line argument or the `BUILDKITE_AGENT_CONFIG` environment variable.
 
 ## Configuration settings
 <!-- vale off -->

--- a/pages/agent/v3/tracing.md.erb
+++ b/pages/agent/v3/tracing.md.erb
@@ -2,7 +2,7 @@
 
 Distributed tracing tools like [Datadog APM](https://www.datadoghq.com/product/apm/) or [OpenTelemetry](https://opentelemetry.io/) tracing allow you to gain more insight into the the performance of your CI runs - what's fast, what's slow, what could be optimized, and more importantly, how these things are changing over time.
 
-The Buildkite agent currently supports the two tracing backends listed above, Datadog APM (via OpenTracing) and OpenTelemetry. This doc will guide you through setting up tracing using either of these backends.
+The Buildkite agent currently supports the two tracing backends listed above, Datadog APM (using OpenTracing) and OpenTelemetry. This doc will guide you through setting up tracing using either of these backends.
 
 {:toc}
 

--- a/pages/integrations/sso/github_sso.md.erb
+++ b/pages/integrations/sso/github_sso.md.erb
@@ -27,7 +27,7 @@ Once you've performed a test login you can enable your provider. Activating SSO 
 
 If you need to edit or update your GitHub provider settings at any time, you will need to [disable the SSO provider](/docs/integrations/sso#disabling-and-removing-sso) first.
 
-After you've enabled GitHub as the SSO provider for your Buildkite organization, new and expired users will need to log in via GitHub by visiting `buildkite.com/sso/your-organization-name`. They will be asked to provide their email address, and a sign-in link will be emailed to them.
+After you've enabled GitHub as the SSO provider for your Buildkite organization, new and expired users will need to log in through GitHub by visiting `buildkite.com/sso/your-organization-name`. They will be asked to provide their email address, and a sign-in link will be emailed to them.
 
 Sending the sign-in link by email is an additional security and privacy measure, as a user can be a member of several Buildkite organizations. If the names of such Buildkite organizations themselves contain information – for example, `buildkite.com/sso/flyingcar` or `buildkite.com/sso/aliens`, disclosing a list of such organizations to somebody who only knows an email address could leak sensitive information.
 

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -16,7 +16,7 @@ You can have complete control over when to trigger pipeline builds by using cond
 
 Pipeline-level build conditionals are evaluated before any other build trigger settings. If both a conditional and a branch filter are present, both filters must pass for a build to be created – first the pipeline-level limiting filter and then the conditional filter.
 
-Conditionals are supported in [Bitbucket](/docs/integrations/bitbucket), [Bitbucket Server](/docs/integrations/bitbucket-server), [GitHub](/docs/integrations/github), [GitHub Enterprise](/docs/integrations/github-enterprise), and [GitLab](/docs/integrations/gitlab) (including GitLab Community and GitLab Enterprise). You can add a conditional on your _Pipeline Settings page_ in the Buildkite UI or via the REST API.
+Conditionals are supported in [Bitbucket](/docs/integrations/bitbucket), [Bitbucket Server](/docs/integrations/bitbucket-server), [GitHub](/docs/integrations/github), [GitHub Enterprise](/docs/integrations/github-enterprise), and [GitLab](/docs/integrations/gitlab) (including GitLab Community and GitLab Enterprise). You can add a conditional on your _Pipeline Settings page_ in the Buildkite UI or using the REST API.
 
 <div class="Docs__note">
   <h3>Evaluating conditionals</h3>

--- a/pages/pipelines/permissions.md.erb
+++ b/pages/pipelines/permissions.md.erb
@@ -171,7 +171,7 @@ You can remove a user in your organization's _Settings_ in the Buildkite UI.
 
 ### Security guarantees of removing a user
 
-When you remove a user from your organization, the active session tokens belonging to this user cannot make calls to the product that will return (or make changes to) any of the data available via the web UI, API, etc. So removing a compromised or rogue user is as effective as killing all sessions by the user.
+When you remove a user from your organization, the active session tokens belonging to this user cannot make calls to the product that will return (or make changes to) any of the data available using the web UI, API, etc. So removing a compromised or rogue user is as effective as killing all sessions by the user.
 
 Within Buildkite's access model, organizations don't own users, so they can't control users' sessions because users represent individuals who may be members of multiple organizations.
 
@@ -196,7 +196,7 @@ If the attacker has control of the SSO, the scope of the security incident is be
 
 ### Disabling and re-enabling SSO
 
-The other control you have is the organization membership's SSO mode. If the membership requires SSO, the user will only have access to your organization in the particular sessions authenticated via your SSO provider.
+The other control you have is the organization membership's SSO mode. If the membership requires SSO, the user will only have access to your organization in the particular sessions authenticated through your SSO provider.
 
 <section class="Docs__troubleshooting-note">
   <p>Before you proceed, make sure that you have at least one user with SSO as an optional log in requirement in your organization to make it possible for someone to log back in!</p>


### PR DESCRIPTION
Vale gripes about several uses of "via". This fixes them, so there are zero warnings or errors when running Vale.