### PR TITLE
H2 sentence-case linting (round 2)

### DIFF
--- a/pages/plugins.md.erb
+++ b/pages/plugins.md.erb
@@ -22,7 +22,7 @@ Some plugins allow configuration. This is usually defined in your `pipeline.yml`
 
 ## Finding plugins
 
-In the [Buildkite Plugin Directory](/docs/plugins/directory) you can find all the plugins maintained by Buildkite, as well as plugins from third-party developers.
+In the [Buildkite plugins directory](/docs/plugins/directory) you can find all the plugins maintained by Buildkite, as well as plugins from third-party developers.
 
 ## Creating a plugin
 

--- a/pages/plugins/directory.md.erb
+++ b/pages/plugins/directory.md.erb
@@ -1,6 +1,6 @@
 # Plugins Directory
 
-The [Plugins Directory](https://buildkite.com/plugins) is where you can both discover and publish Buildkite plugins. Visit the directory at https://buildkite.com/plugins
+The [plugins directory](https://buildkite.com/plugins) is where you can both discover and publish Buildkite plugins. Visit the directory at https://buildkite.com/plugins
 
 <a href="https://buildkite.com/plugins"><%= image("plugins-directory.png", width: 404, height: 237, alt: "Screenshot of a number of plugins", class: "no-decoration") %></a>
 
@@ -15,7 +15,7 @@ To have your plugin appear in the directory:
 1. Host your plugin on GitHub as a public repository.
 1. Ensure your repository contains a valid `plugin.yml` file containing at least the `name` and `description` fields.
 1. Add the `buildkite-plugin` [GitHub repository topic](https://help.github.com/en/github/administering-a-repository/classifying-your-repository-with-topics).
-1. Wait up to 1 hour for the plugin directory to sync with GitHub, and for your plugin to appear.
+1. Wait up to 1 hour for the plugins directory to sync with GitHub, and for your plugin to appear.
 
 For example:
 
@@ -23,7 +23,7 @@ For example:
 
 Once completed, your plugin will display in the directory as pictured below:
 
-<%= image "ecr-plugin-directory-item.png", width: 1014/2, height: 500/2, alt: "Screenshot of ECR plugin in the Buildkite Plugins Directory" %>
+<%= image "ecr-plugin-directory-item.png", width: 1014/2, height: 500/2, alt: "Screenshot of ECR plugin in the Buildkite plugins directory" %>
 
 <section class="Docs__troubleshooting-note">
 	<p>If you've completed the above steps and your plugin doesn't appear, send an email to <a href="mailto:support@buildkite.com">support@buildkite.com</a> and we'll investigate it for you.</p>

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -29,7 +29,7 @@ git init
 
 ## Step 2: Add a plugin.yml
 
-Next, create `plugin.yml` to describe how the plugin appears in the [Buildkite Plugin Directory](/docs/plugins/directory), what it requires, and what configuration options it accepts.
+Next, create `plugin.yml` to describe how the plugin appears in the [Buildkite plugins directory](/docs/plugins/directory), what it requires, and what configuration options it accepts.
 
 ```yaml
 name: File Counter
@@ -90,7 +90,7 @@ Configuration properties are available to the hook script as environment variabl
 
 ## Step 3: Validate the plugin.yml
 
-The [Buildkite Plugin Linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) helps ensure your plugin is up-to-date, and has all the required files to be listed in the plugin directory.
+The [Buildkite Plugin Linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) helps ensure your plugin is up-to-date, and has all the required files to be listed in the plugins directory.
 
 You can run the plugin linter with the following Docker command:
 
@@ -232,9 +232,9 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-## Publish to the Buildkite Plugin Directory
+## Publish to the Buildkite plugins directory
 
-To add your plugin to the [Buildkite Plugin Directory](https://buildkite.com/plugins), publish your repository to a public GitHub repository and add the `buildkite-plugin` [repository topic tag](https://github.com/topics/buildkite-plugin). For full instructions, see the [Plugin Directory documentation](/docs/plugins/directory).
+To add your plugin to the [Buildkite plugins directory](https://buildkite.com/plugins), publish your repository to a public GitHub repository and add the `buildkite-plugin` [repository topic tag](https://github.com/topics/buildkite-plugin). For full instructions, see the [plugins directory documentation](/docs/plugins/directory).
 
 ## Designing plugins: single-command plugins versus library plugins
 

--- a/vale/styles/Buildkite/existence.yml
+++ b/vale/styles/Buildkite/existence.yml
@@ -10,6 +10,7 @@ level: error
 ignorecase: True
 # swap maps tokens in form of bad: good
 swap:
-  whitelist: allowlist
   blacklist: blocklist
   oauth: OAuth
+  plugin directory: plugins directory
+  whitelist: allowlist

--- a/vale/styles/Buildkite/h2-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h2-h6_sentence_case.yml
@@ -23,6 +23,7 @@ exceptions:
   - Docker Compose
   - Elastic Stack
   - FAQs
+  - GitHub
   - GitHub App
   - Google Cloud Functions
   - GraphQL


### PR DESCRIPTION
This PR adds fixes and exceptions to support enabling sentence-case linting on H2s for the root of `pages` (that is, the immediate `pages/*.md.erb` files and files affected by these changes). Subsequent PRs will start going folder-by-folder though the rest of `pages`.