### PR TITLE
Addressing the feedback

### DIFF
--- a/pages/agent/v3/installation.md.erb
+++ b/pages/agent/v3/installation.md.erb
@@ -1,6 +1,6 @@
 # How to Install Buildkite Agent
 
-The Buildkite Agent runs on your own machine, whether it's a VPS, server, desktop computer, embedded device. There are installers for:
+The Buildkite agent runs on your own machine, whether it's a VPS, server, desktop computer, embedded device. There are installers for:
 
 <% AGENT_INSTALLERS.each do |installer| %>
 * [<%= installer[:title] %>](<%= docs_page_path installer[:url] %>)<% end %>

--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -52,7 +52,7 @@ See the [configuration documentation](/docs/agent/v3/configuration) for an expla
 
 ## Which user the agent runs as
 
-On macOS, the Buildkite agent runs as the user who started the launched service.
+On macOS, the Buildkite agent runs as the user who started the `launchd` service.
 
 ## Starting on login
 

--- a/pages/agent/v3/ssh_keys.md.erb
+++ b/pages/agent/v3/ssh_keys.md.erb
@@ -6,7 +6,7 @@ If your agent needs to clone your repositories using git and SSH, you'll need to
 
 ## Finding your SSH key directory
 
-The Buildkite agent runs [on your own machine](/docs/agent/v3/installation), whether it's a VPS, server, desktop computer, embedded device. When the Buildkite agent runs any git operations, SSH will look for keys in `~/.ssh` under whichever user the agent runs as. Each platform's [agent installation documentation](/docs/agent/v3/installation) specifies the exact location of this directory.
+When the Buildkite agent runs any git operations, it will look for SSH keys in `~/.ssh` under the user the agent is running as. Each platform's [agent installation documentation](/docs/agent/v3/installation) specifies which user the agent runs as and in which directory the SSH keys are. For example, on Debian the agent runs as `buildkite-agent` and the SSH keys are in `/var/lib/buildkite-agent/.ssh/` but on macOS the agent runs as the user who started the `lauchd` service, and the SSH keys are in that user's `.ssh` directory.
 
 ## Debugging SSH key issues
 

--- a/pages/agent/v3/ssh_keys.md.erb
+++ b/pages/agent/v3/ssh_keys.md.erb
@@ -6,7 +6,7 @@ If your agent needs to clone your repositories using git and SSH, you'll need to
 
 ## Finding your SSH key directory
 
-When the Buildkite Agent runs any git operations, SSH will look for keys in `~/.ssh` under whichever user the agent runs as. Each platform's [agent installation documentation](/docs/agent/v3/installation) specifies the exact location of this directory.
+The Buildkite agent runs [on your own machine](/docs/agent/v3/installation), whether it's a VPS, server, desktop computer, embedded device. When the Buildkite agent runs any git operations, SSH will look for keys in `~/.ssh` under whichever user the agent runs as. Each platform's [agent installation documentation](/docs/agent/v3/installation) specifies the exact location of this directory.
 
 ## Debugging SSH key issues
 


### PR DESCRIPTION
According to the docs' user feedback, the docs were unclear on where the Buildkite agent is actually run. Adding info and a link to the page in question + fixing a faulty capital letter on the agent installation page.