### PR TITLE
Add emojicom feedback widget to footer

### DIFF
--- a/app/assets/stylesheets/public/_footer.scss
+++ b/app/assets/stylesheets/public/_footer.scss
@@ -55,4 +55,8 @@
     margin-top: 3px;
     width: 16px;
   }
+
+  .emoji-feedback {
+    grid-column: 1 / -1;
+  }
 }

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -40,4 +40,5 @@
       </li>
     </ul>
   </section>
+  <div class="emoji-feedback" id="emojicom-widget-inline"></div>
 </footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,6 +63,7 @@
       </div>
 
     </main>
+
     <%= javascript_tag nonce: true do %>
       /* This api key is intentionally public */
       docsearch({
@@ -72,5 +73,11 @@
         inputSelector: '#search'
       });
     <% end %>
+
+    <%= javascript_tag nonce: true do %>
+      window.emojicom_widget = { campaign: '8N28RGdZ9DrL5WuI60WS' };
+    <% end %>
+    <%= javascript_include_tag "https://cdn.emojicom.io/embed/widget.js", nonce: true, async: true %>
+
   </body>
 </html>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -18,6 +18,7 @@
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
+  policy.child_src   "https://cdn.emojicom.io/"
   policy.font_src    :self, 'https://www2.buildkiteassets.com/'
   policy.img_src     :self, 'https://buildkiteassets.com/', 'https://buildkite.com/', ENV.fetch('BADGE_DOMAIN', 'https://badge.buildkite.com')
   policy.object_src  :none
@@ -25,7 +26,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src   :self, :unsafe_inline
 
   # allow AJAX queries against our search vendor
-  policy.connect_src "https://#{ENV['ALGOLIA_APP_ID']}-dsn.algolia.net", "https://#{ENV['ALGOLIA_APP_ID']}-1.algolianet.com", "https://#{ENV['ALGOLIA_APP_ID']}-2.algolianet.com", "https://#{ENV['ALGOLIA_APP_ID']}-3.algolianet.com", "https://www.google-analytics.com/"
+  policy.connect_src "https://#{ENV['ALGOLIA_APP_ID']}-dsn.algolia.net", "https://#{ENV['ALGOLIA_APP_ID']}-1.algolianet.com", "https://#{ENV['ALGOLIA_APP_ID']}-2.algolianet.com", "https://#{ENV['ALGOLIA_APP_ID']}-3.algolianet.com", "https://www.google-analytics.com/", " https://emojicom.io/"
 
   # Specify URI for violation reports
   policy.report_uri "/_csp-violation-reports"


### PR DESCRIPTION
This resolves DOC-45:
https://linear.app/buildkite/issue/DOC-45/how-helpful-was-this-article

You can view it live on the footer of any page:
https://bk-docs-pr-1593.onrender.com/docs/tutorials/getting-started


<img width="807" alt="image" src="https://user-images.githubusercontent.com/3682/173827003-b48c99bf-b6ca-4490-a451-8e4f71fdf229.png">

<img width="801" alt="image" src="https://user-images.githubusercontent.com/3682/173827172-7b19de7e-206a-4918-965f-2208c06fc185.png">

<img width="186" alt="image" src="https://user-images.githubusercontent.com/3682/173826922-4efefcb8-e763-4ffb-9856-a7fa381c9153.png">


We can also choose particular emoji (up to 5) or do our own custom images. @olyism, in particular, I'd love your thoughts here. Emoji is very Buildkite, but perhaps custom icons might be cool?

Recommended image dimensions are 40px × 40px (max). To support high resolution displays upload an 80px × 80px (max). Maximum image size is 20 KB.


I also feel the padding is too large here and I'm tempted to re-write the padding structure of the footer to solve that (since we can't control things inside the widget.

Feedback very welcome!

I'll leave this as draft while we work out what we want to do about whitespace and the images, but we can also launch before we have the image decision and put those in place when ready.