### PR TITLE
Fix typo in Minitest doc

### DIFF
--- a/pages/test_analytics/ruby_collectors.md.erb
+++ b/pages/test_analytics/ruby_collectors.md.erb
@@ -95,4 +95,4 @@ If you're already using minitest for your tests, add the `buildkite-test_collect
 
 Once you're done, in your Test Analytics dashboard, you'll see analytics of test executions on all branches that include this code.
 
-If you don't see branch names, build numbers, or commit hashes in the Test Analytics UI, then see [CI Environments](/docs/test-analytics/ci-environments) to learn more about exporting your environment to the RSpec collector.
+If you don't see branch names, build numbers, or commit hashes in the Test Analytics UI, then see [CI Environments](/docs/test-analytics/ci-environments) to learn more about exporting your environment to the minitest collector.


### PR DESCRIPTION
https://buildkite.com/docs/test-analytics/ruby-collectors#minitest-collector

![CleanShot 2022-06-06 at 13 50 27@2x](https://user-images.githubusercontent.com/1000669/172096889-40d56a1f-c3d5-44a4-bf33-f1aa71fec242.png)
