### PR TITLE
Fix typo in Slack channel name

### DIFF
--- a/pages/test_analytics/other_collectors.md.erb
+++ b/pages/test_analytics/other_collectors.md.erb
@@ -11,5 +11,5 @@ The following collectors are coming soon:
 
 ## Questions or feedback
 
-- Join the #test-collector [community Slack channel](https://chat.buildkite.community/)
+- Join the #test-analytics [community Slack channel](https://chat.buildkite.community/)
 - <a href="mailto:support+analytics@buildkite.com?subject=Test Analytics: New test framework request">Email support</a>


### PR DESCRIPTION
Fixes a typo in the Slack channel name - should be #test-analytics channel
