### PR TITLE
Add Vale rule to require title-case H1s

### DIFF
--- a/pages/agent/v2/cli_artifact.md.erb
+++ b/pages/agent/v2/cli_artifact.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent artifact
+# `buildkite-agent artifact`
 
 <section class="Docs__troubleshooting-note">
   <p>This page references the out-of-date Buildkite Agent v2.</p>

--- a/pages/agent/v2/cli_meta_data.md.erb
+++ b/pages/agent/v2/cli_meta_data.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent meta-data
+# `buildkite-agent meta-data`
 
 <section class="Docs__troubleshooting-note">
   <p>This page references the out-of-date Buildkite Agent v2.</p>

--- a/pages/agent/v2/cli_pipeline.md.erb
+++ b/pages/agent/v2/cli_pipeline.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent pipeline
+# `buildkite-agent pipeline`
 
 <section class="Docs__troubleshooting-note">
   <p>This page references the out-of-date Buildkite Agent v2.</p>

--- a/pages/agent/v2/cli_start.md.erb
+++ b/pages/agent/v2/cli_start.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent start
+# `buildkite-agent start`
 
 <section class="Docs__troubleshooting-note">
   <p>This page references the out-of-date Buildkite Agent v2.</p>

--- a/pages/agent/v2/securing.md.erb
+++ b/pages/agent/v2/securing.md.erb
@@ -1,4 +1,4 @@
-# Securing your Buildkite Agent
+# Securing Your Buildkite Agent
 
 <section class="Docs__troubleshooting-note">
   <p>This page references the out-of-date Buildkite Agent v2.</p>

--- a/pages/agent/v2/upgrading_to_v3.md.erb
+++ b/pages/agent/v2/upgrading_to_v3.md.erb
@@ -1,4 +1,4 @@
-# Upgrading your Buildkite Agents
+# Upgrading Your Buildkite Agents
 
 Upgrade your Agents using your operating system package manager, or by re-running the installation script.
 

--- a/pages/agent/v3/aws/secrets_manager.md.erb
+++ b/pages/agent/v3/aws/secrets_manager.md.erb
@@ -1,4 +1,4 @@
-# Storing your Buildkite Agent token in AWS Secrets Manager
+# Storing your Buildkite Agent Token in AWS Secrets Manager
 
 The Elastic CI Stack for AWS supports reading a Buildkite Agent token from
 the AWS Systems Manager Parameter Store. The token can be stored in a plaintext

--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent annotate
+# `buildkite-agent annotate`
 
 The Buildkite Agent's `annotate` command allows you to add additional information to Buildkite build pages using CommonMark Markdown.
 

--- a/pages/agent/v3/cli_annotation.md.erb
+++ b/pages/agent/v3/cli_annotation.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent annotation
+# `buildkite-agent annotation`
 
 The Buildkite Agent's `annotation` command allows manipulating existing build annotations.
 

--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent artifact
+# `buildkite-agent artifact`
 
 The Buildkite Agent's `artifact` command provides support for uploading and
 downloading of build artifacts, allowing you to share binary data between build

--- a/pages/agent/v3/cli_bootstrap.md.erb
+++ b/pages/agent/v3/cli_bootstrap.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent bootstrap
+# `buildkite-agent bootstrap`
 
 `bootstrap` is the command the agent executes when it comes to run a job on
 your agent.

--- a/pages/agent/v3/cli_meta_data.md.erb
+++ b/pages/agent/v3/cli_meta_data.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent meta-data
+# `buildkite-agent meta-data`
 
 The Buildkite Agent's `meta-data` command provides your build pipeline with a powerful key/value data-store that works across build steps and build agents, no matter the machine or network.
 

--- a/pages/agent/v3/cli_pipeline.md.erb
+++ b/pages/agent/v3/cli_pipeline.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent pipeline
+# `buildkite-agent pipeline`
 
 The Buildkite Agent's `pipeline` command allows you to add and replace build steps in the running build. The steps are defined using YAML or JSON and can be read from a file or streamed from the output of a script.
 

--- a/pages/agent/v3/cli_start.md.erb
+++ b/pages/agent/v3/cli_start.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent start
+# `buildkite-agent start`
 
 The Buildkite Agent's `start` command is used to manually start an agent and register it with Buildkite.
 

--- a/pages/agent/v3/cli_step.md.erb
+++ b/pages/agent/v3/cli_step.md.erb
@@ -1,4 +1,4 @@
-# buildkite-agent step
+# `buildkite-agent step`
 
 The Buildkite agent's `step` command provides the ability to retrieve and update the attributes of steps in your `pipeline.yml` files.
 

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -1,4 +1,4 @@
-# Securing your Buildkite Agent
+# Securing Your Buildkite Agent
 
 In cases where a Buildkite Agent is being deployed into a sensitive environment there are a few default settings and techniques which may be adjusted.
 

