### PR TITLE
Fix typos in env vars

### DIFF
--- a/pages/test_analytics/ruby_collectors.md.erb
+++ b/pages/test_analytics/ruby_collectors.md.erb
@@ -82,7 +82,7 @@ The following variables are set automatically when the RSpec collector is runnin
 | `commit_sha`  | the commit sha for the head of the branch<br />`BUILDKITE_COMMIT`                          |
 | `number`      | the build number of the build<br />`BUILDKITE_BUILD_NUMBER`                                |
 | `job_id`      | the id of a job within the build<br />`BUILDKITE_JOB_ID`                                   |
-| `message`     | the commit message for the head of the branch<br />`BUILDKITE_JOB_ID`                      |
+| `message`     | the commit message for the head of the branch<br />`BUILDKITE_MESSAGE`                      |
 
 ### RSpec on CircleCI
 

--- a/pages/test_analytics/ruby_collectors.md.erb
+++ b/pages/test_analytics/ruby_collectors.md.erb
@@ -124,4 +124,4 @@ If you're using other CI providers, you need to configure these environment vari
 | `BUILDKITE_ANALYTICS_SHA`      | the commit SHA for the head of the branch                      |
 | `BUILDKITE_ANALYTICS_NUMBER`   | the build number of the build                                  |
 | `BUILDKITE_ANALYTICS_JOB_ID`   | the id of a job within the build                               |
-| `BUILDKITE_ANANLYTICS_MESSAGE` | the commit message for the head of the branch                  |
+| `BUILDKITE_ANALYTICS_MESSAGE`  | the commit message for the head of the branch                  |


### PR DESCRIPTION
Fix the following user-reported typos:

- "BUILDKITE_JOB_ID" is repeated for "message". It should be "BUILDKITE_MESSAGE".
- Probably a typo in "BUILDKITE_ANANLYTICS_MESSAGE".