### PR TITLE
⚡️ Quick fixes Thursday 7 Jul 2022

### DIFF
--- a/app/assets/stylesheets/public/_nav.scss
+++ b/app/assets/stylesheets/public/_nav.scss
@@ -186,7 +186,7 @@
       width: auto;
     }
 
-    &:hover {
+    &:not(.Nav__link--pre-expand-children):hover {
       background-color: #fff;
 
       @media (min-width: $screen-md) {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
                   # URL so it points to the /pages version.
                   sub('/app/views/pages', '/pages')
 
-    "https://github.com/buildkite/docs/tree/main#{view_file}"
+    "https://github.com/buildkite/docs/edit/main#{view_file}"
   end
 
   def algolia_api_key

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -124,10 +124,6 @@ class Page
     Page::DataExtractor.extract(markdown_body)
   end
 
-  def open_source_url
-    "https://github.com/buildkite/docs/tree/main/pages/#{basename}.md.erb"
-  end
-
   def canonical_url
     basename.tr('_', '-')
   end

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -12,6 +12,7 @@
       <% nav_data.each_with_index do |children, i| %>
         <%=
           render 'layouts/nav_children',
+          pre_expand_children: false,
           children: children,
           is_dropdown: false,
           nav_level: nav_level,

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -12,7 +12,7 @@
       <% nav_data.each_with_index do |children, i| %>
         <%=
           render 'layouts/nav_children',
-          pre_expand_children: false,
+          start_expanded: false,
           children: children,
           is_dropdown: false,
           nav_level: nav_level,

--- a/app/views/layouts/_nav_children.html.erb
+++ b/app/views/layouts/_nav_children.html.erb
@@ -1,5 +1,7 @@
 <% nav_level = nav_level + 1 %>
-<ul class="<%= is_dropdown ? 'Nav__dropdown' : "Nav__section Nav__section--level#{nav_level}" %>">
+<ul class="
+  <%= is_dropdown ? 'Nav__dropdown' : "Nav__section Nav__section--level#{nav_level}" %>
+  <%= pre_expand_children ? 'Nav__section--show' : '' %>">
   <% children.each do |child| %>
     <li class="
       Nav__item
@@ -14,6 +16,7 @@
         pill: child['pill'],
         new_window: child['new_window'],
         is_dropdown: child['is_dropdown'],
+        pre_expand_children: child['pre_expand_children'],
         nav_level: nav_level,
         current_path: current_path
       %>
@@ -23,6 +26,7 @@
           render 'layouts/nav_children',
           children: child['children'],
           is_dropdown: child['is_dropdown'],
+          pre_expand_children: child['pre_expand_children'],
           nav_level: nav_level,
           current_path: current_path 
         %>

--- a/app/views/layouts/_nav_children.html.erb
+++ b/app/views/layouts/_nav_children.html.erb
@@ -1,7 +1,7 @@
 <% nav_level = nav_level + 1 %>
 <ul class="
   <%= is_dropdown ? 'Nav__dropdown' : "Nav__section Nav__section--level#{nav_level}" %>
-  <%= pre_expand_children ? 'Nav__section--show' : '' %>">
+  <%= start_expanded ? 'Nav__section--show' : '' %>">
   <% children.each do |child| %>
     <li class="
       Nav__item
@@ -16,7 +16,7 @@
         pill: child['pill'],
         new_window: child['new_window'],
         is_dropdown: child['is_dropdown'],
-        pre_expand_children: child['pre_expand_children'],
+        start_expanded: child['start_expanded'],
         nav_level: nav_level,
         current_path: current_path
       %>
@@ -26,7 +26,7 @@
           render 'layouts/nav_children',
           children: child['children'],
           is_dropdown: child['is_dropdown'],
-          pre_expand_children: child['pre_expand_children'],
+          start_expanded: child['start_expanded'],
           nav_level: nav_level,
           current_path: current_path 
         %>

--- a/app/views/layouts/_nav_link.html.erb
+++ b/app/views/layouts/_nav_link.html.erb
@@ -13,7 +13,7 @@
       <span class="Nav__pill pill pill--<%= pill %> pill--small"><%= pill %></span>
     <% end %>
   </a>
-<% elsif pre_expand_children %>
+<% elsif start_expanded %>
   <span class="<%= css_classes_nav_link %> Nav__link--pre-expand-children">
     <%= icon_image %>
     <%= name %>

--- a/app/views/layouts/_nav_link.html.erb
+++ b/app/views/layouts/_nav_link.html.erb
@@ -1,10 +1,9 @@
 <% icon_image = icon ? image_tag("icons/#{icon}") : '' %>
+<% css_classes_nav_link = "Nav__link Nav__link--level#{nav_level}" %>
+
 <% if path %>
   <a
-    class="
-      Nav__link
-      Nav__link--level<%= nav_level %>
-      <%= 'Nav__link--current' if current_path == nav_path(path) %>"
+    class="<%= css_classes_nav_link %> <%= 'Nav__link--current' if current_path == nav_path(path) %>"
     href="<%= nav_path(path) %>"
     <%= new_window && 'target=_blank' %>
   >
@@ -14,12 +13,17 @@
       <span class="Nav__pill pill pill--<%= pill %> pill--small"><%= pill %></span>
     <% end %>
   </a>
+<% elsif pre_expand_children %>
+  <span class="<%= css_classes_nav_link %> Nav__link--pre-expand-children">
+    <%= icon_image %>
+    <%= name %>
+    <% if pill %>
+      <span class="Nav__pill pill pill--<%= pill %> pill--small"><%= pill %></span>
+    <% end %>
+  </span>
 <% else %>
   <button 
-    class="
-      Nav__link
-      Nav__link--level<%= nav_level %>
-      <%= is_dropdown ? 'Nav__dropdown-toggle' : 'Nav__toggle' %>"
+    class="<%= css_classes_nav_link %> <%= is_dropdown ? 'Nav__dropdown-toggle' : 'Nav__toggle' %>"
     data-toggle-nav-level="<%= nav_level %>"
   >
     <%= icon_image %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -50,7 +50,7 @@
       <article class="HomepageCategory">
         <%= link_to "/docs/integrations/source-control", class: "HomepageCategory__header" do %>
           <h3 class="HomepageCategory__heading">Source control</h3>
-          <p class="HomepageCategory__subtext">Trigger builds from your code repo</p>
+          <p class="HomepageCategory__subtext">Trigger builds from your repository</p>
           <div class="HomepageCategory__icon" aria-hidden>
             <%= image_tag "icons/repository.svg", alt: "Icon: repository", class: "HomepageCategory__icon-img" %>
           </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -24,7 +24,7 @@
           <li class="HomepageCategory__list-item"><%= link_to "Running builds in Docker containers", "/docs/tutorials/docker-containerized-builds", class: 'HomepageCategory__list-item-link' %></li>
           <li class="HomepageCategory__list-item"><%= link_to "Autoscaling builds on Elastic CI stack for AWS", "/docs/tutorials/elastic-ci-stack-aws", class: 'HomepageCategory__list-item-link' %></li>
         </ul>
-        <%= button 'Get started', '/docs/tutorials/getting-started', type: 'primary', has_right_arrow: true %>
+        <%= button 'Set up Pipelines', '/docs/tutorials/getting-started', type: 'primary', has_right_arrow: true %>
       </article>
       <article class="HomepageCategory">
         <%= link_to "/docs/test-analytics", class: "HomepageCategory__header" do %>
@@ -50,7 +50,7 @@
       <article class="HomepageCategory">
         <%= link_to "/docs/integrations/source-control", class: "HomepageCategory__header" do %>
           <h3 class="HomepageCategory__heading">Source control</h3>
-          <p class="HomepageCategory__subtext">Trigger builds from wherever your code is stored</p>
+          <p class="HomepageCategory__subtext">Trigger builds from your code repo</p>
           <div class="HomepageCategory__icon" aria-hidden>
             <%= image_tag "icons/repository.svg", alt: "Icon: repository", class: "HomepageCategory__icon-img" %>
           </div>
@@ -134,7 +134,7 @@
       <article class="HomepageCategory">
         <%= link_to "/docs/agent/v3/elastic-ci-aws/elastic-ci-stack-overview", class: "HomepageCategory__header" do %>
           <h3 class="HomepageCategory__heading">Elastic CI Stack</h3>
-          <p class="HomepageCategory__subtext">Get started with Buildkite Elastic CI Stack for:</p>
+          <p class="HomepageCategory__subtext">Set up your Buildkite Elastic CI Stack</p>
           <div class="HomepageCategory__icon" aria-hidden>
             <%= image_tag "icons/elastic.svg", alt: "Icon: Elastic CI Stack", class: "HomepageCategory__icon-img" %>
           </div>
@@ -142,6 +142,7 @@
         <ul class="HomepageCategory__list">
           <li class="HomepageCategory__list-item"><%= link_to "AWS Linux and Windows", "/docs/agent/v3/elastic-ci-aws", class: 'HomepageCategory__list-item-link' %></li>
           <li class="HomepageCategory__list-item"><%= link_to "AWS EC2 for Mac", "/docs/agent/v3/elastic-ci-stack-for-ec2-mac/autoscaling-mac-metal", class: 'HomepageCategory__list-item-link' %></li>
+          <li class="HomepageCategory__list-item"><%= link_to "Customize instances with bootstrap script", "/docs/agent/v3/elastic-ci-aws#customizing-instances-with-a-bootstrap-script", class: 'HomepageCategory__list-item-link' %></li>
         </ul>
       </article>
     </div>
@@ -174,6 +175,7 @@
           <li class="HomepageCategory__list-item"><%= link_to "Slack and other notifications", "/docs/integrations/slack", class: 'HomepageCategory__list-item-link' %></li>
           <li class="HomepageCategory__list-item"><%= link_to "Single Sign-On (SSO)", "/docs/integrations/sso", class: 'HomepageCategory__list-item-link' %></li>
           <li class="HomepageCategory__list-item"><%= link_to "Buildkite plugins", "/docs/plugins", class: 'HomepageCategory__list-item-link' %></li>
+          <li class="HomepageCategory__list-item"><%= link_to "Test collectors", "/docs/test-analytics#get-started", class: 'HomepageCategory__list-item-link' %></li>
         </ul>
       </div>
     </article>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -134,7 +134,7 @@
       <article class="HomepageCategory">
         <%= link_to "/docs/agent/v3/elastic-ci-aws/elastic-ci-stack-overview", class: "HomepageCategory__header" do %>
           <h3 class="HomepageCategory__heading">Elastic CI Stack</h3>
-          <p class="HomepageCategory__subtext">Set up your Buildkite Elastic CI Stack</p>
+          <p class="HomepageCategory__subtext">Set up Buildkite Elastic CI Stack</p>
           <div class="HomepageCategory__icon" aria-hidden>
             <%= image_tag "icons/elastic.svg", alt: "Icon: Elastic CI Stack", class: "HomepageCategory__icon-img" %>
           </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -24,7 +24,7 @@
           <li class="HomepageCategory__list-item"><%= link_to "Running builds in Docker containers", "/docs/tutorials/docker-containerized-builds", class: 'HomepageCategory__list-item-link' %></li>
           <li class="HomepageCategory__list-item"><%= link_to "Autoscaling builds on Elastic CI stack for AWS", "/docs/tutorials/elastic-ci-stack-aws", class: 'HomepageCategory__list-item-link' %></li>
         </ul>
-        <%= button 'Set up Pipelines', '/docs/tutorials/getting-started', type: 'primary', has_right_arrow: true %>
+        <%= button 'Set up pipelines', '/docs/tutorials/getting-started', type: 'primary', has_right_arrow: true %>
       </article>
       <article class="HomepageCategory">
         <%= link_to "/docs/test-analytics", class: "HomepageCategory__header" do %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -142,7 +142,7 @@
         <ul class="HomepageCategory__list">
           <li class="HomepageCategory__list-item"><%= link_to "AWS Linux and Windows", "/docs/agent/v3/elastic-ci-aws", class: 'HomepageCategory__list-item-link' %></li>
           <li class="HomepageCategory__list-item"><%= link_to "AWS EC2 for Mac", "/docs/agent/v3/elastic-ci-stack-for-ec2-mac/autoscaling-mac-metal", class: 'HomepageCategory__list-item-link' %></li>
-          <li class="HomepageCategory__list-item"><%= link_to "Customize instances with bootstrap script", "/docs/agent/v3/elastic-ci-aws#customizing-instances-with-a-bootstrap-script", class: 'HomepageCategory__list-item-link' %></li>
+          <li class="HomepageCategory__list-item"><%= link_to "Customizing instances", "/docs/agent/v3/elastic-ci-aws#customizing-instances-with-a-bootstrap-script", class: 'HomepageCategory__list-item-link' %></li>
         </ul>
       </article>
     </div>

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -374,7 +374,7 @@
       - name: 'Overview'
         path: 'test-analytics'
       - name: 'Getting started'
-        pre_expand_children: true
+        start_expanded: true
         children:
           - name: 'Configuring test suites'
             path: 'test-analytics/test-suites'
@@ -385,7 +385,7 @@
           - name: 'CI environment variables'
             path: 'test-analytics/ci-environments'
       - name: 'Languages'
-        pre_expand_children: true
+        start_expanded: true
         children:
           - name: 'Ruby'
             path: 'test-analytics/ruby-collectors'
@@ -405,7 +405,7 @@
           - name: 'Other languages'
             path: 'test-analytics/other-collectors'
       - name: 'References'
-        pre_expand_children: true
+        start_expanded: true
         children:
           - name: 'Importing JUnit XML'
             path: 'test-analytics/importing-junit-xml'

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -374,6 +374,7 @@
       - name: 'Overview'
         path: 'test-analytics'
       - name: 'Getting started'
+        pre_expand_children: true
         children:
           - name: 'Configuring test suites'
             path: 'test-analytics/test-suites'
@@ -384,6 +385,7 @@
           - name: 'CI environment variables'
             path: 'test-analytics/ci-environments'
       - name: 'Languages'
+        pre_expand_children: true
         children:
           - name: 'Ruby'
             path: 'test-analytics/ruby-collectors'
@@ -403,6 +405,7 @@
           - name: 'Other languages'
             path: 'test-analytics/other-collectors'
       - name: 'References'
+        pre_expand_children: true
         children:
           - name: 'Importing JUnit XML'
             path: 'test-analytics/importing-junit-xml'

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -165,7 +165,7 @@ The following expressions are supported by the `if` attribute.
 The following variables are supported by the `if` attribute. Note that you cannot use [Build Meta-data](/docs/pipelines/build-meta-data) in conditional expressions.
 
 <div class="Docs__troubleshooting-note">
-  <h3 class="Docs__heading" id="unverified">Unverified commits</h3>
+  <h3 id="unverified">Unverified commits</h3>
 	<p>Note that GitHub accepts <a href="https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification">unsigned commits</a>, including information about the commit author and passes them along to webhooks, so you should not rely on these for authentication unless you are confident that all of your commits are trusted.</p>
 </div>
 

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -13,7 +13,7 @@ For best practices and recommendations about using secrets in your environment v
 The following environment variables may be visible in your commands, plugins, and hooks.
 
 <div class="Docs__troubleshooting-note">
-  <h3 class="Docs__heading" id="unverified">Unverified commits</h3>
+  <h3 id="unverified">Unverified commits</h3>
 	<p>Note that GitHub accepts <a href="https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification">unsigned commits</a>, including information about the commit author and passes them along to webhooks, so you should not rely on these for authentication unless you are confident that all of your commits are trusted.</p>
 </div>
 

--- a/pages/pipelines/permissions.md.erb
+++ b/pages/pipelines/permissions.md.erb
@@ -43,7 +43,7 @@ If you're creating pipelines programmatically using the REST API, you can add th
 You can also restrict agents to specific teams with the `BUILDKITE_BUILD_CREATOR_TEAMS` environment variable. Using agent hooks, you can allow or disallow builds based on the creator's team memberships.
 
 <div class="Docs__troubleshooting-note">
-  <h3 class="Docs__heading" id="unverified">Unverified commits</h3>
+  <h3 id="unverified">Unverified commits</h3>
 	<p>Note that GitHub accepts <a href="https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification">unsigned commits</a>, including information about the commit author and passes them along to webhooks, so you should not rely on these for authentication unless you are confident that all of your commits are trusted.</p>
 </div>
 

--- a/spec/features/reading_pages_spec.rb
+++ b/spec/features/reading_pages_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "reading pages" do
 
     it "links to the GitHub source files" do
       visit "/docs/tutorials/getting-started"
-      expect(page).to have_css("a[href='https://github.com/buildkite/docs/tree/main/pages/tutorials/getting_started.md.erb']", text: 'Contribute an update')
+      expect(page).to have_css("a[href='https://github.com/buildkite/docs/edit/main/pages/tutorials/getting_started.md.erb']", text: 'Contribute an update')
     end
   end
 


### PR DESCRIPTION
A series of quick fixes to clear the backlog:

- [x] **Homepage content changes**: added Elastic CI bootstrap link, test collector link and minor copy changes fe51a8040bbc0e3c2085d7464f4802ef4dc3e699
- [x] [DOC-431](https://linear.app/buildkite/issue/DOC-431) [pre-expand menu on TA](https://github.com/buildkite/docs/pull/1629/commits/6a033eed3e894b5b8430d0cd7c3e47f751591eb7): removes one click for customers to see what's under each menu heading
- [x] [DOC-437](https://linear.app/buildkite/issue/DOC-437) [no doc heading '#' on hover in note](https://github.com/buildkite/docs/pull/1629/commits/19bc7c2747e8cf80f5f1e0510c884329421ce81d): fixed the bug @karensawrey found when you hover over this message the `::before` ⚠️ icon gets replaced with a `#` anchor
- [x] [DOC-439](https://linear.app/buildkite/issue/DOC-439) [shortcut contribute directly to edit](https://github.com/buildkite/docs/pull/1629/commits/3f8662d5b74e59d12caff03f637fd509c411988c): @JuanitoFatas's proposed change to shortcut to the edit view to make a contribution
- [x] [DOC-439](https://linear.app/buildkite/issue/DOC-439) [remove unused method](https://github.com/buildkite/docs/pull/1629/commits/66429b5dc28b9c54ba00613987a07bf308d666b0): removed a dupe method that's not being used

I've manually checked the above in Chrome. Let me know if you're good with the above or need further fixes.