--- a/pages/agent/v3/upgrading.md.erb
+++ b/pages/agent/v3/upgrading.md.erb
@@ -1,4 +1,4 @@
-# Upgrading your Buildkite Agents
+# Upgrading Your Buildkite Agents
 
 Upgrade your Agents using your operating system package manager, or by re-running the installation script.
 As long as you're using Agent v3 or later, no configuration changes are necessary.

--- a/pages/apis/graphql/graphql_cookbook.md.erb
+++ b/pages/apis/graphql/graphql_cookbook.md.erb
@@ -1,4 +1,4 @@
-# GraphQL API cookbook
+# GraphQL API Cookbook
 
 This page provides examples for common API tasks. Want to suggest a recipe? We welcome pull requests to the [docs repo](https://github.com/buildkite/docs).
 

--- a/pages/apis/graphql/graphql_tutorial.md.erb
+++ b/pages/apis/graphql/graphql_tutorial.md.erb
@@ -1,4 +1,4 @@
-# Getting started with GraphQL from the Buildkite Console or the command line
+# Getting Started with GraphQL from the Buildkite Console or the Command Line
 
 [GraphQL](http://graphql.org) is a standard for defining, querying and documenting APIs in a human-friendly way, with built-in documentation, a friendly query language and a bunch of tools to help you get started.
 

--- a/pages/integrations/sso/google_workspace.md.erb
+++ b/pages/integrations/sso/google_workspace.md.erb
@@ -1,4 +1,4 @@
-# Single sign-on with Google Workspace
+# Single Sign-On with Google Workspace
 
 Google Workspace (previously GSuite and Google Apps) can be used as an SSO provider for your Buildkite organization. To complete this tutorial, you will need admin privileges for Buildkite.
 

--- a/pages/pipelines/archiving_and_deleting_pipelines.md.erb
+++ b/pages/pipelines/archiving_and_deleting_pipelines.md.erb
@@ -1,4 +1,4 @@
-# Archiving and deleting Pipelines
+# Archiving and Deleting Pipelines
 
 {:toc}
 

--- a/pages/pipelines/build_meta_data.md.erb
+++ b/pages/pipelines/build_meta_data.md.erb
@@ -1,4 +1,4 @@
-# Using Build Meta-data
+# Using Build Meta-Data
 
 In this guide, we'll walk through using the Buildkite agent's [meta-data command](/docs/agent/v3/cli-meta-data) to store and retrieve data between different steps in a build pipeline.
 

--- a/pages/pipelines/permissions.md.erb
+++ b/pages/pipelines/permissions.md.erb
@@ -1,4 +1,4 @@
-# Controlling user permissions
+# Controlling User Permissions
 
 Customers on the Buildkite [Business and Enterprise](https://buildkite.com/pricing) plans can manage permissions using [Teams](#permissions-with-teams). Enterprise customers can set fine-grained user permissions for their organization with the [member Permissions](#member-permissions) page.
 

--- a/pages/pipelines/skipping.md.erb
+++ b/pages/pipelines/skipping.md.erb
@@ -1,4 +1,4 @@
-# Skipping builds
+# Skipping Builds
 
 Build skipping allows you to avoid unnecessary rebuilds, conserving resources and freeing up agents.
 

--- a/pages/test_analytics/other_collectors.md.erb
+++ b/pages/test_analytics/other_collectors.md.erb
@@ -1,4 +1,4 @@
-# Collecting data from other test frameworks
+# Collecting Data from Other Test Frameworks
 
 {:notoc}
 

--- a/pages/test_analytics/permissions.md.erb
+++ b/pages/test_analytics/permissions.md.erb
@@ -1,4 +1,4 @@
-# Controlling user permissions
+# Controlling User Permissions
 
 Customers on the Buildkite [Business and Enterprise](https://buildkite.com/pricing) plans can manage permissions using [Teams](#permissions-with-teams). Enterprise customers can set fine-grained user permissions for their organization with the [Member Permissions](#member-permissions) page.
 

--- a/vale/styles/Buildkite/h1_title_case.yml
+++ b/vale/styles/Buildkite/h1_title_case.yml
@@ -1,0 +1,10 @@
+extends: capitalization
+message: "'%s' should be in title case"
+level: error
+scope: heading.h1
+match: $title
+style: Chicago
+exceptions:
+  - macOS
+  - Sign-On
+  - v2

--- a/vale/styles/Buildkite/h1_title_case.yml
+++ b/vale/styles/Buildkite/h1_title_case.yml
@@ -5,6 +5,6 @@ scope: heading.h1
 match: $title
 style: Chicago
 exceptions:
-  - macOS
-  - Sign-On
-  - v2
+  - macOS  # always lowercase m
+  - Sign-On  # capitalized "on" for symmetry with "SSO" initialism
+  - v2  # version identifier, appears in some agent page titles


### PR DESCRIPTION
The style guide calls for title case H1s, in contrast to sentence case H2s elsewhere. Speculatively, I've written a Vale rule to require this and fixed up the handful of cases where this convention wasn't already followed.

If this is desirable, I can create a corresponding rule for sentence case on H2+ headings.

Prompted by @karensawrey in https://github.com/buildkite/docs/pull/1615#discussion_r911041368.