### PR TITLE
searching/downloading artifacts from parallel steps

### DIFF
--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -160,7 +160,7 @@ Return a list of artifacts that match a query.
 
 ## Parallelized steps
 
-Currently, buildkite does not support collating artifacts from parallelized steps under a single key. Thus using the `--step` option with a parallelized step key will return only artifacts from the last completed step.
+Currently, Buildkite does not support collating artifacts from parallelized steps under a single key. Thus using the `--step` option with a parallelized step key will return only artifacts from the last completed step.
 
 If you are trying to collate artifacts from parallelized steps, it is best to upload these files with a unique path or name and omit the `--step` flag.
 

--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -158,6 +158,16 @@ Return a list of artifacts that match a query.
 <%= render 'agent/v3/help/artifact_search' %>
 
 
+## Parallelized steps
+
+Currently, buildkite does not support collating artifacts from parallelized steps under a single key. Thus using the `--step` option with a parallelized step key will return only artifacts from the last completed step.
+
+If you are trying to collate artifacts from parallelized steps, it is best to upload these files with a unique path or name and omit the `--step` flag.
+
+```bash
+buildkite-agent artifact <download or search> "artifacts/path/*" . --build $BUILDKITE_BUILD_ID
+```
+
 ## Fetching the SHA of an artifact
 
 Use this command in your build scripts to verify downloaded artifacts against the original SHA-1 of the file.


### PR DESCRIPTION
Adds a note to explain the use of `--step` option when searching or downloading artifacts from parallel steps.

See https://forum.buildkite.community/t/download-artifacts-from-parallel-builds/1502/2