### PR TITLE
Add Golang and Python collectors

### DIFF
--- a/app/assets/stylesheets/public/utils/_button.scss
+++ b/app/assets/stylesheets/public/utils/_button.scss
@@ -3,12 +3,18 @@
   border: transparent 1px solid;
   border-radius: 5px;
   color: #333;
-  display: inline-flex;
+  display: flex;
   font-size: 0.8888rem;
   font-weight: 500;
   line-height: 1.4;
+  margin-bottom: 10px;
+  margin-right: 5px;
   text-decoration: none !important; // button labels should never have underlines
   
+  @media (min-width: 480px) {
+    display: inline-flex;
+  }
+
   &--default {
     background-color: white;
     border-color: #ddd;

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -247,6 +247,8 @@
             <%= sidebar_link_to "Ruby", 'test-analytics/ruby-collectors' %>
             <%= sidebar_link_to "JavaScript", 'test-analytics/js-collectors' %>
             <%= sidebar_link_to "Swift", 'test-analytics/swift-collectors' %>
+            <%= sidebar_link_to "Python", 'test-analytics/python-collectors' %>
+            <%= sidebar_link_to "Golang", 'test-analytics/golang-collectors' %>
             <%= sidebar_link_to "Elixir", 'test-analytics/elixir-collectors' %>
             <%= sidebar_link_to "Rust", 'test-analytics/rust-collectors' %>
             <%= sidebar_link_to "Other languages", 'test-analytics/other-collectors' %>

--- a/data/tiles.yml
+++ b/data/tiles.yml
@@ -21,6 +21,8 @@ test_analytics_guides:
         url: "/docs/test-analytics/js-collectors"
       - text: "Swift"
         url: "/docs/test-analytics/swift-collectors"
+      - text: "Golang"
+        url: "/docs/test-analytics/golang-collectors"
       - text: "Elixir"
         url: "/docs/test-analytics/elixir-collectors"
       - text: "Rust"

--- a/data/tiles.yml
+++ b/data/tiles.yml
@@ -21,6 +21,8 @@ test_analytics_guides:
         url: "/docs/test-analytics/js-collectors"
       - text: "Swift"
         url: "/docs/test-analytics/swift-collectors"
+      - text: "Python"
+        url: "/docs/test-analytics/python-collectors"
       - text: "Golang"
         url: "/docs/test-analytics/golang-collectors"
       - text: "Elixir"

--- a/pages/test_analytics.md.erb
+++ b/pages/test_analytics.md.erb
@@ -17,7 +17,7 @@ Test Analytics helps you track and analyze the steps in that pipeline that invol
 <!-- vale off -->
 
 <%= button ":rspec: RSpec", "/docs/test-analytics/ruby-collectors#rspec-collector" %>
-<%= button ":ruby: Minitest", "/docs/test-analytics/ruby-collectors#minitest-collector" %>
+<%= button ":ruby: minitest", "/docs/test-analytics/ruby-collectors#minitest-collector" %>
 <%= button ":jest: Jest", "/docs/test-analytics/js-collectors" %>
 <%= button ":swift: Swift", "/docs/test-analytics/swift-collectors" %>
 <%= button ":pytest: pytest", "/docs/test-analytics/python-collectors" %>

--- a/pages/test_analytics.md.erb
+++ b/pages/test_analytics.md.erb
@@ -20,6 +20,8 @@ Test Analytics helps you track and analyze the steps in that pipeline that invol
 <%= button ":ruby: Minitest", "/docs/test-analytics/ruby-collectors#minitest-collector" %>
 <%= button ":jest: Jest", "/docs/test-analytics/js-collectors" %>
 <%= button ":swift: Swift", "/docs/test-analytics/swift-collectors" %>
+<%= button ":pytest: pytest", "/docs/test-analytics/python-collectors" %>
+<%= button ":golang: Golang", "/docs/test-analytics/golang-collectors" %>
 <%= button ":elixir: Elixir", "/docs/test-analytics/elixir-collectors" %>
 <%= button ":rust: Rust", "/docs/test-analytics/rust-collectors" %>
 

--- a/pages/test_analytics/golang_collectors.md.erb
+++ b/pages/test_analytics/golang_collectors.md.erb
@@ -1,8 +1,6 @@
 # Configuring Golang with Test Analytics
 
-To use Test Analytics with your golang projects,
-you use [gotestsum](https://github.com/gotestyourself/gotestsum) to generate JUnit XML files,
-and then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) to Test Analytics.
+To use Test Analytics with your Golang projects, generate JUnit XML files with [gotestsum](https://github.com/gotestyourself/gotestsum), and then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) to Test Analytics.
 
 {:notoc}
 

--- a/pages/test_analytics/golang_collectors.md.erb
+++ b/pages/test_analytics/golang_collectors.md.erb
@@ -1,0 +1,41 @@
+# Configuring Golang with Test Analytics
+
+To use Test Analytics with your golang projects,
+you use [gotestsum](https://github.com/gotestyourself/gotestsum) to generate JUnit XML files,
+and then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) to Test Analytics.
+
+{:notoc}
+
+1. Install [gotestsum](https://github.com/gotestyourself/gotestsum):
+
+    ```sh
+    go install gotest.tools/gotestsum@latest
+    ```
+
+1. Use gotestsum to run your tests and output JUnit XML, by replacing `go test` with `go testsum`, for example:
+
+    ```sh
+    gotestsum --junitfile junit.xml ./...
+    ```
+
+1. Upload the JUnit.xml to Buildkite:
+
+    ```sh
+    curl \
+      -X POST \
+      --fail-with-body \
+      -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
+      -F "data=@junit.xml" \
+      -F "format=junit" \
+      -F "run_env[CI]=buildkite" \
+      -F "run_env[key]=$BUILDKITE_BUILD_ID" \
+      -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+      -F "run_env[job_id]=$BUILDKITE_JOB_ID" \
+      -F "run_env[branch]=$BUILDKITE_BRANCH" \
+      -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
+      -F "run_env[message]=$BUILDKITE_MESSAGE" \
+      -F "run_env[url]=$BUILDKITE_BUILD_URL" \
+      https://analytics-api.buildkite.com/v1/uploads
+    ```
+
+See [gotestsum](https://github.com/gotestyourself/gotestsum) for full documentation of its features and command line flags.

--- a/pages/test_analytics/golang_collectors.md.erb
+++ b/pages/test_analytics/golang_collectors.md.erb
@@ -38,4 +38,4 @@ and then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) 
       https://analytics-api.buildkite.com/v1/uploads
     ```
 
-See [gotestsum](https://github.com/gotestyourself/gotestsum) for full documentation of its features and command line flags.
+See [gotestsum](https://github.com/gotestyourself/gotestsum) for full documentation of its features and command-line flags.

--- a/pages/test_analytics/other_collectors.md.erb
+++ b/pages/test_analytics/other_collectors.md.erb
@@ -6,7 +6,6 @@ You can integrate any language and framework by uploading [Test Analytics JSON](
 
 The following collectors are coming soon:
 
-- pytest
 - Android
 - .NET
 

--- a/pages/test_analytics/python_collectors.md.erb
+++ b/pages/test_analytics/python_collectors.md.erb
@@ -1,0 +1,41 @@
+# Configuring Python with Test Analytics
+
+To use Test Analytics with your Python projects,
+you use [pytest](https://docs.pytest.org) to generate JUnit XML files,
+and then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) to Test Analytics.
+
+{:notoc}
+
+1. Install [pytest](https://docs.pytest.org/en/6.2.x/getting-started.html):
+
+    ```sh
+    pip install -U pytest
+    ```
+
+1. Use pytest to run your tests and output JUnit XML, for example:
+
+    ```sh
+    pytest testing/ --junitxml="result.xml"
+    ```
+
+1. Upload the JUnit.xml to Buildkite:
+
+    ```sh
+    curl \
+      -X POST \
+      --fail-with-body \
+      -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
+      -F "data=@junit.xml" \
+      -F "format=junit" \
+      -F "run_env[CI]=buildkite" \
+      -F "run_env[key]=$BUILDKITE_BUILD_ID" \
+      -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+      -F "run_env[job_id]=$BUILDKITE_JOB_ID" \
+      -F "run_env[branch]=$BUILDKITE_BRANCH" \
+      -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
+      -F "run_env[message]=$BUILDKITE_MESSAGE" \
+      -F "run_env[url]=$BUILDKITE_BUILD_URL" \
+      https://analytics-api.buildkite.com/v1/uploads
+    ```
+
+See [pytest](https://docs.pytest.org) for full documentation of its features and command line flags.

--- a/pages/test_analytics/python_collectors.md.erb
+++ b/pages/test_analytics/python_collectors.md.erb
@@ -1,8 +1,6 @@
 # Configuring Python with Test Analytics
 
-To use Test Analytics with your Python projects,
-you use [pytest](https://docs.pytest.org) to generate JUnit XML files,
-and then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) to Test Analytics.
+To use Test Analytics with your Python projects, generate JUnit XML files with [pytest](https://docs.pytest.org), and then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) to Test Analytics.
 
 {:notoc}
 

--- a/pages/test_analytics/python_collectors.md.erb
+++ b/pages/test_analytics/python_collectors.md.erb
@@ -38,4 +38,4 @@ and then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) 
       https://analytics-api.buildkite.com/v1/uploads
     ```
 
-See [pytest](https://docs.pytest.org) for full documentation of its features and command line flags.
+See [pytest](https://docs.pytest.org) for full documentation of its features and command-line flags.

--- a/vale/styles/vocab.txt
+++ b/vale/styles/vocab.txt
@@ -93,6 +93,7 @@ gif
 githooks
 globbing
 golang
+gotestsum
 Graviton
 gz
 heroku


### PR DESCRIPTION
<img width="1059" alt="Screen Shot 2022-06-02 at 9 18 38 pm" src="https://user-images.githubusercontent.com/7202667/171618069-1371c347-40e9-414e-a45d-a6e160885fc6.png">

Add Golang and Python collectors pages, as they can be configured with Test Analytics.

Here's the advice from @toolmantim 

> If we wanted to add Golang to the languages, here's the rough instructions: https://gist.github.com/toolmantim/4d65c4d3209500a0565cc999da88ea5f

> Python actually follows the same pattern, except it's built into pytest:
> `pytest testing/ --junitxml="result.xml"`
> That will run all your tests and output the JUnit XML file

I've created the two pages based on the above [instructions](https://gist.github.com/toolmantim/4d65c4d3209500a0565cc999da88ea5f). I'm unsure how polished these are as I don't have experience working with Golang and Python test frameworks.
