### PR TITLE
💚 Explicitly opt-out of toc on the TA Landing Page

### DIFF
--- a/pages/test_analytics.md.erb
+++ b/pages/test_analytics.md.erb
@@ -12,6 +12,8 @@ Test Analytics helps you track and analyze the steps in that pipeline that invol
 - Identify, fix, and monitor test suite performance
 - Track, improve, and monitor test suite reliability
 
+{:notoc}
+
 <%= image "overview.png", width: 975, height: 205, alt: "Screenshot of test suite trend showing five metrics over 28 days" %>
 
 ## Get started


### PR DESCRIPTION
There's a linting error that's causing a failed build. I've pushed up the fix by explicitly [omit TOC](https://github.com/buildkite/docs/pull/1521) on the TA Landing Page.

I forgot to rebase `main` when I merged the [TA Landing Page PR](https://github.com/buildkite/docs/pull/1523).
