### PR TITLE
Fix typo in module name in ruby collector docs

### DIFF
--- a/pages/test_analytics/ruby_collectors.md.erb
+++ b/pages/test_analytics/ruby_collectors.md.erb
@@ -82,7 +82,7 @@ If you're already using minitest for your tests, add the `buildkite-test_collect
     ```rb
     require "buildkite/test_collector"
 
-    Buildkite::Collector.configure(hook: :minitest)
+    Buildkite::TestCollector.configure(hook: :minitest)
     ```
 
 4. Commit and push your changes:


### PR DESCRIPTION
Changed `Collector` to `TestCollector`