### PR TITLE
Update PD integration page with security info

### DIFF
--- a/pages/integrations/pagerduty.md.erb
+++ b/pages/integrations/pagerduty.md.erb
@@ -36,7 +36,9 @@ Copy the "Integration Key" from your Integrations list and  use it in [Sending C
 
 By default, after you've added an Integration API Key, Buildkite will send PagerDuty a Change Event every build regardless of whether the build passed or failed.
 
-Add the PagerDuty [Integration API Key](#generating-a-pagerduty-integration-api-key) to the [`notify` attribute](/docs/pipelines/notifications) of your build configuration:
+Add the PagerDuty [Integration API Key](#generating-a-pagerduty-integration-api-key) to the [`notify` attribute](/docs/pipelines/notifications) of your build configuration.
+
+Make sure that you're using a secure secrets management solution to handle the PagerDuty Integration key, and never commit it in plaintext to source control in a YAML file. See [Managing Pipeline Secrets](/docs/pipelines/secrets) for more information on safely handling your secretes within your infrastructure.
 
 ```yaml
 steps:
@@ -45,7 +47,7 @@ steps:
   - command: "deploy.sh"
 
 notify:
-  - pagerduty_change_event: "636d22Yourc0418Key3b49eee3e8"
+  - pagerduty_change_event: "${ENV_VAR_NAME}"
 ```
 {: codeblock-file="pipeline.yml"}
 
@@ -55,7 +57,7 @@ To send Change Events only when the build passes, add a [condition](/docs/pipeli
 
 ```yaml
 notify:
-  - pagerduty_change_event: "636d22Yourc0418Key3b49eee3e8"
+  - pagerduty_change_event: "${ENV_VAR_NAME}"
     if: "build.state == 'passed'"
 ```
 

--- a/pages/integrations/pagerduty.md.erb
+++ b/pages/integrations/pagerduty.md.erb
@@ -47,7 +47,7 @@ steps:
   - command: "deploy.sh"
 
 notify:
-  - pagerduty_change_event: "${ENV_VAR_NAME}"
+  - pagerduty_change_event: "${PAGER_DUTY_API_KEY}"
 ```
 {: codeblock-file="pipeline.yml"}
 
@@ -57,7 +57,7 @@ To send Change Events only when the build passes, add a [condition](/docs/pipeli
 
 ```yaml
 notify:
-  - pagerduty_change_event: "${ENV_VAR_NAME}"
+  - pagerduty_change_event: "${PAGER_DUTY_API_KEY}"
     if: "build.state == 'passed'"
 ```
 


### PR DESCRIPTION
- Removes mention of a PagerDuty Integration key provided as plaintext
- Adds recommended reading on handling secrets