### PR TITLE
Test Analytics Max Upload Limit

### DIFF
--- a/pages/test_analytics/importing_junit_xml.md.erb
+++ b/pages/test_analytics/importing_junit_xml.md.erb
@@ -122,4 +122,6 @@ To learn more about passing through environment variables to `run_env`-prefixed 
 
 Note that when a payload is processed, Buildkite validates and queues each test execution result in a loop. For that reason, it is possible for some to be queued and others to be skipped. Even when some or all test executions get skipped, REST API will respond with a `202 Accepted` because the upload and the run were created in the database, but the skipped test execution results were not ingested.
 
+A single JUnit XML can have a maxium of 5000 test results. If the limit of 5000 is exceeded then an upload request will fail. To upload more than 5000 test results for a single run upload multiple smaller XML files with the same `run_env[key]`.
+
 Currently, the errors returned contain no information on individual records that failed the validation. This may complicate the process of fixing and retrying the request.

--- a/pages/test_analytics/importing_junit_xml.md.erb
+++ b/pages/test_analytics/importing_junit_xml.md.erb
@@ -122,6 +122,6 @@ To learn more about passing through environment variables to `run_env`-prefixed 
 
 Note that when a payload is processed, Buildkite validates and queues each test execution result in a loop. For that reason, it is possible for some to be queued and others to be skipped. Even when some or all test executions get skipped, REST API will respond with a `202 Accepted` because the upload and the run were created in the database, but the skipped test execution results were not ingested.
 
-A single JUnit XML can have a maxium of 5000 test results. If the limit of 5000 is exceeded then an upload request will fail. To upload more than 5000 test results for a single run upload multiple smaller XML files with the same `run_env[key]`.
+A single JUnit XML can have a maximum of 5000 test results. If the limit of 5000 is exceeded then an upload request will fail. To upload more than 5000 test results for a single run upload multiple smaller XML files with the same `run_env[key]`.
 
 Currently, the errors returned contain no information on individual records that failed the validation. This may complicate the process of fixing and retrying the request.


### PR DESCRIPTION
Add a note regarding the maximum upload limit for JUnit XML test results.