### PR TITLE
💬 Remove TOC on pages with one collector

### DIFF
--- a/pages/test_analytics/javascript_collectors.md.erb
+++ b/pages/test_analytics/javascript_collectors.md.erb
@@ -3,7 +3,7 @@
 Test Analytics ships with a Jest test collector, and [more are coming soon](https://github.com/buildkite/test-collector-javascript/issues?q=is%3Aissue+is%3Aopen+label%3A%22test+frameworks%22).
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
-{:toc}
+{:notoc}
 
 ## Jest collector
 

--- a/pages/test_analytics/python_collectors.md.erb
+++ b/pages/test_analytics/python_collectors.md.erb
@@ -3,7 +3,7 @@
 Test Analytics collectors for Python are provided by the [`buildkite-test-collector`](https://pypi.org/project/buildkite-test-collector/) package.
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
-{:toc}
+{:notoc}
 
 ## pytest collector
 


### PR DESCRIPTION
Python and JavaScript Test Analytics collector pages currently only have one collector. Like the Swift page, we can remove visual clutter and duplicate headings by disabling Table of Contents.

## Screenshots

### Before

<img width="1493" alt="Screen Shot 2022-07-04 at 10 36 24 am" src="https://user-images.githubusercontent.com/7202667/177063249-011b9f7b-6c10-46fc-a554-e9fff46e7cb4.png">

<img width="331" alt="Screen Shot 2022-07-04 at 10 36 07 am" src="https://user-images.githubusercontent.com/7202667/177063236-eb77637b-4274-4bf0-827b-36353193b8e5.png">


### After

<img width="1485" alt="Screen Shot 2022-07-04 at 10 34 19 am" src="https://user-images.githubusercontent.com/7202667/177063143-14294779-85a5-4f85-936d-9759cfe94154.png">

<img width="330" alt="Screen Shot 2022-07-04 at 10 34 43 am" src="https://user-images.githubusercontent.com/7202667/177063165-739b6d5b-8d75-43b5-ae6f-37513cf9fc8e.png">

<img width="1476" alt="Screen Shot 2022-07-04 at 10 35 04 am" src="https://user-images.githubusercontent.com/7202667/177063184-6104c1a3-def9-4a32-8643-f9191c3cdf44.png">

<img width="331" alt="Screen Shot 2022-07-04 at 10 35 32 am" src="https://user-images.githubusercontent.com/7202667/177063197-ec38ee2c-cde6-47e0-b729-f7ee4962ab05.png">
