### PR TITLE
Make TimeHelpers from ActiveSupport in RSpec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'capybara/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/support/time_helper.rb
+++ b/spec/support/time_helper.rb
@@ -1,0 +1,5 @@
+require "active_support/testing/time_helpers"
+
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
This Pull Request sets up RSpec to use https://edgeapi.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html in the tests.

