### PR TITLE
Update Algolia config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,5 @@ group :test do
   # Browser testing stuff
   gem "capybara"
 end
+
+gem "dotenv", "~> 2.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
     erubi (1.10.0)
     escape_utils (1.2.1)
     execjs (2.8.1)
@@ -161,6 +162,7 @@ DEPENDENCIES
   byebug
   capybara
   commonmarker
+  dotenv (~> 2.7)
   escape_utils
   foreman
   listen

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ To test changes to the indexing configuration:
 
 2. Run `bundle exec rake update_test_index`.
 
+_This will not work on the Apple Silicon chips as Algolia has deprecated the
+scraper and have not developed an ARM version._
+
 ## License
 
 See [LICENSE.md](LICENSE.md) (MIT)

--- a/config/algolia.json
+++ b/config/algolia.json
@@ -18,12 +18,13 @@
     "lvl4": ".Docs__article h4, .Docs__article th",
     "lvl5": ".Docs__article h5, .Docs__article td:first-child",
     "lvl6": ".Docs__article h6",
-    "text": ".Docs__article p, .Docs__article li, .Docs__article td"
+    "text": ".Docs__article .TextContent p, .Docs__article .TextContent li, .Docs__article .TextContent td"
   },
   "selectors_exclude": [
-    ".Docs__toc",
     ".Docs__note--footer-typo",
-    ".HomepageCategory"
+    ".HomepageCategory",
+    ".Notification",
+    ".Toc"
   ],
   "custom_settings": {
     "synonyms": [
@@ -33,7 +34,7 @@
         "config.yml",
         "config.yaml"
       ]
-
     ]
-  }
+  },
+  "nb_hits": 5823
 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,11 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# Load dotenv only in development or test environment
+if ['development', 'test'].include? ENV['RAILS_ENV']
+  Dotenv.load
+end
+
 module Docs
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
This resolves DOC-426:
https://linear.app/buildkite/issue/DOC-426/update-algolia-config-to-reflect-new-html-structure

This updates the config settings for Algolia and also makes sure that the search now works in dev and in the Render environments for PRs.

Testing to be done between Render and the live site to confirm this works as expected.