### PR TITLE
Change Agent example configurations to use %spawn

### DIFF
--- a/data/agent_attributes.yaml
+++ b/data/agent_attributes.yaml
@@ -150,14 +150,13 @@ attributes:
         The DogStatsD instance to send metrics to using UDP.
 - name: name
   env_var: BUILDKITE_AGENT_NAME
-  default_value: "%hostname-%n"
+  default_value: "%hostname-%spawn"
   required: false
   desc: |
       The name of the agent. Supports template variables.
 
-      - `%hostname` (the agent machine’s hostname)
+      - `%hostname` (the agent machine's hostname)
       - `%spawn` (a unique number for each agent started using `--spawn`; added in [v3.27.0](https://github.com/buildkite/agent/releases/tag/v3.27.0)).
-      - `%n` (a unique number for the agent).
       - `%pid` (the agent process id).
 
       Note that if you're using `--spawn` to run multiple agents in a single process, we recommend using `%spawn` in your agent name, or to ensure that each agent running on a host with the same `build-path` has a unique name.

--- a/pages/agent/v2/configuration.md.erb
+++ b/pages/agent/v2/configuration.md.erb
@@ -18,7 +18,7 @@ The agent token from your organization’s Agents page<br>
 _Environment variable:_ `BUILDKITE_AGENT_TOKEN`
 
 `name`<br>The name of the agent<br>
-_Default:_ `"%hostname-%n"`<br>
+_Default:_ `"%hostname-%spawn"`<br>
 _Environment variable:_ `BUILDKITE_AGENT_NAME`
 
 `priority`<br>
@@ -105,7 +105,7 @@ _Environment variable:_ `BUILDKITE_TIMESTAMP_LINES`
 
 ```sh
 token="24db61df8338027652b24aadf82dd483b016eef98fcd332815"
-name="my-app-%n"
+name="my-app-%spawn"
 meta-data="ci=true,docker=true"
 git-clean-flags="-fdqx"
 debug=true

--- a/pages/agent/v2/configuration.md.erb
+++ b/pages/agent/v2/configuration.md.erb
@@ -105,7 +105,7 @@ _Environment variable:_ `BUILDKITE_TIMESTAMP_LINES`
 
 ```sh
 token="24db61df8338027652b24aadf82dd483b016eef98fcd332815"
-name="my-app-%spawn"
+name="my-app-%n"
 meta-data="ci=true,docker=true"
 git-clean-flags="-fdqx"
 debug=true

--- a/pages/agent/v2/configuration.md.erb
+++ b/pages/agent/v2/configuration.md.erb
@@ -105,7 +105,7 @@ _Environment variable:_ `BUILDKITE_TIMESTAMP_LINES`
 
 ```sh
 token="24db61df8338027652b24aadf82dd483b016eef98fcd332815"
-name="my-app-%n"
+name="my-app-%spawn"
 meta-data="ci=true,docker=true"
 git-clean-flags="-fdqx"
 debug=true

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -8,7 +8,7 @@ Every agent installer comes with a configuration file. You can also customize ma
 
 ```sh
 token="24db61df8338027652b24aadf82dd483b016eef98fcd332815"
-name="my-app-%n"
+name="my-app-%spawn"
 tags="ci=true,docker=true"
 git-clean-flags="-ffdqx"
 debug=true

--- a/pages/plugins/using.md.erb
+++ b/pages/plugins/using.md.erb
@@ -83,7 +83,7 @@ steps:
   - wait
 
   # Use the app image built above to run concurrent tests
-  - label: "\:docker\: Test %n"
+  - label: "\:docker\: Test %spawn"
     command: test.sh
     parallelism: 25
     plugins:

--- a/pages/tutorials/parallel_builds.md.erb
+++ b/pages/tutorials/parallel_builds.md.erb
@@ -51,8 +51,8 @@ steps:
 {: codeblock-file="pipeline.yml"}
 
 You can choose from the following parallel job index label helpers:
-* `%n` to display job count starting at `0`.
-* `%N` to display job count starting at `1`.
+
+* `%spawn` to display job count starting at `0`.
 * `%t` to display the total number of parallel jobs in the step.
 
 Now that the pipeline is configured, create a new build:

--- a/pages/tutorials/parallel_builds.md.erb
+++ b/pages/tutorials/parallel_builds.md.erb
@@ -40,12 +40,12 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-Update the name of the step to include `%n`, like the example below. This will include a number at runtime so that you can differentiate between the parallel build jobs.
+Update the name of the step to include `%spawn`, like the example below. This will include a number at runtime so that you can differentiate between the parallel build jobs.
 
 ```yaml
 steps:
   - command: "tests.sh"
-    label: "Test %n"
+    label: "Test %spawn"
     parallelism: 5
 ```
 {: codeblock-file="pipeline.yml"}
@@ -58,7 +58,7 @@ You can choose from the following parallel job index label helpers:
 Now that the pipeline is configured, create a new build:
 
 <%= image 'build.png', size: '405x204', alt: 'The build' %>
-If you inspect the first job’s environment variables you’ll find:
+If you inspect the first job's environment variables you'll find:
 
 ```
 BUILDKITE_PARALLEL_JOB=0


### PR DESCRIPTION
The `%spawn` is the recommended way to configure agent name.

We stopped using [`%n` in the default agent config 1.5 years ago](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/794) and plan to phase it out.

If your agents have unique names already (with a unique hostname) then using the `-%n` is also redundant.