### PR TITLE
Exclude some Dockerfiles from Dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@ updates:
       interval: monthly
     open-pull-requests-limit: 3
   - package-ecosystem: docker
-    directory: "/"
+    directory: "/vale"
     schedule:
       interval: daily


### PR DESCRIPTION
Dependabot errors out on one of the root Dockerfiles (because `public.ecr.aws` doesn't support an API it requires, see
https://github.com/dependabot/dependabot-core/issues/4212). To avoid this, I've changed the dependabot configuration to only upgrade Vale.

This is a follow-up to https://github.com/buildkite/docs/pull/1538.