### PR TITLE
Make env var specific in our Ruby collector setup instructions

### DIFF
--- a/pages/test_analytics/ruby_collectors.md.erb
+++ b/pages/test_analytics/ruby_collectors.md.erb
@@ -33,7 +33,7 @@ Before you start, make sure RSpec runs with access to [CI environment variables]
     bundle
     ```
 
-3. Add the Test Analytics code to your application in `spec/spec_helper.rb`, and set the environment variable [securely](/docs/pipelines/secrets) on your agent or agents.
+3. Add the Test Analytics code to your application in `spec/spec_helper.rb`, and set the BUILDKITE_ANALYTICS_TOKEN [securely](/docs/pipelines/secrets) on your agent or agents.
 
     ```rb
     require "buildkite/test_collector"

--- a/pages/test_analytics/ruby_collectors.md.erb
+++ b/pages/test_analytics/ruby_collectors.md.erb
@@ -79,7 +79,7 @@ If you're already using minitest for your tests, add the `buildkite-test_collect
     bundle
     ```
 
-3. Add the Test Analytics code to your application in `test/test_helper.rb`, and set the environment variable [securely](/docs/pipelines/secrets) on your agent or agents.
+3. Add the Test Analytics code to your application in `test/test_helper.rb`, and set the BUILDKITE_ANALYTICS_TOKEN [securely](/docs/pipelines/secrets) on your agent or agents.
 
     ```rb
     require "buildkite/test_collector"


### PR DESCRIPTION
This PR addresses feedback from a customer re: updates we previously made that removed the specific reference to which env var to set in our Ruby setup instructions. Our in-app instructions are specific on this point; let's port that info over here as well 🎉