### PR TITLE
Add missing BUILDKITE_BUILD_ID to TA Docker example

### DIFF
--- a/pages/test_analytics/ci_environments.md.erb
+++ b/pages/test_analytics/ci_environments.md.erb
@@ -25,6 +25,7 @@ To pass them through to the Docker container, use the `--env` option:
 ```
   docker run \
     --env BUILDKITE_ANALYTICS_TOKEN \
+    --env BUILDKITE_BUILD_ID \
     --env BUILDKITE_BUILD_NUMBER \
     --env BUILDKITE_JOB_ID \
     --env BUILDKITE_BRANCH \


### PR DESCRIPTION
A community member reporting this issue on Slack
https://buildkite-community.slack.com/archives/C03HXN4ARB5/p1656868462825419

Without the BUILD_ID environment variable, concurrent build runs are
not aggregated into a single run.
https://buildkite.com/docs/test-analytics/ci-environments#containers-and-test-collectors
