### PR TITLE
Add Test Analytics JSON import format reference

### DIFF
--- a/pages/test_analytics/importing_json.md.erb
+++ b/pages/test_analytics/importing_json.md.erb
@@ -47,196 +47,7 @@ curl --request POST \
     }
 ```
 
-<!-- From https://github.com/buildkite/buildkite/blob/main/spec/fixtures/analytics/upload.jsons -->
-
-The JSON format is not yet documented, but the following example is what is produced by the [RSpec collector](/docs/test-analytics/ruby-collectors#rspec-collector):
-
-
-```json
-[
-  {
-    "id": "95f7e024-9e0a-450f-bc64-9edb62d43fa9",
-    "scope": "Analytics::Upload associations",
-    "name": "fails",
-    "identifier": "./spec/models/analytics/upload_spec.rb[1:1:3]",
-    "location": "./spec/models/analytics/upload_spec.rb:24",
-    "file_name": "./spec/models/analytics/upload_spec.rb",
-    "result": "failed",
-    "failure_reason": "Failure/Error: expect(true).to eq false",
-    "failure_expanded": [
-      {
-        "expanded": [
-          "  expected: false",
-          "       got: true",
-          "",
-          "  (compared using ==)",
-          "",
-          "  Diff:",
-          "  @@ -1 +1 @@",
-          "  -false","  +true"
-        ],
-        "backtrace": [
-          "./spec/models/analytics/upload_spec.rb:25:in `block (3 levels) in \u003ctop (required)\u003e'","./spec/support/log.rb:17:in `run'",
-          "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-          "-e:1:in `\u003cmain\u003e'"
-        ]
-      }
-    ],
-    "history": {
-      "section": "top",
-      "start_at": 347611.724809,
-      "end_at": 347612.451041,
-      "duration": 0.726232000044547,
-      "detail": {},
-      "children": [
-        {
-          "section": "sql",
-          "start_at": 347611.734956,
-          "end_at": 347611.735647,
-          "duration": 0.0006910000229254365,
-          "detail": {
-            "query": "SET client_min_messages TO 'warning' /*line:/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'*/"
-          },
-          "children": []
-        }
-      ]
-    }
-  },
-  {
-    "id": "3ec5600e-fe8e-46b6-91b2-0eb3a2652e30",
-    "scope": "Analytics::Upload associations",
-    "name": "also fails",
-    "identifier": "./spec/models/analytics/upload_spec.rb[1:1:4]",
-    "location": "./spec/models/analytics/upload_spec.rb:27",
-    "file_name": "./spec/models/analytics/upload_spec.rb",
-    "result": "failed",
-    "failure_reason": "Failure/Error: raise StandardError",
-    "failure_expanded": [
-      {
-        "expanded": [
-          "StandardError:",
-          "  StandardError"
-        ],
-        "backtrace": [
-          "./spec/models/analytics/upload_spec.rb:28:in `block (3 levels) in \u003ctop (required)\u003e'","./spec/support/log.rb:17:in `run'","./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-          "-e:1:in `\u003cmain\u003e'"
-        ]
-      }
-    ],
-    "history": {
-      "section": "top",
-      "start_at": 347612.50397,
-      "end_at": 347612.787357,
-      "duration": 0.2833869999740273,
-      "detail": {},
-      "children": [
-        {
-          "section": "sql",
-          "start_at": 347612.53343899996,
-          "end_at": 347612.618446,
-          "duration": 0.08500700001604855,
-          "detail": {
-            "query":  "ALTER TABLE \"agent_connection_counts\" DISABLE TRIGGER ALL;\nDELETE FROM \"agent_connection_counts\";\nALTER TABLE \"agent_connection_counts\" ENABLE TRIGGER ALL;\nALTER TABLE \"agent_registration_tokens\" DISABLE TRIGGER ALL;\nDELETE FROM \"agent_registration_tokens\";\nALTER TABLE \"agent_registration_tokens\" ENABLE TRIGGER ALL;\nALTER TABLE \"agents\" DISABLE TRIGGER ALL;\nDELETE FROM \"agents\";\nALTER TABLE \"agents\" ENABLE TRIGGER ALL;\nALTER TABLE \"agents_projects\" DISABLE TRIGGER ALL;\nDELETE FROM \"agents_projects\";"
-          },
-          "children": []
-        }
-      ]
-    }
-  },
-  {
-    "id": "aac73c9d-f899-4e4e-a841-f33896a193e7",
-    "scope": "Analytics::Upload associations",
-    "name": "upload.executions",
-    "identifier": "./spec/models/analytics/upload_spec.rb[1:1:1]",
-    "location": "./spec/models/analytics/upload_spec.rb:12",
-    "file_name": "./spec/models/analytics/upload_spec.rb",
-    "result": "failed",
-    "failure_reason": "Got 2 failures and 1 other error from failure aggregation block",
-    "failure_expanded": [
-      {
-        "expanded": [
-          "Failure/Error: expect(true).to eq false","","  expected: false",
-          "       got: true",
-          "",
-          "  (compared using ==)",
-          "",
-          "  Diff:",
-          "  @@ -1 +1 @@",
-          "  -false",
-          "  +true"
-        ],
-        "backtrace": [
-          "./spec/models/analytics/upload_spec.rb:14:in `block (4 levels) in \u003ctop (required)\u003e'",
-          "./spec/models/analytics/upload_spec.rb:13:in `block (3 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/log.rb:17:in `run'",
-          "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-          "-e:1:in `\u003cmain\u003e'"
-        ]
-      },
-      {
-        "expanded": [
-          "Failure/Error: expect(upload.executions.count).to eq 1",
-          "",
-          "  expected: 1",
-          "       got: 2",
-          "",
-          "  (compared using ==)"
-        ],
-        "backtrace": [
-          "./spec/models/analytics/upload_spec.rb:15:in `block (4 levels) in \u003ctop (required)\u003e'",
-          "./spec/models/analytics/upload_spec.rb:13:in `block (3 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/log.rb:17:in `run'",
-          "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-          "-e:1:in `\u003cmain\u003e'"]
-      },
-      {
-        "expanded": [
-          "Failure/Error: raise StandardError",
-          "",
-          "StandardError:",
-          "  StandardError"
-        ],
-        "backtrace": [
-          "./spec/models/analytics/upload_spec.rb:16:in `block (4 levels) in \u003ctop (required)\u003e'",
-          "./spec/models/analytics/upload_spec.rb:13:in `block (3 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/log.rb:17:in `run'",
-          "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-          "-e:1:in `\u003cmain\u003e'"
-        ]
-      }
-    ],
-    "history": {
-      "section": "top",
-      "start_at": 347612.791024,
-      "end_at": 347613.109785,
-      "duration": 0.3187610000022687,
-      "detail": {},
-      "children": [
-        {
-          "section": "sql",
-          "start_at": 347612.819713,
-          "end_at": 347612.898322,
-          "duration": 0.07860900001833215,
-          "detail": {
-            "query": "ALTER TABLE \"agent_connection_counts\" DISABLE TRIGGER ALL;\nDELETE FROM \"agent_connection_counts\";\nALTER TABLE \"agent_connection_counts\" ENABLE TRIGGER ALL;\nALTER TABLE \"agent_registration_tokens\" DISABLE TRIGGER ALL;\nDELETE FROM \"agent_registration_tokens\";"
-          },
-          "children": []
-        }
-      ]
-    }
-  }
-]
-```
+Read [Test data reference](#test-data-reference) for a description of the `data` array schema.
 
 Test Analytics parses the JSON and imports all valid test cases for ingestion and valuation. The response to a successful request is `202 Accepted` with the newly created `id` (Run ID), and totals for the number of `queued` and `skipped` test cases contained in the uploaded data.
 
@@ -251,6 +62,132 @@ Test Analytics parses the JSON and imports all valid test cases for ingestion an
 Note that when a payload is processed, Buildkite validates and queues each test execution result in a loop. For that reason, it is possible for some to be queued and others to be skipped. Even when some or all test executions get skipped, REST API will respond with a `202 Accepted` because the upload and the run were created in the database, but the skipped test execution results were not ingested.
 
 Currently, the errors returned contain no information on individual records that failed the validation. This may make complicate the process of fixing and retrying the request.
+
+## Test data reference
+
+The endpoint's `data` array is made up of one or more _test result_ objects.
+The objects contain the overall result and metadata about the test.
+It also contains _history_ object, which is a summary of the duration of the test run.
+Within the history object, detailed _span_ objects record the highest resolution details of the test run.
+
+- [Test result](#test-result-objects)
+   - [History](#history-objects)
+      - [Spans](#span-objects)
+
+### Test result objects
+
+A test result represents a single test run.
+
+<!--
+
+key;required;type;description;example
+id;true;UUIDv4 string;a unique identifier for this test result;1b70486f-ca5f-4e6d-beb8-6347b2e49278
+scope;;string;a group or topic for the test;Student.isEnrolled()
+name;;string;a name or description for the test;Manager.isEnrolled() returns_boolean
+identifier;;string;a unique identifier for the test. If your test runner supports it, use the identifier needed to rerun this test;Manager.isEnrolled#returns_boolean
+location;;string;the file and line number where the test originates, separated by a colon (:);./tests/Manager/isEnrolled.js:32
+file_name;;string;the file where the test orginates;./tests/Manager/isEnrolled.js
+result;;string "passed", "failed", "skipped", or "unknown";the outcome of the test;"failed"
+failure_reason;;string;if applicable, a short summary of why the test failed;Expected Boolean, got Object
+history;true;history object;See [History objects];
+
+-->
+
+| Key                  | Type                                                        | Description                                                                                                     | Example                                |
+| -------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `id` (required)      | UUIDv4 string                                               | a unique identifier for this test result                                                                        | `1b70486f-ca5f-4e6d-beb8-6347b2e49278` |
+| `scope`              | string                                                      | a group or topic for the test                                                                                   | `Student.isEnrolled()`                 |
+| `name`               | string                                                      | a name or description for the test                                                                              | `Manager.isEnrolled() returns_boolean` |
+| `identifier`         | string                                                      | a unique identifier for the test. If your test runner supports it, use the identifier needed to rerun this test | `Manager.isEnrolled#returns_boolean`   |
+| `location`           | string                                                      | the file and line number where the test originates, separated by a colon (`:`)                                  | `./tests/Manager/isEnrolled.js:32`     |
+| `file_name`          | string                                                      | the file where the test orginates                                                                               | `./tests/Manager/isEnrolled.js`        |
+| `result`             | strings `"passed"`, `"failed"`, `"skipped"`, or `"unknown"` | the outcome of the test                                                                                         | `failed`                               |
+| `failure_reason`     | string                                                      | if applicable, a short summary of why the test failed                                                           | `Expected Boolean, got Object`         |
+| `history` (required) | history object                                              | See [History objects](#history-objects)                                                                                                                  |
+
+**Example:**
+
+```js
+{
+  "id": "95f7e024-9e0a-450f-bc64-9edb62d43fa9",
+  "scope": "Analytics::Upload associations",
+  "name": "fails",
+  "identifier": "./spec/models/analytics/upload_spec.rb[1:1:3]",
+  "location": "./spec/models/analytics/upload_spec.rb:24",
+  "file_name": "./spec/models/analytics/upload_spec.rb",
+  "result": "failed",
+  "failure_reason": "Failure/Error: expect(true).to eq false",
+  "history": {
+    /* history object */
+  }
+}
+```
+
+### History objects
+
+A history object represents the overall duration of the test run and contains detailed span data, more finely recording the test run.
+
+<!--
+Key;Required;Type;Description;Example
+start_at;;number;TK
+end_at;;number;TK
+duration;true;number;how long the test took to run;7.07654
+children;;array of span objects;See [Span objects](#tk)
+-->
+
+| Key                   | Type                  | Description                       | Example |
+| --------------------- | --------------------- | --------------------------------- | ------- |
+| `start_at`            | number                | TK                                |         |
+| `end_at`              | number                | TK                                |         |
+| `duration` (required) | number                | how long the test took to run     | 7.07654 |
+| `children`            | array of span objects | See [Span objects](#span-objects) |         |
+
+**Example:**
+
+```js
+{
+  "start_at": 347611.724809,
+  "end_at": 347612.451041,
+  "duration": 0.726232000044547,
+  "children": [
+    /* span objects */
+  ]
+}
+```
+
+### Span objects
+
+Span objects represent the finest duration resolution of a test run.
+It represents, for example, the duration of an individual database query within a test.
+
+<!--
+key;required;type;description;example
+section;true;string "http", "sql", "sleep", or "annotation"
+start_at;;number
+end_at;;number
+duration;;number;how long the test took to run
+-->
+
+| key                | type                                                   | description                   | example |
+| ------------------ | ------------------------------------------------------ | ----------------------------- | ------- |
+| section (required) | string `"http"`, `"sql"`, `"sleep"`, or `"annotation"` | TK                            |         |
+| start_at           | number                                                 | TK                            |         |
+| end_at             | number                                                 | TK                            |         |
+| duration           | number                                                 | how long the test took to run |         |
+
+**Example:**
+
+```js
+{
+  "section": "sql",
+  "start_at": 347611.734956,
+  "end_at": 347611.735647,
+  "duration": 0.0006910000229254365,
+  "detail": {
+    "query": "SET client_min_messages TO 'warning' /*line:/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'*/"
+  }
+}
+```
 
 ## Environment variables
 


### PR DESCRIPTION
This is a WIP, a skeleton really, to show one possible approach for describing the JSON format. It breaks it down into three component types: a result object, one or more history objects, and (presumably many) span objects. Treat this as a concept and then we can proceed toward filling in all the gaps (and moving it to better format, probably YAML, to give us flexibility to change the presentation).