### PR TITLE
Structure Test Analytics JSON format reference

### DIFF
--- a/app/models/test_analytics_json.rb
+++ b/app/models/test_analytics_json.rb
@@ -1,0 +1,5 @@
+TEST_ANALYTICS_JSON = {
+  "history" => YAML.load_file('data/test_analytics_json_fields_history.yaml'),
+  "span" => YAML.load_file('data/test_analytics_json_fields_span.yaml'),
+  "test_result" => YAML.load_file('data/test_analytics_json_fields_test_result.yaml')
+}.freeze

--- a/data/test_analytics_json_fields.schema.yaml
+++ b/data/test_analytics_json_fields.schema.yaml
@@ -1,0 +1,33 @@
+---
+type: object
+properties:
+  fields:
+    type: array
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+        required:
+          type: boolean
+        type:
+          type: string
+        enumerated_values:
+          type: array
+          items:
+            type: string
+        desc:
+          type: string
+        examples:
+          type: array
+          items:
+            type: string
+      required:
+        - name
+        - required
+        - type
+        - enumerated_values
+        - desc
+        - examples
+required:
+  - fields

--- a/data/test_analytics_json_fields_history.yaml
+++ b/data/test_analytics_json_fields_history.yaml
@@ -1,0 +1,26 @@
+fields:
+- name: start_at
+  required: true
+  type: number
+  enumerated_values:
+  desc: |
+      A monotonically increasing number
+  examples:
+- name: end_at
+  required: false
+  type: number
+  desc: |
+      A monotonically increasing number
+  examples:
+- name: duration
+  required: true
+  type: number
+  desc: |
+      How long the test took to run
+  examples:
+- name: children
+  required: false
+  type: array of span objects
+  desc: |
+      Read [Span objects](/docs/test-analytics/importing-json#json-test-results-data-reference-span-objects)
+  examples:

--- a/data/test_analytics_json_fields_span.yaml
+++ b/data/test_analytics_json_fields_span.yaml
@@ -1,0 +1,30 @@
+fields:
+- name: section
+  required: true
+  type: string
+  enumerated_values:
+      - http
+      - sql
+      - sleep
+      - annotation
+  desc: |
+      A section category for this span
+  examples:
+- name: start_at
+  required: false
+  type: number
+  desc: |
+      A monotonically increasing number
+  examples:
+- name: end_at
+  required: false
+  type: number
+  desc: |
+      A monotonically increasing number
+  examples:
+- name: duration
+  required: true
+  type: number
+  desc: |
+      How long the span took to run
+  examples:

--- a/data/test_analytics_json_fields_test_result.yaml
+++ b/data/test_analytics_json_fields_test_result.yaml
@@ -64,6 +64,13 @@ fields:
        If applicable, a short summary of why the test failed
   examples:
       - Expected Boolean, got Object
+- name: failure_expanded
+  required: false
+  type: array of hashes
+  desc: |
+       A more detailed explanation of why the test failed
+  examples: 
+
 - name: history
   required: true
   type: history object

--- a/data/test_analytics_json_fields_test_result.yaml
+++ b/data/test_analytics_json_fields_test_result.yaml
@@ -4,7 +4,7 @@ fields:
   type: UUIDv4 string
   enumerated_values:
   desc: |
-      A unique identifier for this test result
+      A unique identifier for this test result. If a test execution with this UUID already exists in the Test Analytics database, this result is ignored.
   examples:
       - 1b70486f-ca5f-4e6d-beb8-6347b2e49278
 - name: scope

--- a/data/test_analytics_json_fields_test_result.yaml
+++ b/data/test_analytics_json_fields_test_result.yaml
@@ -1,0 +1,71 @@
+fields:
+- name: id
+  required: true
+  type: UUIDv4 string
+  enumerated_values:
+  desc: |
+      A unique identifier for this test result
+  examples:
+      - 1b70486f-ca5f-4e6d-beb8-6347b2e49278
+- name: scope
+  required: false
+  type: string
+  enumerated_values:
+  desc: |
+      A group or topic for the test
+  examples:
+      - Student.isEnrolled()
+- name: name
+  required: false
+  type: string
+  desc: |
+      A name or description for the test
+  examples:
+      - Manager.isEnrolled() returns_boolean
+- name: identifier
+  required: true
+  type: string
+  enumerated_values:
+  desc: |
+      A unique identifier for the test. If your test runner supports it, use the identifier needed to rerun this test
+  examples:
+      - Manager.isEnrolled#returns_boolean
+- name: location
+  required: false
+  type: string
+  enumerated_values:
+  desc: |
+      The file and line number where the test originates, separated by a colon (`:`)
+  examples:
+      - ./tests/Manager/isEnrolled.js:32
+- name: file_name
+  required: false
+  type: string
+  desc: |
+      The file where the test originates
+  examples:
+      - ./tests/Manager/isEnrolled.js
+- name: result
+  required: false
+  type: string
+  enumerated_values:
+      - passed
+      - failed
+      - skipped
+      - unknown
+  desc: |
+      The outcome of the test
+  examples:
+      - failed
+- name: failure_reason
+  required: false
+  type: string
+  desc: |
+       If applicable, a short summary of why the test failed
+  examples:
+      - Expected Boolean, got Object
+- name: history
+  required: true
+  type: history object
+  desc: |
+      Read [History objects](/docs/test-analytics/importing-json#json-test-results-data-reference-history-objects)

--- a/pages/test_analytics/importing_json.md.erb
+++ b/pages/test_analytics/importing_json.md.erb
@@ -183,6 +183,27 @@ end
   "file_name": "./spec/models/analytics/upload_spec.rb",
   "result": "failed",
   "failure_reason": "Failure/Error: expect(true).to eq false",
+  "failure_expanded": [
+  {
+      "expanded": [
+      "  expected: false",
+      "       got: true",
+      "",
+      "  (compared using ==)",
+      "",
+      "  Diff:",
+      "  @@ -1 +1 @@",
+      "  -false","  +true"
+      ],
+      "backtrace": [
+      "./spec/models/analytics/upload_spec.rb:25:in `block (3 levels) in \u003ctop (required)\u003e'","./spec/support/log.rb:17:in `run'",
+      "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
+      "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
+      "/Users/abc/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
+      "-e:1:in `\u003cmain\u003e'"
+      ]
+  }
+  ],
   "history": {
     /* history object */
   }

--- a/pages/test_analytics/importing_json.md.erb
+++ b/pages/test_analytics/importing_json.md.erb
@@ -128,33 +128,48 @@ Or in a simplified code view:
 
 A test result represents a single test run.
 
+<%
+def render_enumerated_values(values)
+  if values.nil? or values.length == 1
+    return ''
+  end
 
-<%#
-<!--
-Key;required;Type;Description;example
-id;true;UUIDv4 string;a unique identifier for this test result;1b70486f-ca5f-4e6d-beb8-6347b2e49278
-scope;;string;a group or topic for the test;Student.isEnrolled()
-name;;string;a name or description for the test;Manager.isEnrolled() returns_boolean
-identifier;true;string;a unique identifier for the test. If your test runner supports it, use the identifier needed to rerun this test;Manager.isEnrolled#returns_boolean
-location;;string;the file and line number where the test originates, separated by a colon (:);./tests/Manager/isEnrolled.js:32
-file_name;;string;the file where the test originates;./tests/Manager/isEnrolled.js
-result;;string "passed", "failed", "skipped", or "unknown";the outcome of the test;"failed"
-failure_reason;;string;if applicable, a short summary of why the test failed;Expected Boolean, got Object
-history;true;history object;See [History objects];
--->
+  if values.length == 1
+    return "(<code>#{values[0]}</code>)"
+  end
+
+  if values.length == 2
+    return "(<code>#{values[0]}</code> or <code>#{values[1]}</code>)"
+  end
+
+  return '(' + values[0..-2].map{|value| "<code>#{value}</code>"}.join(', ') + " or <code>#{values[-1]}</code>)"
+end
 %>
 
-| Key                             | Type                                                        | Description                                                                                                     | Example                                |
-|---------------------------------|-------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|----------------------------------------|
-| `id` (required)                 | UUIDv4 string                                               | a unique identifier for this test result                                                                        | `1b70486f-ca5f-4e6d-beb8-6347b2e49278` |
-| `scope`                         | string                                                      | a group or topic for the test                                                                                   | `Student.isEnrolled()`                 |
-| `name`                          | string                                                      | a name or description for the test                                                                              | `Manager.isEnrolled() returns_boolean` |
-| `identifier` (required)         | string                                                      | a unique identifier for the test. If your test runner supports it, use the identifier needed to rerun this test | `Manager.isEnrolled#returns_boolean`   |
-| `location`                      | string                                                      | the file and line number where the test originates, separated by a colon (`:`)                                  | `./tests/Manager/isEnrolled.js:32`     |
-| `file_name`                     | string                                                      | the file where the test originates                                                                              | `./tests/Manager/isEnrolled.js`        |
-| `result`                        | strings `"passed"`, `"failed"`, `"skipped"`, or `"unknown"` | the outcome of the test                                                                                         | `failed`                               |
-| `failure_reason`                | string                                                      | if applicable, a short summary of why the test failed                                                           | `Expected Boolean, got Object`         |
-| `history` (required)            | history object                                              | Read [History objects](#json-test-results-data-reference-history-objects)                                       |                                        |
+<table class="responsive-table">
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Type</th>
+      <th>Description</th>
+      <th>Examples</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% TEST_ANALYTICS_JSON['test_result']['fields'].each do |field| -%>
+      <tr>
+        <td><code><%= field['name'] %></code> <%= '(required)' if field['required'] %></td>
+        <td><%= field['type'] %> <%= render_enumerated_values(field['enumerated_values']) %></td>
+        <td>
+          <%= render_markdown(text: field['desc']) %>
+        </td>
+        <td>
+          <%= field['examples'].map{|example| "<code>#{render_markdown(text: example)}</code>"}.join(', ') unless field['examples'].nil? %>
+        </td>
+      </tr>
+    <% end -%>
+  </tbody>
+</table>
 
 **Example:**
 
@@ -178,22 +193,26 @@ history;true;history object;See [History objects];
 
 A history object represents the overall duration of the test run and contains detailed span data, more finely recording the test run.
 
-<%#
-<!--
-Key;Required;Type;Description;Example
-start_at;;number;TK
-end_at;;number;TK
-duration;true;number;how long the test took to run;7.07654
-children;;array of span objects;See [Span objects](#tk)
--->
-%>
-
-| Key                   | Type                  | Description                                                         |
-|-----------------------|-----------------------|---------------------------------------------------------------------|
-| `start_at`            | number                | A monotonically increasing number                                   |
-| `end_at`              | number                | A monotonically increasing number                                   |
-| `duration` (required) | number                | How long the test took to run                                       |
-| `children`            | array of span objects | Read [Span objects](#json-test-results-data-reference-span-objects) |
+<table class="responsive-table">
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% TEST_ANALYTICS_JSON['history']['fields'].each do |field| -%>
+      <tr>
+        <td><code><%= field['name'] %></code> <%= '(required)' if field['required'] %></td>
+        <td><%= field['type'] %> <%= render_enumerated_values(field['enumerated_values']) %></td>
+        <td>
+          <%= render_markdown(text: field['desc']) %>
+        </td>
+      </tr>
+    <% end -%>
+  </tbody>
+</table>
 
 **Example:**
 
@@ -213,22 +232,26 @@ children;;array of span objects;See [Span objects](#tk)
 Span objects represent the finest duration resolution of a test run.
 It represents, for example, the duration of an individual database query within a test.
 
-<%#
-<!--
-Key;required;Type;Description;example
-section;true;string "http", "sql", "sleep", or "annotation"
-start_at;;number
-end_at;;number
-duration;;number;how long the test took to run
--->
-%>
-
-| Key                | Type                                                   | Description                       |
-|--------------------|--------------------------------------------------------|-----------------------------------|
-| `section` (required) | string `"http"`, `"sql"`, `"sleep"`, or `"annotation"` | A section category for this span  |
-| `start_at`           | number                                                 | A monotonically increasing number |
-| `end_at`             | number                                                 | A monotonically increasing number |
-| `duration`           | number                                                 | How long the span took to run     |
+<table class="responsive-table">
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% TEST_ANALYTICS_JSON['span']['fields'].each do |field| -%>
+      <tr>
+        <td><code><%= field['name'] %></code> <%= '(required)' if field['required'] %></td>
+        <td><%= field['type'] %> <%= render_enumerated_values(field['enumerated_values']) %></td>
+        <td>
+          <%= render_markdown(text: field['desc']) %>
+        </td>
+      </tr>
+    <% end -%>
+  </tbody>
+</table>
 
 **Example:**
 


### PR DESCRIPTION
I'm not sure this is genuinely good, but it does eliminate some Markdown tables (🤮) and CSV-filled comments with something a little less awful. There are more opportunities to refactor here, but this is my attempt at starting that process.