### PR TITLE
Fix faulty Integrations link on the Docs homepage

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -159,7 +159,7 @@
       </div>
       <div class="HomepageCategory">
         <h3 class="HomepageCategory__heading">
-          <a href="/docs/apis">Integrations</a>
+          <a href="/docs/integrations">Integrations</a>
           <%= image_tag("icons/integration.svg", alt: "Icon: APIs") %>
         </h3>
         <ul>


### PR DESCRIPTION
Links to APIs now (looks like a typo). Needs to link to Integrations. Links now.