### PR TITLE
Emphasize difference between agent and job lifecycles

### DIFF
--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -104,6 +104,7 @@ a plugin can define.
 The Buildkite agent executes agent lifecycle hooks.
 These hooks can only be defined in the [agent `hooks-path`](#hook-locations-agent-hooks) directory.
 Agent lifecycle hooks can be executables written in any programming language.
+On Unix-like systems (such as Linux and macOS), hooks must be files that are executable by the user the agent is running as.
 
 Use agent lifecycle hooks to prepare for or clean up after all jobs that may run.
 For example, use `pre-bootstrap` to block unwanted jobs from running or use `agent-shutdown` to tear down a service after all jobs are finished.

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -136,7 +136,7 @@ they are run as part of each job:
 
 Job lifecycle hooks are sourced for every job an agent accepts.
 Use job lifecycle hooks to prepare for jobs, override default behavior, or clean up after jobs that have finished.
-For example, use `environment` to set a job's environment variables or `pre-exit` to delete temporary files and remove containers.
+For example, use the `environment` hook to set a job's environment variables or the `pre-exit` hook to delete temporary files and remove containers.
 If your hook is related to the startup or shutdown of the agent, consider [agent lifecycle hooks](#job-lifecycle-hooks) for those tasks instead.
 
 Job lifecycle hooks are shell scripts that you can use to run commands and export environment variables to jobs.

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -139,8 +139,8 @@ Use job lifecycle hooks to prepare for jobs, override default behavior, or clean
 For example, use the `environment` hook to set a job's environment variables or the `pre-exit` hook to delete temporary files and remove containers.
 If your hook is related to the startup or shutdown of the agent, consider [agent lifecycle hooks](#job-lifecycle-hooks) for those tasks instead.
 
-Job lifecycle hooks are shell scripts that you can use to run commands and export environment variables to jobs.
-These hooks have access to all the standard [Buildkite environment variables](/docs/pipelines/environment-variables).
+Job lifecycle hooks have access to all the standard [Buildkite environment variables](/docs/pipelines/environment-variables).
+
 Job lifecycle hooks are copied to `$TMPDIR` directory and *sourced* by the agent's default shell.
 This has a few implications:
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -101,12 +101,16 @@ a plugin can define.
 
 ### Creating agent lifecycle hooks
 
-Agent lifecycle hooks can be written in the programming language of your choice
-and are executed by the Buildkite agent. See the documentation for each agent
-lifecycle hook for details on the interface between them and the Buildkite
-agent.
-
+The Buildkite agent executes agent lifecycle hooks.
 These hooks can only be defined in the [agent `hooks-path`](#hook-locations-agent-hooks) directory.
+Agent lifecycle hooks can be written in any programming language, but make sure the file is executable.
+
+Use agent lifecycle hooks to prepare for or clean up after all jobs that may run.
+For example, use `pre-bootstrap` to block unwanted jobs from running or use `agent-shutdown` to tear down a service after all jobs are finished.
+If your hook uses details about any individual job to run, prefer [job lifecycle hooks](#job-lifecycle-hooks) for those tasks instead.
+
+The agent exports few environment variables to agent lifecycle hooks.
+Read the [agent lifecycle hooks table](#agent-lifecycle-hooks) for details on the interface between the agent and each hook type.
 
 ## Job lifecycle hooks
 
@@ -129,12 +133,15 @@ they are run as part of each job:
 
 ### Creating job lifecycle hooks
 
-Job lifecycle hooks run for every job an agent accepts. They are shell
-scripts you can use to run commands and export environment variables. These
-hooks have access to all the standard [Buildkite environment variables](/docs/pipelines/environment-variables).
+Job lifecycle hooks are sourced for every job an agent accepts.
+Use job lifecycle hooks to prepare for jobs, override default behavior, or clean up after jobs that have finished.
+For example, use `environment` to set a job's environment variables or `pre-exit` to delete temporary files and remove containers.
+If your hook is related to the startup or shutdown of the agent, consider [agent lifecycle hooks](#job-lifecycle-hooks) for those tasks instead.
 
-Job lifecycle hooks are copied to `$TMPDIR` directory and *sourced* by the
-agent's default shell. This has a few implications:
+Job lifecycle hooks are shell scripts that you can use to run commands and export environment variables to jobs.
+These hooks have access to all the standard [Buildkite environment variables](/docs/pipelines/environment-variables).
+Job lifecycle hooks are copied to `$TMPDIR` directory and *sourced* by the agent's default shell.
+This has a few implications:
 
 * `$BASH_SOURCE` contains the location the hook is sourced from
 * `$0` contains the location of the copy of the script that is running from `$TMPDIR`

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -103,7 +103,7 @@ a plugin can define.
 
 The Buildkite agent executes agent lifecycle hooks.
 These hooks can only be defined in the [agent `hooks-path`](#hook-locations-agent-hooks) directory.
-Agent lifecycle hooks can be written in any programming language, but make sure the file is executable.
+Agent lifecycle hooks can be executables written in any programming language.
 
 Use agent lifecycle hooks to prepare for or clean up after all jobs that may run.
 For example, use `pre-bootstrap` to block unwanted jobs from running or use `agent-shutdown` to tear down a service after all jobs are finished.


### PR DESCRIPTION
This tries to do a few things, so that readers don't attempt to go against the grain with hooks (e.g., trying to use the agent-shutdown hook to clean up after individual jobs).

Mainly, I tried to emphasize:

- The minimalist nature of the `pre-bootstrap` and `agent-shutdown` hooks
- The job details exposed to job hooks
- Applications for agent and job hooks

Things I did _not_ attempt to do despite being tempted: rewriting the whole thing or challenging the distinction between agent and job lifecycles.