### PR TITLE
💄 Link logo to homepage

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -333,7 +333,7 @@ label[for='navicon'] span { // hide alt text
   font-weight: bold;
   border-radius: 3px;
   text-decoration: none;
-  transition: background-color 300ms;
+  transition: background-color $transition-speed;
 
   @media (max-width: $Docs__bp_stacked) {
     margin-top: 10px;

--- a/app/assets/stylesheets/public/_homepage.scss
+++ b/app/assets/stylesheets/public/_homepage.scss
@@ -8,7 +8,7 @@
   z-index: 5;
 
   &__logo {
-    transition: opacity 300ms;
+    transition: opacity $transition-speed;
     will-change: opacity;
 
     &:hover {

--- a/app/assets/stylesheets/public/_homepage.scss
+++ b/app/assets/stylesheets/public/_homepage.scss
@@ -7,6 +7,15 @@
   text-align: center;
   z-index: 5;
 
+  &__logo {
+    transition: opacity 300ms;
+    will-change: opacity;
+
+    &:hover {
+      opacity: .75;
+    }
+  }
+
   h1 {
     font-size: 32px;
     font-weight: bold;

--- a/app/assets/stylesheets/public/_site_header.scss
+++ b/app/assets/stylesheets/public/_site_header.scss
@@ -35,7 +35,7 @@ $SiteHeader__bp_wrap_search: 600px;
 }
 
 .SiteHeader__logo-img {
-  transition: opacity 300ms;
+  transition: opacity $transition-speed;
   will-change: opacity;
 
   &:hover {
@@ -47,7 +47,7 @@ $SiteHeader__bp_wrap_search: 600px;
   font-weight: bold;
   color: black;
   text-decoration: none;
-  transition: color 300ms;
+  transition: color $transition-speed;
   will-change: color;
 
   &:hover,

--- a/app/assets/stylesheets/public/_site_header.scss
+++ b/app/assets/stylesheets/public/_site_header.scss
@@ -34,6 +34,15 @@ $SiteHeader__bp_wrap_search: 600px;
   margin-right: 3em;
 }
 
+.SiteHeader__logo-img {
+  transition: opacity 300ms;
+  will-change: opacity;
+
+  &:hover {
+    opacity: .75;
+  }
+}
+
 .SiteHeader__docslink {
   font-weight: bold;
   color: black;

--- a/app/assets/stylesheets/public/_site_header.scss
+++ b/app/assets/stylesheets/public/_site_header.scss
@@ -19,21 +19,31 @@ $SiteHeader__bp_wrap_search: 600px;
 
 .SiteHeader__inner {
   display: flex;
+
   @media (max-width: $SiteHeader__bp_wrap_search) {
     flex-direction: column;
   }
+}
+
+.SiteHeader__logo {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  line-height: $SiteHeaderLogoHeight;
+  margin-bottom: .5em;
+  margin-right: 3em;
 }
 
 .SiteHeader__docslink {
   font-weight: bold;
   color: black;
   text-decoration: none;
-  display: flex;
-  align-items: center;
   transition: color 300ms;
   will-change: color;
 
-  &:hover, &:focus, &:active {
+  &:hover,
+  &:focus,
+  &:active {
     color: #14CC80;
   }
 }
@@ -47,14 +57,7 @@ $SiteHeader__bp_wrap_search: 600px;
   }
 }
 
-.SiteHeader__logo, .SiteHeader__tagline {
-  margin: 0;
-}
 
-.SiteHeader__logo {
-  flex: 0 0 auto;
-  line-height: $SiteHeaderLogoHeight;
-  display: inline-block;
-  margin-right: 3em;
-  margin-bottom: .5em;
+.SiteHeader__tagline {
+  margin: 0;
 }

--- a/app/assets/stylesheets/public/_variables.scss
+++ b/app/assets/stylesheets/public/_variables.scss
@@ -2,3 +2,4 @@ $font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neu
 $text-on-dark-subdued-opacity: .8;
 $text-on-dark-very-subdued-opacity: .7;
 $color-brand-green: rgb(2, 129, 76);
+$transition-speed: 300ms;

--- a/app/assets/stylesheets/public/utils/_bootstrap_form.scss
+++ b/app/assets/stylesheets/public/utils/_bootstrap_form.scss
@@ -58,8 +58,8 @@
     text-decoration: none;
     -webkit-appearance: none;
     -moz-appearance: none;
-    -webkit-transition: background-color 300ms;
-    transition: background-color 300ms;
+    -webkit-transition: background-color $transition-speed;
+    transition: background-color $transition-speed;
 
     &:hover {
       background-color: #00BB64;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,17 +47,15 @@
   <body <%= beta? ? 'class=beta' : ''-%>>
     <header class="SiteHeader">
       <div class="SiteHeader__inner PageContainer">
-        <h1 class="SiteHeader__logo">
-          <%= link_to home_page_path, class: 'SiteHeader__docslink' do %>
-            <span class="SiteHeader__mark">
-              <svg
-                  width="<%= local_assigns.fetch(:width) { 42 } %>"
-                  height="<%= local_assigns.fetch(:height) { 28 } %>"
-                  viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title></title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
-            </span>
-            Buildkite Docs
+        <div class="SiteHeader__logo">
+          <%= link_to "https://buildkite.com/home", class: "SiteHeader__mark" do %>
+            <svg
+              width="<%= local_assigns.fetch(:width) { 42 } %>"
+              height="<%= local_assigns.fetch(:height) { 28 } %>"
+              viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title></title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
           <% end %>
-        </h1>
+          <%= link_to "Buildkite Docs", home_page_path, class: "SiteHeader__docslink" %>
+        </div>
         <p class="OffScreen SiteHeader__tagline">Lightning fast testing and delivery for all your software projects.</p>
         <p class="OffScreen SiteHeader__skip-nav"><a href="#main">Skip to main content</a></p>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,6 +51,7 @@
           <%= link_to "https://buildkite.com/home", aria: { label: "Buildkite logo" }, class: "SiteHeader__mark", title: "Go to Buildkite homepage" do %>
             <svg
               aria-hidden="true"
+              class="SiteHeader__logo-img"
               focusable="false"
               width="<%= local_assigns.fetch(:width) { 42 } %>"
               height="<%= local_assigns.fetch(:height) { 28 } %>"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,13 +48,15 @@
     <header class="SiteHeader">
       <div class="SiteHeader__inner PageContainer">
         <div class="SiteHeader__logo">
-          <%= link_to "https://buildkite.com/home", class: "SiteHeader__mark" do %>
+          <%= link_to "https://buildkite.com/home", aria: { label: "Buildkite logo" }, class: "SiteHeader__mark", title: "Go to Buildkite homepage" do %>
             <svg
+              aria-hidden="true"
+              focusable="false"
               width="<%= local_assigns.fetch(:width) { 42 } %>"
               height="<%= local_assigns.fetch(:height) { 28 } %>"
-              viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title></title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
+              viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
           <% end %>
-          <%= link_to "Buildkite Docs", home_page_path, class: "SiteHeader__docslink" %>
+          <%= link_to "Buildkite Docs", home_page_path, class: "SiteHeader__docslink", title: "Return to Docs index page" %>
         </div>
         <p class="OffScreen SiteHeader__tagline">Lightning fast testing and delivery for all your software projects.</p>
         <p class="OffScreen SiteHeader__skip-nav"><a href="#main">Skip to main content</a></p>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -54,9 +54,11 @@
     <header class="HomeHeader PageContainer">
       <%= link_to "https://buildkite.com/home", title: "Go to Buildkite homepage" do %>
         <svg
-            width="84"
-            height="56"
-            viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title>Buildkite</title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
+          aria-labelledby="logoTitle"
+          role="img"
+          width="84"
+          height="56"
+          viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title id="logoTitle">Buildkite</title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
       <% end %>
       <h1>Buildkite Docs</h1>
       <p class="OffScreen SiteHeader__tagline">Lightning fast testing and delivery for all your software projects.</p>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -52,10 +52,12 @@
   </head>
   <body>
     <header class="HomeHeader PageContainer">
-      <svg
-          width="84"
-          height="56"
-          viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title>Buildkite</title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
+      <%= link_to "https://buildkite.com/home", title: "Go to Buildkite homepage" do %>
+        <svg
+            width="84"
+            height="56"
+            viewBox="0 0 42 28" xmlns="http://www.w3.org/2000/svg"><title>Buildkite</title><g fill="none" fill-rule="evenodd"><path fill="#30F2A2" d="M0 0l13.965 6.94v13.988L0 13.99M28.042 0l13.854 6.94-13.854 7.05"/><path fill="#14CC80" d="M28.042 0L13.965 6.94v13.988l14.077-6.938M41.896 6.94l-13.854 7.05v13.99l13.854-7.052"/></g></svg>
+      <% end %>
       <h1>Buildkite Docs</h1>
       <p class="OffScreen SiteHeader__tagline">Lightning fast testing and delivery for all your software projects.</p>
       <p class="OffScreen SiteHeader__skip-nav"><a href="#main">Skip to main content</a></p>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -55,6 +55,7 @@
       <%= link_to "https://buildkite.com/home", title: "Go to Buildkite homepage" do %>
         <svg
           aria-labelledby="logoTitle"
+          class="HomeHeader__logo"
           role="img"
           width="84"
           height="56"


### PR DESCRIPTION
Link Buildkite logo in the header to the homepage. 

This makes it easier for customers to find the link back to our homepage. This is an interim design improvement until we have a new header design (which we may adopt from the Marketing site, but to be discussed or confirmed later).

https://www.loom.com/share/101d5aaa93644424b0c665cb4cd7523c

Changes:
- Add hyperlink to logos
- "Buildkite Docs" header text still links to the Docs index page
- a11y improvements
- Hover effect on logo to indicate these are linkable
- Refactor: use `$transition-speed` variable for all transition instances
