### PR TITLE
👔 Should use support+analytics email

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -32,7 +32,8 @@
         </a>
       </li>
       <li class="footer__list-item">
-        <a class="footer__list-item-link" href="mailto:support@buildkite.com">
+        <% support_email = ("test-analytics".in? request.path) ? "support+analytics@buildkite.com" : "support@buildkite.com" %>
+        <a class="footer__list-item-link" href="mailto:<%= support_email %>">
           <img alt="Icon: paper dart" class="footer__list-item-icon" src="<%= image_url('icons/email.svg') %>" />
           Email support
         </a>


### PR DESCRIPTION
Missed this template logic. The support email address should be `support+analytics@buildkite.com` when we're on any on the Test Analytics pages.
