### PR TITLE
💬 Link to offical collector GitHub repo

### DIFF
--- a/pages/test_analytics/elixir_collectors.md.erb
+++ b/pages/test_analytics/elixir_collectors.md.erb
@@ -1,6 +1,7 @@
 # Elixir Collectors
 
-Test Analytics ships with a ExUnit test collector.
+Test Analytics ships with a ExUnit test collector :github: [`test_collector_elixir`](https://github.com/buildkite/test_collector_elixir).
+
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
 {:notoc}

--- a/pages/test_analytics/js_collectors.md.erb
+++ b/pages/test_analytics/js_collectors.md.erb
@@ -1,13 +1,14 @@
 # JavaScript Collectors
 
-Test Analytics ships with a Jest test collector.
+Test Analytics ships with JavaScript collectors :github: [`test-collector-javascript`](https://github.com/buildkite/test-collector-javascript).
+
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
 {:toc}
 
 ## Jest collector
 
-[Jest](https://jestjs.io/) is a JavaScript testing framework.
+Test Analytics ships with a [Jest](https://jestjs.io/) test collector.
 If you're already using Jest, then you can add `buildkite-collector/jest/reporter` to your list of reporters to collect your test results into your Test Analytics dashboard.
 
 Before you start, make sure Jest runs with access to [CI environment variables](/docs/test-analytics/ci-environments).

--- a/pages/test_analytics/ruby_collectors.md.erb
+++ b/pages/test_analytics/ruby_collectors.md.erb
@@ -1,6 +1,8 @@
 # Ruby Collectors
 
-Test Analytics ships with the Ruby collectors listed on this page. You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
+Test Analytics ships with Ruby collectors :github: [`test-collectors-ruby`](https://github.com/buildkite/test-collector-ruby).
+
+You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
 {:toc}
 

--- a/pages/test_analytics/rust_collectors.md.erb
+++ b/pages/test_analytics/rust_collectors.md.erb
@@ -1,6 +1,7 @@
 # Rust Collector
 
-Test Analytics ships with a Rust test collector.
+Test Analytics ships with a Rust collector :github: [`test-collector-rust`](https://github.com/buildkite/test-collector-rust).
+
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
 {:notoc}

--- a/pages/test_analytics/swift_collectors.md.erb
+++ b/pages/test_analytics/swift_collectors.md.erb
@@ -1,6 +1,7 @@
 # Swift Collectors
 
-Test Analytics ships with Swift collectors listed on this page, and [more coming soon](https://github.com/buildkite/test-collector-swift/labels/test%20framework).
+Test Analytics ships with Swift collectors :github: [`test-collector-swift`](https://github.com/buildkite/test-collector-swift), and [more coming soon](https://github.com/buildkite/test-collector-swift/labels/test%20framework).
+
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
 {:notoc}


### PR DESCRIPTION
Pushing up a suggestion to link Collectors to the respective GitHub repo.

I've chatted with different people who agree that linking Collectors on Docs to the respective GitHub repo is helpful. Customers can see the Collectors' source code if needed and there are additional information on the repo as well.

That being said, there's an argument to having a 'single source of truth' for documentation, which is helpful for docs findability and maintainability.

I'm trying out a small improvement here to simply add a text link, nothing fancy for now.

Open to your thoughts on this.
