### PR TITLE
Add pytest collector docs

### DIFF
--- a/pages/test_analytics/python_collectors.md.erb
+++ b/pages/test_analytics/python_collectors.md.erb
@@ -1,39 +1,54 @@
-# Configuring Python with Test Analytics
+# Python collectors
 
-To use Test Analytics with your Python projects, generate JUnit XML files with [pytest](https://docs.pytest.org), and then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) to Test Analytics.
+Test Analytics collectors for Python are provided by the [`buildkite-test-collector`](https://pypi.org/project/buildkite-test-collector/) package.
+You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
-{:notoc}
+{:toc}
 
-1. Install [pytest](https://docs.pytest.org/en/6.2.x/getting-started.html):
+## pytest collector
 
-    ```sh
-    pip install -U pytest
+pytest is a testing framework for Python.
+If you're already using pytest, then you can install `buildkite-test-collector` to collect test results into your Test Analytics dashboard.
+
+Before you start, make sure pytest runs with access to [CI environment variables](/docs/test-analytics/ci-environments).
+
+To get started with `buildkite-test-collector`:
+
+1. In your CI environment, set the `BUILDKITE_ANALYTICS_TOKEN` environment variable [securely](/docs/pipelines/secrets) to your Buildkite Test Analytics API token.
+
+1. Add `buildkite-test-collector` to your list of dependencies. Some examples:
+
+    <ul>
+      <li>
+          If you're using a <code>requirements.txt</code> file, add
+          <code>buildkite-test-collector</code> on a new line.
+      </li>
+      <li>
+          <p>
+          If you're using a <code>setup.py</code> file, add
+          <code>buildkite-test-collector</code> to the
+          <code>extras_require</code> argument, like this:
+          </p>
+          <pre><code>extras_require={&quot;dev&quot;: [&quot;pytest&quot;, &quot;  buildkite-test-collector&quot;]}</code></pre>
+      </li>
+      <li>
+          If you're using Pipenv, run
+          <code>pipenv install --dev buildkite-test-collector</code>.
+      </li>
+    </ul>
+    <p>
+    If you're using another tool, see your dependency management system's
+    documentation for help.
+    </p>
+
+1. Commit and push your changes:
+
+    ```shell
+    $ git add .
+    $ git commit -m "Install and set up Buildkite Test Analytics"
+    $ git push
     ```
 
-1. Use pytest to run your tests and output JUnit XML, for example:
+Once you're done, in your Test Analytics dashboard, you'll see analytics of test executions on all branches that include this code.
 
-    ```sh
-    pytest testing/ --junitxml="junit.xml"
-    ```
-
-1. Upload the JUnit.xml to Buildkite:
-
-    ```sh
-    curl \
-      -X POST \
-      --fail-with-body \
-      -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
-      -F "data=@junit.xml" \
-      -F "format=junit" \
-      -F "run_env[CI]=buildkite" \
-      -F "run_env[key]=$BUILDKITE_BUILD_ID" \
-      -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
-      -F "run_env[job_id]=$BUILDKITE_JOB_ID" \
-      -F "run_env[branch]=$BUILDKITE_BRANCH" \
-      -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
-      -F "run_env[message]=$BUILDKITE_MESSAGE" \
-      -F "run_env[url]=$BUILDKITE_BUILD_URL" \
-      https://analytics-api.buildkite.com/v1/uploads
-    ```
-
-See [pytest](https://docs.pytest.org) for full documentation of its features and command-line flags.
+If you don't see branch names, build numbers, or commit hashes in Test Analytics, then read [CI Environments](/docs/test-analytics/ci-environments) to learn more about exporting your environment to the collector.

--- a/vale/styles/vocab.txt
+++ b/vale/styles/vocab.txt
@@ -39,6 +39,7 @@ Okta
 Pagerduty
 Phabricator
 Phabricator's
+Pipenv
 Postgres
 Powershell
 Readme


### PR DESCRIPTION
This adds test collector docs for Python's pytest framework. It replaces the previous docs, which more or less duplicated the JUnit XML upload docs.