### PR TITLE
Agent name %random

### DIFF
--- a/data/agent_attributes.yaml
+++ b/data/agent_attributes.yaml
@@ -157,6 +157,7 @@ attributes:
 
       - `%hostname` (the agent machine's hostname)
       - `%spawn` (a unique number for each agent started using `--spawn`; added in [v3.27.0](https://github.com/buildkite/agent/releases/tag/v3.27.0)).
+      - `%random` (some random alphanumeric characters).
       - `%pid` (the agent process id).
 
       Note that if you're using `--spawn` to run multiple agents in a single process, we recommend using `%spawn` in your agent name, or to ensure that each agent running on a host with the same `build-path` has a unique name.

--- a/pages/agent/v2/configuration.md.erb
+++ b/pages/agent/v2/configuration.md.erb
@@ -105,7 +105,7 @@ _Environment variable:_ `BUILDKITE_TIMESTAMP_LINES`
 
 ```sh
 token="24db61df8338027652b24aadf82dd483b016eef98fcd332815"
-name="my-app-%spawn"
+name="my-app-%random"
 meta-data="ci=true,docker=true"
 git-clean-flags="-fdqx"
 debug=true


### PR DESCRIPTION
Add documentation for the new `%random` parameter available in agent names.

For the moment this is 6 alphanumeric characters, but that's not guaranteed. It will remain around there. I feel like the other items are vague enough that these words are sufficient.

An example would be: `agent-%random` becomes `agent-RXo43u`.

I've also updated the agent v2 example because it never supported `%spawn`, but it does support `%random` because the latter is done server-side.

Fixes DOC-397.