### PR TITLE
🚑 HOTFIX: Search pop up should not be clipped

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -86,38 +86,6 @@ label[for='navicon'] {
   }
 }
 
-.Docs__nav__search {
-  position: relative;
-
-  input {
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    background-color: #fff;
-    border-radius: .2em;
-    border: 1px solid #ccc;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
-    box-sizing: border-box;
-    color: #555;
-    display: block;
-    font-family: inherit;
-    font-size: 16px;
-    outline: none;
-    margin: 0 0 15px 0;
-    padding: 8px 10px;
-    transition: border-color 0.2s;
-    width: 100%;
-    &:focus { background-color: rgba(white, .1); border-color: #14CC80; }
-    &::-webkit-input-placeholder { color: rgba(#555, .35); }
-    &:-moz-placeholder { color: rgba(#555, .35); }
-    &::-moz-placeholder { color: rgba(#555, .35); }
-    &:-ms-input-placeholder { color: rgba(#555, .35); }
-
-    @media (max-width: ($screen-md - 1)) {
-
-    }
-  }
-}
-
 .Search-container {
   position: relative;
 

--- a/app/assets/stylesheets/public/_search.scss
+++ b/app/assets/stylesheets/public/_search.scss
@@ -1,0 +1,27 @@
+.Search {
+  line-height: 1;
+  position: relative;
+
+  &__input {
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    background-color: #fff;
+    border-radius: .2em;
+    border: 1px solid #ccc;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+    box-sizing: border-box;
+    color: #555;
+    display: block;
+    font-family: inherit;
+    font-size: 16px;
+    outline: none;
+    padding: 8px 10px;
+    transition: border-color 0.2s;
+    width: 100%;
+    &:focus { background-color: rgba(white, .1); border-color: #14CC80; }
+    &::-webkit-input-placeholder { color: rgba(#555, .35); }
+    &:-moz-placeholder { color: rgba(#555, .35); }
+    &::-moz-placeholder { color: rgba(#555, .35); }
+    &:-ms-input-placeholder { color: rgba(#555, .35); }
+  }
+}

--- a/app/assets/stylesheets/public/_site_header.scss
+++ b/app/assets/stylesheets/public/_site_header.scss
@@ -5,7 +5,7 @@ $SiteHeaderLogoHeight: 36px;
   box-sizing: border-box;
   padding-top: 15px;
   line-height: $SiteHeaderLogoHeight;
-  z-index: 5;
+  z-index: 20;
   
   @media (min-width: $screen-md) {
     border-bottom: #ddd 1px solid;

--- a/app/assets/stylesheets/public/_site_header.scss
+++ b/app/assets/stylesheets/public/_site_header.scss
@@ -22,6 +22,7 @@ $SiteHeaderLogoHeight: 36px;
 .SiteHeader__inner {
   align-items: center;
   display: flex;
+  gap: 30px;
 }
 
 .SiteHeader__logo {

--- a/app/assets/stylesheets/public/_site_header.scss
+++ b/app/assets/stylesheets/public/_site_header.scss
@@ -3,7 +3,6 @@ $SiteHeaderLogoHeight: 36px;
 .SiteHeader {
   background-color: #fff;
   box-sizing: border-box;
-  padding-right: 50px;
   padding-top: 15px;
   line-height: $SiteHeaderLogoHeight;
   z-index: 5;
@@ -20,9 +19,15 @@ $SiteHeaderLogoHeight: 36px;
 }
 
 .SiteHeader__inner {
-  align-items: center;
   display: flex;
-  gap: 30px;
+  flex-direction: column;
+  gap: 15px;
+
+  @media (min-width: $screen-sm) {
+    align-items: center;
+    flex-direction: row;
+    gap: 30px;
+  }
 }
 
 .SiteHeader__logo {
@@ -49,7 +54,7 @@ $SiteHeaderLogoHeight: 36px;
   font-size: 16px;
   margin-left: auto;
 
-  @media (min-width: $screen-sm) {
+  @media (min-width: $screen-md) {
     display: inline-flex;
     gap: 30px;
   }

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -4,13 +4,6 @@
 <label class="Button Button--default" for="navicon"><span>Display menu</span></label>
 
 <nav class="Docs__nav">
-  <div class="Docs__nav__search">
-    <div class="Search-container">
-      <input id="search" placeholder="Search" />
-      <kbd title="Press / to search">/</kbd>
-    </div>
-  </div>
-
   <div class="Docs__nav__sections">
     <div class="Docs__nav__section-container <%= "current expanded" if current_section == 'tutorials' %>" data-docs-path="tutorials">
       <p class="Docs__nav__section-heading">Tutorials</p>

--- a/app/views/layouts/_site_header.html.erb
+++ b/app/views/layouts/_site_header.html.erb
@@ -13,6 +13,12 @@
       <%= link_to "Buildkite Docs", home_page_path, class: "SiteHeader__docslink", title: "Return to Docs index page" %>
     </div>
     <p class="OffScreen SiteHeader__tagline">Lightning fast testing and delivery for all your software projects.</p>
+    <div class="Search">
+      <div class="Search-container">
+        <input id="search" class="Search__input" placeholder="Search" />
+        <kbd class="Search__kbd" title="Press / to search">/</kbd>
+      </div>
+    </div>
     <p class="OffScreen SiteHeader__skip-nav"><a href="#main">Skip to main content</a></p>
     <div class="SiteHeader__links">
       <%= link_to "https://buildkite.com/home", title: "Go to Buildkite homepage", class: "SiteHeader__docslink" do %>


### PR DESCRIPTION
Position absolute children within a `overflow-y: scroll;` element get clipped. The search pop up is wider than the scrolling sidebar and got clipped, making the search unusable.

To fix this, I've moved the search box into the header.
