### PR TITLE
Change 'team names' to 'team slugs'

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -143,7 +143,7 @@ Example: `"cdanvers@kree-net.com"`
 
 <h3 class="h3-caps">BUILDKITE_BUILD_CREATOR_TEAMS</h3>
 
-A colon separated list of **[unverified](#unverified)** non-private team names that the build creator belongs to. The value cannot be modified.
+A colon separated list of **[unverified](#unverified)** non-private team slugs that the build creator belongs to. The value cannot be modified.
 
 Example: `"everyone:platform"`
 
@@ -559,7 +559,7 @@ Example: `"4735ba57-80d0-46e2-8fa0-b28223a86586"`
 
 <h3 class="h3-caps">BUILDKITE_UNBLOCKER_TEAMS</h3>
 
-A colon separated list of non-private team names that the user who unblocked the build belongs to. The value cannot be modified.
+A colon separated list of non-private team slugs that the user who unblocked the build belongs to. The value cannot be modified.
 
 Example: `"everyone:platform"`
 


### PR DESCRIPTION
The docs aren't quite accurate in this part. The value that is present in the environment variables is the slugified version of the team name.

It is referred to as the slug in the APIs so changing that here as well.
