### PR TITLE
Generalize build key description re: parallelized builds

### DIFF
--- a/pages/test_analytics/test_suites.md.erb
+++ b/pages/test_analytics/test_suites.md.erb
@@ -12,7 +12,7 @@ To delete a suite, or regenerate its API token, go to suite settings.
 
 ## Parallelized builds
 
-Test Analytics works even when your test runs are split across different agents by de-duplicating against the Test Analytics API token and unique build identifier.
+Test Analytics works even when your test runs are split across different agents by de-duplicating against the Test Analytics API token and unique build identifier. The unique build identifier is a string made up of the specifics of each build, and is constructed differently by different CI providers.
 
 ## Compare across branches
 

--- a/pages/test_analytics/test_suites.md.erb
+++ b/pages/test_analytics/test_suites.md.erb
@@ -12,7 +12,9 @@ To delete a suite, or regenerate its API token, go to suite settings.
 
 ## Parallelized builds
 
-Test Analytics works even when your test runs are split across different agents by de-duplicating against the Test Analytics API token and unique build identifier. The unique build identifier is a string made up of the specifics of each build, and is constructed differently by different CI providers.
+Test Analytics works even when your test runs are split across different agents by de-duplicating against the Test Analytics API token and unique build identifier.
+
+The information that serves as a unique build identifier differs between CI environments. For details, see `run_env[key]` environment variables on our [CI environments page](/docs/test-analytics/ci-environments).
 
 ## Compare across branches
 

--- a/pages/test_analytics/test_suites.md.erb
+++ b/pages/test_analytics/test_suites.md.erb
@@ -12,7 +12,7 @@ To delete a suite, or regenerate its API token, go to suite settings.
 
 ## Parallelized builds
 
-Test Analytics works even when your test runs are split across different agents by de-duplicating against the Test Analytics API token and Build ID.
+Test Analytics works even when your test runs are split across different agents by de-duplicating against the Test Analytics API token and unique build identifier.
 
 ## Compare across branches
 


### PR DESCRIPTION
This PR generalizes our language around unique build key because the exact env var will be different depending on CI (Build ID was a little Buildkite-specific, and perhaps hard to match up on the CI page).

For example:

- For Buildkite, it is BUILDKITE_BUILD_ID
- For Circle, it is CIRCLE_WORKFLOW_ID-$CIRCLE_BUILD_NUM
- For GH Actions, it is GITHUB_ACTION-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT
- For generic CI, it is BUILDKITE_ANALYTICS_KEY

Happy for wordsmith humans to suggest better words in place of the ones I chose, should inspiration strike ⚡💡. Like, would `unique build key` be better than `unique build identifier`? 🤷🏻‍♂️