### PR TITLE
Rewrite Test Analytics import docs for multipart form

### DIFF
--- a/pages/test_analytics/importing_json.md.erb
+++ b/pages/test_analytics/importing_json.md.erb
@@ -116,7 +116,7 @@ history;true;history object;See [History objects];
 | `file_name`          | string                                                      | the file where the test originates                                                                              | `./tests/Manager/isEnrolled.js`        |
 | `result`             | strings `"passed"`, `"failed"`, `"skipped"`, or `"unknown"` | the outcome of the test                                                                                         | `failed`                               |
 | `failure_reason`     | string                                                      | if applicable, a short summary of why the test failed                                                           | `Expected Boolean, got Object`         |
-| `history` (required) | history object                                              | Read [History objects](#history-objects)                                                                                                                 |
+| `history` (required) | history object                                              | Read [History objects](#json-test-results-data-reference-history-objects)                                                                                                                 |
 
 **Example:**
 
@@ -155,7 +155,7 @@ children;;array of span objects;See [Span objects](#tk)
 | `start_at`            | number                | A monotonically increasing number |
 | `end_at`              | number                | A monotonically increasing number |
 | `duration` (required) | number                | How long the test took to run     |
-| `children`            | array of span objects | Read [Span objects](#span-objects)|
+| `children`            | array of span objects | Read [Span objects](#json-test-results-data-reference-span-objects)|
 
 **Example:**
 

--- a/pages/test_analytics/importing_json.md.erb
+++ b/pages/test_analytics/importing_json.md.erb
@@ -2,266 +2,203 @@
 
 {:toc}
 
-The beta release ships with [RSpec collector](/docs/test-analytics/ruby-collectors#rspec-collector). However, you you can also upload test results by importing JSON or [JUnit XML](/docs/test-analytics/importing-junit-xml).
+If a test collector is unavailable, you can upload tests results directly to the Test Analytics API.
+You can upload JSON-formatted test results (described in this page) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
 ## How to import JSON
 
-The Test Analytics JSON API accepts all of the same information that test framework integrations do, allowing you to display, analyze, and explore more detailed information than the generic JUnit XML reports.
+To import [JSON-formatted test results](#json-test-results-data-reference), make a `POST` request to `https://analytics-api.buildkite.com/v1/uploads` with a `multipart/form-data` body.
 
-To import JSON formatted test result data, make a POST request to `https://analytics-api.buildkite.com/v1/uploads`, with metadata and JSON in the request body.
+To upload JSON, the request body must contain the following fields:
 
-Test Analytics uses the variables in the `run_env` attribute to populate test information:
+| Field name | Value |
+| --- | --- |
+| `data` | [JSON-formatted test results](#json-test-results-data-reference) |
+| `format` | `json` |
+| `run_env[CI]` | The name of your CI environment |
+| `run_env[key]` | A unique key for the build that initiated the CI run |
+| `run_env[url]` | A URL that links to the build in your CI system |
+| `run_env[branch]` | A version control branch or reference for this run |
+| `run_env[commit_sha]` | A unique identifier for the version control revision for this run |
+| `run_env[number]` | A counter for this build |
+| `run_env[job_id]` | An identifier for a job within a build |
+| `run_env[message]` | The commit message or other description of the build |
 
-* if you're making the request in a Buildkite pipeline, you can use the Buildkite environment variables to set the metadata automatically, like in the following example:
-* if you're making the request elsewhere, [set the environment variables](#environment-variables) yourself
+For example, to import the contents of a `test-results.json` file in a Buildkite pipeline run:
 
-Test Analytics uses the variables in the `run_env` attribute to populate test information. The only *required* variable is `key`, but other Test Analytics features such as linking back to the originating build, do require the [other variables](#environment-variables) to work.
+1. Securely [set the Test Analytics token environment variable](/docs/pipelines/secrets) (`TEST_ANALYTICS_TOKEN`).
 
-Securely [add the Test Analytics token environment variable](/docs/pipelines/secrets) `TEST_ANALYTICS_TOKEN`) to your environment, so that it's available to the curl command:
+2. Run the following `curl` command:
 
-```sh
-curl --request POST \
-  --url https://analytics-api.buildkite.com/v1/uploads \
-  --header 'Authorization: Token token="'$TEST_ANALYTICS_TOKEN'";' \
-  --header 'Content-Type: application/json' \
-  --data @- << EOF
-    {
-    "format": "json",
-    "run_env": {
-      "CI": "buildkite",
-      "key": "$BUILDKITE_BUILD_ID",
-      "number": "$BUILDKITE_BUILD_NUMBER",
-      "job_id": "$BUILDKITE_JOB_ID",
-      "branch": "$BUILDKITE_BRANCH",
-      "commit_sha": "$BUILDKITE_COMMIT",
-      "message": "$BUILDKITE_MESSAGE",
-      "url": "$BUILDKITE_BUILD_URL"
-    },
-    "data": [
-              <put JSON format results here>
-          ]
-    }
-```
+    ```sh
+    curl \
+      -X POST \
+      --fail-with-body \
+      -H "Authorization: Token token=\"$TEST_ANALYTICS_TOKEN\"" \
+      -F "data=@test-results.json" \
+      -F "format=json" \
+      -F "run_env[CI]=buildkite" \
+      -F "run_env[key]=$BUILDKITE_BUILD_ID" \
+      -F "run_env[url]=$BUILDKITE_BUILD_URL" \
+      -F "run_env[branch]=$BUILDKITE_BRANCH" \
+      -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
+      -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+      -F "run_env[job_id]=$BUILDKITE_JOB_ID" \
+      -F "run_env[message]=$BUILDKITE_MESSAGE" \
+      https://analytics-api.buildkite.com/v1/uploads
+    ```
 
-<!-- From https://github.com/buildkite/buildkite/blob/main/spec/fixtures/analytics/upload.jsons -->
+To learn more about passing through environment variables to `run_env`-prefixed fields, read [CI Environments](/docs/test-analytics/ci-environments).
 
-The JSON format is not yet documented, but the following example is what is produced by the [RSpec collector](/docs/test-analytics/ruby-collectors#rspec-collector):
+## JSON test results data reference
 
+JSON test results data is made up of an array of one or more _test result_ objects.
+A test result object contains an overall result and metadata.
+It also contains a _history_ object, which is a summary of the duration of the test run.
+Within the history object, detailed _span_ objects record the highest resolution details of the test run.
 
-```json
+Schematically, the JSON test results data is like this:
+
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable MD007 -->
+
+* A test result array of:
+   - [Test result](#json-test-results-data-reference-test-result-objects)
+      * [History](#json-test-results-data-reference-history-objects)
+         - [Spans](#json-test-results-data-reference-span-objects)
+
+<!-- markdownlint-restore -->
+
+Or in a simplified code view:
+
+```js
 [
   {
-    "id": "95f7e024-9e0a-450f-bc64-9edb62d43fa9",
-    "scope": "Analytics::Upload associations",
-    "name": "fails",
-    "identifier": "./spec/models/analytics/upload_spec.rb[1:1:3]",
-    "location": "./spec/models/analytics/upload_spec.rb:24",
-    "file_name": "./spec/models/analytics/upload_spec.rb",
-    "result": "failed",
-    "failure_reason": "Failure/Error: expect(true).to eq false",
-    "failure_expanded": [
-      {
-        "expanded": [
-          "  expected: false",
-          "       got: true",
-          "",
-          "  (compared using ==)",
-          "",
-          "  Diff:",
-          "  @@ -1 +1 @@",
-          "  -false","  +true"
-        ],
-        "backtrace": [
-          "./spec/models/analytics/upload_spec.rb:25:in `block (3 levels) in \u003ctop (required)\u003e'","./spec/support/log.rb:17:in `run'",
-          "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-          "-e:1:in `\u003cmain\u003e'"
-        ]
-      }
-    ],
+    /* Test result object */
     "history": {
-      "section": "top",
-      "start_at": 347611.724809,
-      "end_at": 347612.451041,
-      "duration": 0.726232000044547,
-      "detail": {},
+      /* history object */
       "children": [
-        {
-          "section": "sql",
-          "start_at": 347611.734956,
-          "end_at": 347611.735647,
-          "duration": 0.0006910000229254365,
-          "detail": {
-            "query": "SET client_min_messages TO 'warning' /*line:/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'*/"
-          },
-          "children": []
-        }
+        /* span objects */
       ]
     }
   },
-  {
-    "id": "3ec5600e-fe8e-46b6-91b2-0eb3a2652e30",
-    "scope": "Analytics::Upload associations",
-    "name": "also fails",
-    "identifier": "./spec/models/analytics/upload_spec.rb[1:1:4]",
-    "location": "./spec/models/analytics/upload_spec.rb:27",
-    "file_name": "./spec/models/analytics/upload_spec.rb",
-    "result": "failed",
-    "failure_reason": "Failure/Error: raise StandardError",
-    "failure_expanded": [
-      {
-        "expanded": [
-          "StandardError:",
-          "  StandardError"
-        ],
-        "backtrace": [
-          "./spec/models/analytics/upload_spec.rb:28:in `block (3 levels) in \u003ctop (required)\u003e'","./spec/support/log.rb:17:in `run'","./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-          "-e:1:in `\u003cmain\u003e'"
-        ]
-      }
-    ],
-    "history": {
-      "section": "top",
-      "start_at": 347612.50397,
-      "end_at": 347612.787357,
-      "duration": 0.2833869999740273,
-      "detail": {},
-      "children": [
-        {
-          "section": "sql",
-          "start_at": 347612.53343899996,
-          "end_at": 347612.618446,
-          "duration": 0.08500700001604855,
-          "detail": {
-            "query":  "ALTER TABLE \"agent_connection_counts\" DISABLE TRIGGER ALL;\nDELETE FROM \"agent_connection_counts\";\nALTER TABLE \"agent_connection_counts\" ENABLE TRIGGER ALL;\nALTER TABLE \"agent_registration_tokens\" DISABLE TRIGGER ALL;\nDELETE FROM \"agent_registration_tokens\";\nALTER TABLE \"agent_registration_tokens\" ENABLE TRIGGER ALL;\nALTER TABLE \"agents\" DISABLE TRIGGER ALL;\nDELETE FROM \"agents\";\nALTER TABLE \"agents\" ENABLE TRIGGER ALL;\nALTER TABLE \"agents_projects\" DISABLE TRIGGER ALL;\nDELETE FROM \"agents_projects\";"
-          },
-          "children": []
-        }
-      ]
-    }
-  },
-  {
-    "id": "aac73c9d-f899-4e4e-a841-f33896a193e7",
-    "scope": "Analytics::Upload associations",
-    "name": "upload.executions",
-    "identifier": "./spec/models/analytics/upload_spec.rb[1:1:1]",
-    "location": "./spec/models/analytics/upload_spec.rb:12",
-    "file_name": "./spec/models/analytics/upload_spec.rb",
-    "result": "failed",
-    "failure_reason": "Got 2 failures and 1 other error from failure aggregation block",
-    "failure_expanded": [
-      {
-        "expanded": [
-          "Failure/Error: expect(true).to eq false","","  expected: false",
-          "       got: true",
-          "",
-          "  (compared using ==)",
-          "",
-          "  Diff:",
-          "  @@ -1 +1 @@",
-          "  -false",
-          "  +true"
-        ],
-        "backtrace": [
-          "./spec/models/analytics/upload_spec.rb:14:in `block (4 levels) in \u003ctop (required)\u003e'",
-          "./spec/models/analytics/upload_spec.rb:13:in `block (3 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/log.rb:17:in `run'",
-          "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-          "-e:1:in `\u003cmain\u003e'"
-        ]
-      },
-      {
-        "expanded": [
-          "Failure/Error: expect(upload.executions.count).to eq 1",
-          "",
-          "  expected: 1",
-          "       got: 2",
-          "",
-          "  (compared using ==)"
-        ],
-        "backtrace": [
-          "./spec/models/analytics/upload_spec.rb:15:in `block (4 levels) in \u003ctop (required)\u003e'",
-          "./spec/models/analytics/upload_spec.rb:13:in `block (3 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/log.rb:17:in `run'",
-          "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-          "-e:1:in `\u003cmain\u003e'"]
-      },
-      {
-        "expanded": [
-          "Failure/Error: raise StandardError",
-          "",
-          "StandardError:",
-          "  StandardError"
-        ],
-        "backtrace": [
-          "./spec/models/analytics/upload_spec.rb:16:in `block (4 levels) in \u003ctop (required)\u003e'",
-          "./spec/models/analytics/upload_spec.rb:13:in `block (3 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/log.rb:17:in `run'",
-          "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
-          "/Users/roselu/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-          "-e:1:in `\u003cmain\u003e'"
-        ]
-      }
-    ],
-    "history": {
-      "section": "top",
-      "start_at": 347612.791024,
-      "end_at": 347613.109785,
-      "duration": 0.3187610000022687,
-      "detail": {},
-      "children": [
-        {
-          "section": "sql",
-          "start_at": 347612.819713,
-          "end_at": 347612.898322,
-          "duration": 0.07860900001833215,
-          "detail": {
-            "query": "ALTER TABLE \"agent_connection_counts\" DISABLE TRIGGER ALL;\nDELETE FROM \"agent_connection_counts\";\nALTER TABLE \"agent_connection_counts\" ENABLE TRIGGER ALL;\nALTER TABLE \"agent_registration_tokens\" DISABLE TRIGGER ALL;\nDELETE FROM \"agent_registration_tokens\";"
-          },
-          "children": []
-        }
-      ]
-    }
-  }
+  { /* Test result object */ },
 ]
 ```
 
-Test Analytics parses the JSON and imports all valid test cases for ingestion and valuation. The response to a successful request is `202 Accepted` with the newly created `id` (Run ID), and totals for the number of `queued` and `skipped` test cases contained in the uploaded data.
+### Test result objects
 
-```json
+A test result represents a single test run.
+
+
+<%#
+<!--
+Key;required;Type;Description;example
+id;true;UUIDv4 string;a unique identifier for this test result;1b70486f-ca5f-4e6d-beb8-6347b2e49278
+scope;;string;a group or topic for the test;Student.isEnrolled()
+name;;string;a name or description for the test;Manager.isEnrolled() returns_boolean
+identifier;;string;a unique identifier for the test. If your test runner supports it, use the identifier needed to rerun this test;Manager.isEnrolled#returns_boolean
+location;;string;the file and line number where the test originates, separated by a colon (:);./tests/Manager/isEnrolled.js:32
+file_name;;string;the file where the test originates;./tests/Manager/isEnrolled.js
+result;;string "passed", "failed", "skipped", or "unknown";the outcome of the test;"failed"
+failure_reason;;string;if applicable, a short summary of why the test failed;Expected Boolean, got Object
+history;true;history object;See [History objects];
+-->
+%>
+
+| Key                  | Type                                                        | Description                                                                                                     | Example                                |
+| -------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `id` (required)      | UUIDv4 string                                               | a unique identifier for this test result                                                                        | `1b70486f-ca5f-4e6d-beb8-6347b2e49278` |
+| `scope`              | string                                                      | a group or topic for the test                                                                                   | `Student.isEnrolled()`                 |
+| `name`               | string                                                      | a name or description for the test                                                                              | `Manager.isEnrolled() returns_boolean` |
+| `identifier`         | string                                                      | a unique identifier for the test. If your test runner supports it, use the identifier needed to rerun this test | `Manager.isEnrolled#returns_boolean`   |
+| `location`           | string                                                      | the file and line number where the test originates, separated by a colon (`:`)                                  | `./tests/Manager/isEnrolled.js:32`     |
+| `file_name`          | string                                                      | the file where the test originates                                                                              | `./tests/Manager/isEnrolled.js`        |
+| `result`             | strings `"passed"`, `"failed"`, `"skipped"`, or `"unknown"` | the outcome of the test                                                                                         | `failed`                               |
+| `failure_reason`     | string                                                      | if applicable, a short summary of why the test failed                                                           | `Expected Boolean, got Object`         |
+| `history` (required) | history object                                              | Read [History objects](#history-objects)                                                                                                                 |
+
+**Example:**
+
+```js
 {
-  "id": "eac9b176-7869-464d-952e-7f87e2579128",
-  "queued": 3,
-  "skipped": 0
+  "id": "95f7e024-9e0a-450f-bc64-9edb62d43fa9",
+  "scope": "Analytics::Upload associations",
+  "name": "fails",
+  "identifier": "./spec/models/analytics/upload_spec.rb[1:1:3]",
+  "location": "./spec/models/analytics/upload_spec.rb:24",
+  "file_name": "./spec/models/analytics/upload_spec.rb",
+  "result": "failed",
+  "failure_reason": "Failure/Error: expect(true).to eq false",
+  "history": {
+    /* history object */
+  }
 }
 ```
 
-Note that when a payload is processed, Buildkite validates and queues each test execution result in a loop. For that reason, it is possible for some to be queued and others to be skipped. Even when some or all test executions get skipped, REST API will respond with a `202 Accepted` because the upload and the run were created in the database, but the skipped test execution results were not ingested.
+### History objects
 
-Currently, the errors returned contain no information on individual records that failed the validation. This may make complicate the process of fixing and retrying the request.
+A history object represents the overall duration of the test run and contains detailed span data, more finely recording the test run.
 
-## Environment variables
+<%#
+<!--
+Key;Required;Type;Description;Example
+start_at;;number;TK
+end_at;;number;TK
+duration;true;number;how long the test took to run;7.07654
+children;;array of span objects;See [Span objects](#tk)
+-->
+%>
 
-Test Analytics uses environment variables to populate test information. In the most common case, [RSpec collector](/docs/test-analytics/ruby-collectors#rspec-collector) is used and, regardless of the CI provider you use to run your builds, you'd need to make sure that environment variables are available to RSpec or import API. You'd also need to make sure that the environment variables are passed through to a container if your builds are running in containers.
+| Key                   | Type                  | Description                       |
+| --------------------- | --------------------- | --------------------------------- |
+| `start_at`            | number                | A monotonically increasing number |
+| `end_at`              | number                | A monotonically increasing number |
+| `duration` (required) | number                | How long the test took to run     |
+| `children`            | array of span objects | Read [Span objects](#span-objects)|
 
-But if you're using such tools as the JSON importers or [JUnit](/docs/test-analytics/importing-junit-xml), you need to configure the variables in `run_env` yourself.
+**Example:**
 
-The only required variable is `key`, but some features of Test Analytics aren't available if the other variables are not set:
+```js
+{
+  "start_at": 347611.724809,
+  "end_at": 347612.451041,
+  "duration": 0.726232000044547,
+  "children": [
+    /* span objects */
+  ]
+}
+```
 
-| Variable     | Description                                                    |
-|--------------|----------------------------------------------------------------|
-| `key`        | a unique key for the build that initiated the Test Analytics run |
-| `url`        | URL that links to the build                                    |
-| `branch`     | the branch or reference that this run is for                         |
-| `commit_sha` | the commit SHA for the head of the branch                      |
-| `number`     | the build number of the build                                  |
-| `job_id`     | the id of a job within the build                               |
-| `message`    | the commit message for the head of the branch                  |
+### Span objects
+
+Span objects represent the finest duration resolution of a test run.
+It represents, for example, the duration of an individual database query within a test.
+
+<%#
+<!--
+Key;required;Type;Description;example
+section;true;string "http", "sql", "sleep", or "annotation"
+start_at;;number
+end_at;;number
+duration;;number;how long the test took to run
+-->
+%>
+
+| Key                | Type                                                   | Description                       |
+| ------------------ | ------------------------------------------------------ | --------------------------------- |
+| section (required) | string `"http"`, `"sql"`, `"sleep"`, or `"annotation"` | A section category for this span  |
+| start_at           | number                                                 | A monotonically increasing number |
+| end_at             | number                                                 | A monotonically increasing number |
+| duration           | number                                                 | How long the span took to run     |
+
+**Example:**
+
+```js
+{
+  "section": "sql",
+  "start_at": 347611.734956,
+  "end_at": 347611.735647,
+  "duration": 0.0006910000229254365
+}
+```

--- a/pages/test_analytics/importing_json.md.erb
+++ b/pages/test_analytics/importing_json.md.erb
@@ -2,7 +2,7 @@
 
 {:toc}
 
-If a test collector is unavailable, you can upload tests results directly to the Test Analytics API.
+If a test collector is not available for your test framework, you can upload tests results directly to the Test Analytics API or [write your own test collector](/docs/test-analytics/your-own-collectors).
 You can upload JSON-formatted test results (described in this page) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
 ## How to import JSON

--- a/pages/test_analytics/importing_junit_xml.md.erb
+++ b/pages/test_analytics/importing_junit_xml.md.erb
@@ -51,4 +51,4 @@ To learn more about passing through environment variables to `run_env`-prefixed 
 
 Note that when a payload is processed, Buildkite validates and queues each test execution result in a loop. For that reason, it is possible for some to be queued and others to be skipped. Even when some or all test executions get skipped, REST API will respond with a `202 Accepted` because the upload and the run were created in the database, but the skipped test execution results were not ingested.
 
-Currently, the errors returned contain no information on individual records that failed the validation. This may make complicate the process of fixing and retrying the request.
+Currently, the errors returned contain no information on individual records that failed the validation. This may complicate the process of fixing and retrying the request.

--- a/pages/test_analytics/importing_junit_xml.md.erb
+++ b/pages/test_analytics/importing_junit_xml.md.erb
@@ -6,74 +6,49 @@ While most test frameworks have a built-in JUnit XML export feature, these JUnit
 
 ## How to import JUnit XML
 
+To import JUnit XML, make a `POST` request to `https://analytics-api.buildkite.com/v1/uploads` with a `multipart/form-data` body.
 
+To upload JUnit XML, the request body must contain the following fields:
 
-To import JUnit XML, make a POST request to `https://analytics-api.buildkite.com/v1/uploads`, with metadata and JUnit XML test results encoded as JSON in the request body:
+| Field name | Value |
+| --- | --- |
+| `data` | JUnit XML |
+| `format` | `junit` |
+| `run_env[CI]` | The name of your CI environment |
+| `run_env[key]` | A unique key for the build that initiated the CI run |
+| `run_env[url]` | A URL that links to the build in your CI system |
+| `run_env[branch]` | A version control branch or reference for this run |
+| `run_env[commit_sha]` | A unique identifier for the version control revision for this run |
+| `run_env[number]` | A counter for this build |
+| `run_env[job_id]` | An identifier for a job within a build |
+| `run_env[message]` | The commit message or other description of the build |
 
-Test Analytics uses the variables in the `run_env` attribute to populate test information:
+For example, to import the contents of a `junit.xml` file in a Buildkite pipeline run:
 
-* if you're making the request in a Buildkite pipeline, you can use the Buildkite environment variables to set the metadata automatically, like in the following example:
-* if you're making the request elsewhere, [set the environment variables yourself](#environment-variables)
+1. Securely [set the Test Analytics token environment variable](/docs/pipelines/secrets) (`TEST_ANALYTICS_TOKEN`).
 
-[Securely add the Test Analytics token environment variable](/docs/pipelines/secrets) (`TEST_ANALYTICS_TOKEN`) to your environment, so that it's available to the curl command, and make sure to JSON-encode your JUnit XML as in the next two code blocks.
+2. Run the following `curl` command:
 
-```sh
-curl --request POST \
-  --url https://analytics-api.buildkite.com/v1/uploads \
-  --header 'Authorization: Token token="'$TEST_ANALYTICS_TOKEN'";' \
-  --header 'Content-Type: application/json' \
-  --data @- << EOF
-    {
-      "format": "junit",
-      "run_env": {
-        "CI": "buildkite",
-        "key": "$BUILDKITE_BUILD_ID",
-        "number": "$BUILDKITE_BUILD_NUMBER",
-        "job_id": "$BUILDKITE_JOB_ID",
-        "branch": "$BUILDKITE_BRANCH",
-        "commit_sha": "$BUILDKITE_COMMIT",
-        "message": "$BUILDKITE_MESSAGE",
-        "url": "$BUILDKITE_BUILD_URL"
-      },
-      "data": "JSON-encoded JUnit XML goes here"
-    }
-EOF
-```
+    ```sh
+    curl \
+      -X POST \
+      --fail-with-body \
+      -H "Authorization: Token token=\"$TEST_ANALYTICS_TOKEN\"" \
+      -F "data=@junit.xml" \
+      -F "format=junit" \
+      -F "run_env[CI]=buildkite" \
+      -F "run_env[key]=$BUILDKITE_BUILD_ID" \
+      -F "run_env[url]=$BUILDKITE_BUILD_URL" \
+      -F "run_env[branch]=$BUILDKITE_BRANCH" \
+      -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
+      -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+      -F "run_env[job_id]=$BUILDKITE_JOB_ID" \
+      -F "run_env[message]=$BUILDKITE_MESSAGE" \
+      https://analytics-api.buildkite.com/v1/uploads
+    ```
 
-Example JSON-encoded JUnit XML:
-
-```json
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<testsuites disabled=\"\" errors=\"\" failures=\"\" name=\"\" tests=\"\" time=\"\">\r\n    <testsuite disabled=\"\" errors=\"\" failures=\"\" hostname=\"\" id=\"\"\r\n               name=\"\" package=\"\" skipped=\"\" tests=\"\" time=\"\" timestamp=\"2021-11-23 10:47\">\r\n        <properties>\r\n            <property name=\"\" value=\"\"/>\r\n        </properties>\r\n        <testcase assertions=\"\" classname=\"Banana\" name=\"lol\" status=\"\" file=\"banana.rb\" time=\"1000\">\r\n            <system-out/>\r\n            <system-err/>\r\n        </testcase>\r\n        <testcase assertions=\"\" classname=\"Banana\" name=\"rofl\" status=\"\" file=\"banana.rb\" time=\"1000\">\r\n            <skipped/>\r\n            <system-out/>\r\n            <system-err/>\r\n        </testcase>\r\n        <testcase assertions=\"\" classname=\"Banana\" name=\"hue\" status=\"\" file=\"banana.rb\" time=\"1000\">\r\n            <error message=\"\" type=\"\"/>\r\n            <failure message=\"\" type=\"\"/>\r\n            <system-out/>\r\n            <system-err/>\r\n        </testcase>\r\n        <system-out/>\r\n        <system-err/>\r\n    </testsuite>\r\n</testsuites>"
-```
-
-Test Analytics parses the XML and imports all valid test cases for ingestion and valuation. The response to a successful request is `202 Accepted` with the newly created `id` (Run ID), and totals for the number of `queued` and `skipped` test cases contained in the uploaded data.
-
-```json
-{
-  "id": "eac9b176-7869-464d-952e-7f87e2579128",
-  "queued": 3,
-  "skipped": 0
-}
-```
+To learn more about passing through environment variables to `run_env`-prefixed fields, read [CI Environments](/docs/test-analytics/ci-environments).
 
 Note that when a payload is processed, Buildkite validates and queues each test execution result in a loop. For that reason, it is possible for some to be queued and others to be skipped. Even when some or all test executions get skipped, REST API will respond with a `202 Accepted` because the upload and the run were created in the database, but the skipped test execution results were not ingested.
 
 Currently, the errors returned contain no information on individual records that failed the validation. This may make complicate the process of fixing and retrying the request.
-
-## Environment variables
-
-Test Analytics uses environment variables to populate test information. In the most common case, [RSpec collector](/docs/test-analytics/ruby-collectors#rspec-collector) is used and, regardless of the CI provider you use to run your builds, you'd need to make sure that environment variables are available to RSpec or import API. You'd also need to make sure that the environment variables are passed through to a container if your builds are running in containers.
-
-But if you're using such tools as the JUnit or [JSON](/docs/test-analytics/importing-json) importers, you need to configure the variables in `run_env` yourself.
-
-The only required variable is `key`, but some features of Test Analytics aren't available if the other variables are not set:
-
-| Variable     | Description                                                    |
-|--------------|----------------------------------------------------------------|
-| `key`        | a unique key for the build that initiated the Test Analytics run |
-| `url`        | URL that links to the build                                    |
-| `branch`     | the branch or reference that this run is for                         |
-| `commit_sha` | the commit SHA for the head of the branch                      |
-| `number`     | the build number of the build                                  |
-| `job_id`     | the id of a job within the build                               |
-| `message`    | the commit message for the head of the branch                  |


### PR DESCRIPTION
The API has changed a bit for importing JSON and JUnit XML, from a JSON payload to a `multipart/form-data` payload, this PR attempts to capture that change.

There's some duplication here which is rather unpleasant (namely, the tables ought to either consume already existing YAML or be YAML themselves). I propose we do not attempt to deal with that today.

Since it made sense to do so, I've also rolled up the JSON format reference from #1545, rather than try to wrangle it separately.

The supersedes the following PRs:

- closes https://github.com/buildkite/docs/pull/1548
- closes https://github.com/buildkite/docs/pull/1545