### PR TITLE
💄Improve table of contents styling

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -91,21 +91,6 @@ $color-green: rgb(3, 165, 98);
   margin: .25em 0 0 0;
 }
 
-.Docs__toc {
-  line-height: 1.3;
-
-  p { margin-bottom: .5em; }
-  .Docs__toc__list {
-    margin-top: .5em;
-
-    li {
-      color: $color-brand-green;
-      list-style-type: square;
-      margin-left: 1.2em;
-    }
-  }
-}
-
 @media (min-width: $screen-lg) { //TOC as side column on larger screens
   .Docs__article {
     display: grid;
@@ -117,28 +102,6 @@ $color-green: rgb(3, 165, 98);
 
     &--is-landing-page {
       display: block;
-    }
-  }
-
-  .Docs__toc {
-    font-size: 16px;
-    height: 95%;
-    position: absolute;
-    right: 0;
-    top: 0;
-
-    .Docs__toc__sticky {
-      background: #fefefe;
-      box-shadow: 2px 2px 5px 3px rgba(0, 0, 0, 0.3%);
-      padding: 1px 5px 8px 15px;
-      position: sticky;
-      top: $header-height + 30px;
-      width: $sidebar-width;
-    }
-
-    a {
-      color: #666;
-      text-decoration: none;
     }
   }
 }

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -128,8 +128,19 @@ $color-green: rgb(3, 165, 98);
 }
 
 .Docs__attribute__table {
-  colgroup col:nth-child(1) {
-    width: 5rem;
+  table-layout: fixed;
+  width: 100%;
+
+  th {
+    word-wrap: break-word;
+
+    code {
+      white-space: normal;
+    }
+  }
+
+  td {
+    word-wrap: break-word;
   }
 
   tr.importance th {
@@ -192,10 +203,6 @@ $color-green: rgb(3, 165, 98);
 
   .Docs__attribute__env-var {
     font-size: 0.8em;
-
-    code {
-      white-space: break-spaces;
-    }
   }
 
   .Docs__attribute__default {

--- a/app/assets/stylesheets/public/_nav.scss
+++ b/app/assets/stylesheets/public/_nav.scss
@@ -127,6 +127,7 @@
 
     &--level2 {
       @media (min-width: $screen-md) {
+        background-color: #fff;
         border-right: #ddd 1px solid;
         height: calc(100vh - #{$header-height});
         left: 0;
@@ -172,6 +173,7 @@
     font-size: 14px;
     gap: 5px;
     line-height: 24px;
+    margin: 0;
     padding: 5px 25px;
     text-decoration: none;
     transition: background-color $transition-speed, color $transition-speed;

--- a/app/assets/stylesheets/public/_responsive-table.scss
+++ b/app/assets/stylesheets/public/_responsive-table.scss
@@ -4,7 +4,9 @@
   margin-top: 1rem;
 
   @media (min-width: 960px) {
-    display: initial;
+    display: table;
+    table-layout: fixed;
+    width: 100%;
   }
 
   thead {
@@ -53,6 +55,7 @@
 
   th {
     padding: 0;
+    word-wrap: break-word;
 
     @media (min-width: 960px) {
       padding: .5rem;
@@ -61,6 +64,7 @@
 
   td {
     padding: 0 0 .5rem;
+    word-wrap: break-word;
 
     @media (min-width: 960px) {
       padding: .5rem;
@@ -85,6 +89,10 @@
     @media (min-width: 960px) {
       display: initial;
     }
+  }
+
+  code {
+    white-space: normal !important; // override nested .TextContent styling
   }
 
   .responsive-table__faux-th {

--- a/app/assets/stylesheets/public/_search.scss
+++ b/app/assets/stylesheets/public/_search.scss
@@ -15,6 +15,7 @@
     font-family: inherit;
     font-size: 16px;
     outline: none;
+    margin: 0;
     padding: 8px 10px;
     transition: border-color 0.2s;
     width: 100%;

--- a/app/assets/stylesheets/public/_toc.scss
+++ b/app/assets/stylesheets/public/_toc.scss
@@ -1,12 +1,16 @@
-@media (min-width: $screen-lg) {
-  .Docs__toc {
+.Toc {
+  line-height: 1.3;
+
+  @media (min-width: $screen-lg) {
     font-size: 16px;
     height: 95%;
     position: absolute;
     right: 0;
     top: 0;
+  }
 
-    .Docs__toc__sticky {
+  &__sticky {
+    @media (min-width: $screen-lg) {
       background: #fefefe;
       box-shadow: 2px 2px 5px 3px rgba(0, 0, 0, 0.3%);
       padding: 1px 5px 8px 15px;
@@ -14,25 +18,26 @@
       top: $header-height + 30px;
       width: $sidebar-width;
     }
+  }
 
-    a {
+  .Toc__title {
+    margin-bottom: .5em;
+  }
+
+  &__list {
+    margin-top: .5em;
+  }
+
+  &__list-item {
+    color: $color-brand-green;
+    list-style-type: square;
+    margin-left: 1.2em;
+  }
+
+  &__link {
+    @media (min-width: $screen-lg) {
       color: #666;
       text-decoration: none;
-    }
-  }
-}
-
-.Docs__toc {
-  line-height: 1.3;
-
-  p { margin-bottom: .5em; }
-  .Docs__toc__list {
-    margin-top: .5em;
-
-    li {
-      color: $color-brand-green;
-      list-style-type: square;
-      margin-left: 1.2em;
     }
   }
 }

--- a/app/assets/stylesheets/public/_toc.scss
+++ b/app/assets/stylesheets/public/_toc.scss
@@ -1,42 +1,38 @@
 .Toc {
-  line-height: 1.3;
+  box-sizing: border-box;
 
   @media (min-width: $screen-lg) {
-    font-size: 16px;
-    height: 95%;
-    position: absolute;
+    font-family: $font-family;
+    font-size: 14px;
+    height: calc(100vh - #{$header-height});
+    line-height: 1.5;
+    padding: 30px;
+    position: fixed;
     right: 0;
-    top: 0;
-  }
-
-  &__sticky {
-    @media (min-width: $screen-lg) {
-      background: #fefefe;
-      box-shadow: 2px 2px 5px 3px rgba(0, 0, 0, 0.3%);
-      padding: 1px 5px 8px 15px;
-      position: sticky;
-      top: $header-height + 30px;
-      width: $sidebar-width;
-    }
+    top: $header-height;
+    width: $sidebar-width;
   }
 
   .Toc__title {
-    margin-bottom: .5em;
+    margin-bottom: 10px;
   }
 
   &__list {
-    margin-top: .5em;
+    margin-top: 10px;
   }
 
   &__list-item {
     color: $color-brand-green;
     list-style-type: square;
-    margin-left: 1.2em;
+    
+    @media (min-width: $screen-lg) {
+      margin: 12px 0 12px 15px !important; // override nested .TextContent list styles
+    }
   }
 
   &__link {
     @media (min-width: $screen-lg) {
-      color: #666;
+      color: #4f4f4f !important; // override nested .TextContent list styles
       text-decoration: none;
     }
   }

--- a/app/assets/stylesheets/public/_toc.scss
+++ b/app/assets/stylesheets/public/_toc.scss
@@ -1,0 +1,38 @@
+@media (min-width: $screen-lg) {
+  .Docs__toc {
+    font-size: 16px;
+    height: 95%;
+    position: absolute;
+    right: 0;
+    top: 0;
+
+    .Docs__toc__sticky {
+      background: #fefefe;
+      box-shadow: 2px 2px 5px 3px rgba(0, 0, 0, 0.3%);
+      padding: 1px 5px 8px 15px;
+      position: sticky;
+      top: $header-height + 30px;
+      width: $sidebar-width;
+    }
+
+    a {
+      color: #666;
+      text-decoration: none;
+    }
+  }
+}
+
+.Docs__toc {
+  line-height: 1.3;
+
+  p { margin-bottom: .5em; }
+  .Docs__toc__list {
+    margin-top: .5em;
+
+    li {
+      color: $color-brand-green;
+      list-style-type: square;
+      margin-left: 1.2em;
+    }
+  }
+}

--- a/app/assets/stylesheets/public/_toc.scss
+++ b/app/assets/stylesheets/public/_toc.scss
@@ -6,6 +6,8 @@
     font-size: 14px;
     height: calc(100vh - #{$header-height});
     line-height: 1.5;
+    overscroll-behavior: contain;
+    overflow-y: auto;
     padding: 30px;
     position: fixed;
     right: 0;

--- a/app/assets/stylesheets/public/_toc.scss
+++ b/app/assets/stylesheets/public/_toc.scss
@@ -2,6 +2,8 @@
   box-sizing: border-box;
 
   @media (min-width: $screen-lg) {
+    background-color: #fff;
+    border-left: #ddd 1px solid;
     font-family: $font-family;
     font-size: 14px;
     height: calc(100vh - #{$header-height});

--- a/app/assets/stylesheets/public/utils/_button.scss
+++ b/app/assets/stylesheets/public/utils/_button.scss
@@ -8,8 +8,7 @@
   font-weight: 500;
   gap: 10px;
   line-height: 1.4;
-  margin-bottom: 10px;
-  margin-right: 5px;
+  margin: 0 5px 10px 0;
   padding: 11px 15px;
   text-decoration: none !important; // button labels should never have underlines
   

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -181,11 +181,13 @@ class Page::Renderer
     doc.css('table.responsive-table').each do |table|
       thead_ths = table.css('thead th')
 
-      table.search('./tbody/tr').each do |tr|
-        tr.search('./td').each_with_index do |td, i|
-          faux_th = "<th aria-hidden class=\"responsive-table__faux-th\">#{thead_ths[i].children}</th>"
-          
-          td.add_previous_sibling(faux_th)
+      unless thead_ths.empty?
+        table.search('./tbody/tr').each do |tr|
+          tr.search('./td').each_with_index do |td, i|
+            faux_th = "<th aria-hidden class=\"responsive-table__faux-th\">#{thead_ths[i].children}</th>"
+            
+            td.add_previous_sibling(faux_th)
+          end
         end
       end
     end

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -106,16 +106,18 @@ class Page::Renderer
         node.replace('')
       else
         node.replace(<<~HTML.strip)
-          <div class="Docs__toc">
-            <div class="Docs__toc__sticky">
-              <p><strong>On this page:</strong></p>
-              <ul class="Docs__toc__list">
-                #{headings.map {|heading|
-                  %{<li><a href="##{heading['id']}">#{heading.text.strip}</a></li>}
-                }.join("")}
-              </ul>
-            </div>
-          </div>
+          <nav class="Toc">
+            <p><strong>On this page:</strong></p>
+            <ul class="Toc__list">
+              #{headings.map {|heading|
+                %{
+                  <li class="Toc__list-item">
+                    <a class="Toc__link" href="##{heading['id']}">#{heading.text.strip}</a>
+                  </li>
+                }
+              }.join("")}
+            </ul>
+          </nav>
         HTML
       end
     end

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -105,17 +105,17 @@ class Page::Renderer
       if headings.empty? or node.text == notoc
         node.replace('')
       else
+        html_list_items = headings.map {|heading|
+          <<~HTML.strip
+            <li class="Toc__list-item"><a class="Toc__link" href="##{heading['id']}">#{heading.text.strip}</a></li>
+          HTML
+        }.join("").strip
+        
         node.replace(<<~HTML.strip)
           <nav class="Toc">
             <p><strong>On this page:</strong></p>
             <ul class="Toc__list">
-              #{headings.map {|heading|
-                %{
-                  <li class="Toc__list-item">
-                    <a class="Toc__link" href="##{heading['id']}">#{heading.text.strip}</a>
-                  </li>
-                }
-              }.join("")}
+              #{html_list_items}
             </ul>
           </nav>
         HTML

--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -179,6 +179,7 @@ Environment Variable | Required | Default Value | Description
 `BUILDKITE_S3_ACL` | No | `public-read` | The S3 Object ACL to apply to uploads, one of `private`, `public-read`, `public-read-write`, `authenticated-read`, `bucket-owner-read`, `bucket-owner-full-control`.
 `BUILDKITE_S3_SSE_ENABLED` | No | `false` | If `true`, bucket uploads request AES256 server side encryption.
 `BUILDKITE_S3_ACCESS_URL` | No | `https://$bucket.s3.amazonaws.com` | If set, overrides the base URL used for the artifact's location stored with the Buildkite API.
+{: class="responsive-table"}
 
 You can set these environment variables from a variety of places. Exporting them
 from an [environment hook](/docs/agent/v3/hooks#job-lifecycle-hooks) defined in

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -68,7 +68,7 @@ The following environment variables may be visible in your commands, plugins, an
 
 The following environment variables have been deprecated.
 
-<table>
+<table class="responsive-table">
 <tbody>
   <tr>
     <th><code>BUILDKITE_PROJECT_PROVIDER</code></th>

--- a/spec/features/toc_rendering_spec.rb
+++ b/spec/features/toc_rendering_spec.rb
@@ -5,13 +5,13 @@ RSpec.feature "toc rendering" do
     it "has a TOC" do
       visit "/docs/tutorials/getting-started"
       
-      expect(page).to have_css(".Docs__toc")
+      expect(page).to have_css(".Toc")
     end
   end
   
   describe "/docs/agent/v3/installation" do
     it "does not have a TOC" do
-      expect(page).to have_no_css(".Docs__toc")
+      expect(page).to have_no_css(".Toc")
     end
   end
 end

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -35,15 +35,13 @@ RSpec.describe Page::Renderer do
         MD
 
       html = <<~HTML
-        <div class="Docs__toc">
-          <div class="Docs__toc__sticky">
-            <p><strong>On this page:</strong></p>
-            <ul class="Docs__toc__list">
-              <li><a href="#section-1">Section 1</a></li>
-        <li><a href="#section-2">Section 2</a></li>
-            </ul>
-          </div>
-        </div>
+        <nav class="Toc">
+          <p><strong>On this page:</strong></p>
+          <ul class="Toc__list">
+            <li class="Toc__list-item"><a class="Toc__link" href="#section-1">Section 1</a></li>
+        <li class="Toc__list-item"><a class="Toc__link" href="#section-2">Section 2</a></li>
+          </ul>
+        </nav>
 
         <h2 id="section-1" class="Docs__heading"><a class="Docs__heading__anchor" href="#section-1">Section 1</a></h2>
 
@@ -76,14 +74,12 @@ RSpec.describe Page::Renderer do
       MD
 
       html = <<~HTML
-        <div class="Docs__toc">
-          <div class="Docs__toc__sticky">
-            <p><strong>On this page:</strong></p>
-            <ul class="Docs__toc__list">
-              <li><a href="#section">Section</a></li>
-            </ul>
-          </div>
-        </div>
+        <nav class="Toc">
+          <p><strong>On this page:</strong></p>
+          <ul class="Toc__list">
+            <li class="Toc__list-item"><a class="Toc__link" href="#section">Section</a></li>
+          </ul>
+        </nav>
         
         <h2 id="section" class="Docs__heading"><a class="Docs__heading__anchor" href="#section">Section</a></h2>
         


### PR DESCRIPTION
Small styling tweak for table of contents (TOC) so it aligns better with the overall sidebar look and feel.

## Before

<img width="1436" alt="Screen Shot 2022-06-20 at 9 44 37 am" src="https://user-images.githubusercontent.com/7202667/174514692-72ef50df-2d36-49c5-a4ea-9753079d05e4.png">

- Drop shadow 
- Body font
- No overflow scroll for exceedingly long TOC

## After

Visual tweaks as shown on my local dev:

- Consistent look and feel as per left sidebar nav
- System font
- Position fixed with overflow scrolling

<img width="1400" alt="Screen Shot 2022-06-20 at 12 09 06 pm" src="https://user-images.githubusercontent.com/7202667/174514720-4f1caadd-6ff6-4eef-8c36-d335d48a254d.png">

### Overflow scroll support

<img width="1436" alt="Screen Shot 2022-06-20 at 12 10 58 pm" src="https://user-images.githubusercontent.com/7202667/174514735-f5e215aa-0939-4c27-aec6-6494f264cd67.png">

### Does not affect existing small screen styles

<img width="821" alt="Screen Shot 2022-06-20 at 12 09 18 pm" src="https://user-images.githubusercontent.com/7202667/174514732-dc495f2b-321c-45f3-aea9-15f5d0da0e0d.png">

