### PR TITLE
Document how branch could differ from commit

### DIFF
--- a/data/environment_variables.yaml
+++ b/data/environment_variables.yaml
@@ -78,7 +78,7 @@ variables:
   example: "/usr/local/bin"
 - name: BUILDKITE_BRANCH
   desc: |
-    The branch being built.
+    The branch being built. The value of `BUILDKITE_COMMIT` might not exist on the branch specified here for manual builds where these values are input from a user.
   modifiable: false
   example: "main"
 - name: BUILDKITE_BUILD_CHECKOUT_PATH


### PR DESCRIPTION
The value of `BUILDKITE_BRANCH` might not contain the commit in `BUILDKITE_COMMIT` as these values can be specified when
triggering a build (ie. user input). The value of `BUILDKITE_COMMIT` is what the agent uses to checkout a specific commit.
`BUILDKITE_BRANCH` is mostly for UI and grouping.

If users want to do some checks and elevated privileges based on build branch, they should confirm the branch that contains
the `BUILDKITE_COMMIT` themselves during the agent workflow.
