### PR TITLE
H2 sentence-case linting (round 3)

### DIFF
--- a/pages/agent/v2/cli_artifact.md.erb
+++ b/pages/agent/v2/cli_artifact.md.erb
@@ -298,4 +298,4 @@ export BUILDKITE_S3_ACCESS_URL="https://buildkite-artifacts.example.com/"
 
 ## Using your own private Google Cloud bucket
 
-You can use the `buildkite-agent artifact` command to store artifacts in your own private Google Cloud storage bucket. For instructions for how to set this up, see our [Google Cloud Installation Guide](/docs/agent/v2/gcloud#uploading-artifacts-to-google-cloud-storage).
+You can use the `buildkite-agent artifact` command to store artifacts in your own private Google Cloud Storage bucket. For instructions for how to set this up, see our [Google Cloud Installation Guide](/docs/agent/v2/gcloud#uploading-artifacts-to-google-cloud-storage).

--- a/pages/agent/v2/cli_start.md.erb
+++ b/pages/agent/v2/cli_start.md.erb
@@ -106,6 +106,6 @@ steps:
 
 Partial wildcard matching (for example, `postgres=1.9*` or `postgres=*1.9`) is not yet supported.
 
-## The Queue Tag
+## The queue tag
 
 The `queue` meta-data tag works differently from other tags, and can be used for isolating jobs and agents. See the [agent queues documentation](queues) for more information about using queues.

--- a/pages/agent/v2/docker.md.erb
+++ b/pages/agent/v2/docker.md.erb
@@ -32,6 +32,6 @@ docker run -e BUILDKITE_AGENT_TOKEN="INSERT-YOUR-AGENT-TOKEN-HERE" buildkite/age
 
 By default Docker [starts containers on restart](https://docs.docker.com/articles/host_integration/) so there's no need for upstart or similar. Start your container with `-d` to daemonize it and it will be restarted on system boot with the same environment variables and arguments.
 
-## SSH Keys, Configuration and Customization
+## SSH keys, configuration and customization
 
 See the [GitHub repository](https://github.com/buildkite/docker-buildkite-agent) for instructions on how to customize the base image. Alternatively you can create your own Docker image using our standard installer packages (see our [Ubuntu Dockerfile](https://github.com/buildkite/agent/blob/master/packaging/docker/ubuntu-linux/Dockerfile) for an example).

--- a/pages/agent/v2/gcloud.md.erb
+++ b/pages/agent/v2/gcloud.md.erb
@@ -5,7 +5,7 @@
   <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/gcloud">see the latest version of this document</a>.
 </section>
 
-The Buildkite Agent can be run on [Google Cloud Platform](https://cloud.google.com). For fine control over long–lived agents, you might like to run the agent using individual VM instances on Google Compute Engine. Or run Docker–based builds using a scalable cluster of agents on the Google Container Engine using Kubernetes.
+The Buildkite Agent can be run on [Google Cloud Platform](https://cloud.google.com). For fine control over long–lived agents, you might like to run the agent using individual VM instances on Google Compute Engine. Or run Docker–based builds using a scalable cluster of agents on the Google Kubernetes Engine using Kubernetes.
 
 {:toc}
 
@@ -23,13 +23,13 @@ Connect using SSH:
 
 Follow the [setup instructions for Ubuntu](/docs/agent/v2/ubuntu).
 
-## Running the agent on Google Container Engine
+## Running the agent on Google Kubernetes Engine
 
-[Google Container Engine](https://cloud.google.com/container-engine) can run the agent as a [Docker](https://www.docker.com) container using [Kubernetes](https://kubernetes.io). To [run Docker–based builds](/docs/tutorials/docker-containerized-builds), ensure the container is started with a [privileged security context](https://kubernetes.io/docs/user-guide/pods/#privileged-mode-for-pod-containers) and mount the Docker socket and binary as volumes. For example:
+[Google Kubernetes Engine](https://cloud.google.com/container-engine) can run the agent as a [Docker](https://www.docker.com) container using [Kubernetes](https://kubernetes.io). To [run Docker–based builds](/docs/tutorials/docker-containerized-builds), ensure the container is started with a [privileged security context](https://kubernetes.io/docs/user-guide/pods/#privileged-mode-for-pod-containers) and mount the Docker socket and binary as volumes. For example:
 
-Start a Google Container Engine cluster [through the console](https://console.cloud.google.com/kubernetes/add):
+Start a Google Kubernetes Engine cluster [through the console](https://console.cloud.google.com/kubernetes/add):
 
-<%= image "create-a-cluster.png", size: "2048x1216", alt: "Screenshot of creating a Google Container Engine cluster using the Google Cloud Console" %>
+<%= image "create-a-cluster.png", size: "2048x1216", alt: "Screenshot of creating a Google Kubernetes Engine cluster using the Google Cloud Console" %>
 
 Open [Google Cloud Shell](https://cloud.google.com/shell/), or your own console with [gcloud](https://cloud.google.com/sdk/gcloud/) installed and authenticated. You'll need to configure kubectl to talk to your new cluster. The console includes a "Connect" button which shows the exact command to run:
 
@@ -232,4 +232,4 @@ You can upload the [artifacts](/docs/builds/artifacts) created by your builds to
 export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="gs://my-bucket/$BUILDKITE_PIPELINE_ID/$BUILDKITE_BUILD_ID/$BUILDKITE_JOB_ID"
 ```
 
-Make sure the agent has permission to create new objects. If running on Google Compute Engine or Google Container Engine you can grant Storage Write permission to the instance or cluster, or restrict access more specifically using [a service account](https://cloud.google.com/compute/docs/access/service-accounts).
+Make sure the agent has permission to create new objects. If running on Google Compute Engine or Google Kubernetes Engine you can grant Storage Write permission to the instance or cluster, or restrict access more specifically using [a service account](https://cloud.google.com/compute/docs/access/service-accounts).

--- a/pages/agent/v2/hooks.md.erb
+++ b/pages/agent/v2/hooks.md.erb
@@ -19,7 +19,7 @@ Every agent installer comes with a hooks directory which can be used to override
 
 There are two types of hooks: global hooks which exist on the agent's machine and are the same for every pipeline, and pipeline level hooks which exist in each repository in the `.buildkite/hooks` directory.
 
-## Available Hooks
+## Available hooks
 
 Hooks are called in the following order:
 
@@ -68,7 +68,7 @@ Each agent installer comes with a hooks directory containing a sample set of hoo
 
 To get started with global hooks copy the relevant example script and remove the `.sample` file extension.
 
-## Pipeline Hooks
+## Pipeline hooks
 
 Pipeline hooks allow you to execute pipeline-specific scripts. Pipeline hooks live alongside your pipeline's source code under the directory `.buildkite/hooks`.
 

--- a/pages/agent/v2/osx.md.erb
+++ b/pages/agent/v2/osx.md.erb
@@ -25,7 +25,7 @@ sed -i '' "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" "$(brew --prefix)"/etc/buildkit
 
 If you don't use Homebrew you should follow the [Linux](/docs/agent/v2/linux) install instructions.
 
-## SSH Key Configuration
+## SSH key configuration
 
 SSH keys should be copied to (or generated into) the `.ssh` directory in the users' home directory (for example, `/Users/alice/.ssh`). For example, to generate a new private key which you can add to your source code host:
 

--- a/pages/agent/v2/redhat.md.erb
+++ b/pages/agent/v2/redhat.md.erb
@@ -55,7 +55,7 @@ sudo tail -f /var/log/buildkite-agent.log
 
 See the [Agent SSH Keys](/docs/agent/v2/ssh-keys) documentation for more details.
 
-## File Locations
+## File locations
 
 * Configuration: `/etc/buildkite-agent/buildkite-agent.cfg`
 * Agent Hooks: `/etc/buildkite-agent/hooks/`

--- a/pages/agent/v2/ubuntu.md.erb
+++ b/pages/agent/v2/ubuntu.md.erb
@@ -71,7 +71,7 @@ deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://
 
 See the [Agent SSH Keys](/docs/agent/v2/ssh-keys) documentation for more details.
 
-## File Locations
+## File locations
 
 <%= render_markdown partial: 'agent/v2/apt_locations' %>
 

--- a/pages/agent/v3/cli_artifact.md.erb
+++ b/pages/agent/v3/cli_artifact.md.erb
@@ -282,7 +282,7 @@ export BUILDKITE_S3_ACCESS_URL="https://buildkite-artifacts.example.com/"
 ## Using your private Google Cloud bucket
 
 You can configure the `buildkite-agent artifact` command to store artifacts in
-your private Google Cloud storage bucket. For instructions for how to set this
+your private Google Cloud Storage bucket. For instructions for how to set this
 up, see our [Google Cloud Installation Guide](/docs/agent/v3/gcloud#uploading-artifacts-to-google-cloud-storage).
 
 ## Using your Artifactory instance

--- a/pages/agent/v3/gcloud.md.erb
+++ b/pages/agent/v3/gcloud.md.erb
@@ -1,6 +1,6 @@
 # Running Buildkite Agent on Google Cloud Platform
 
-The Buildkite Agent can be run on [Google Cloud Platform](https://cloud.google.com). For fine control over long–lived agents, you might like to run the agent using individual VM instances on Google Compute Engine. Or run Docker–based builds using a scalable cluster of agents on the Google Container Engine using Kubernetes.
+The Buildkite Agent can be run on [Google Cloud Platform](https://cloud.google.com). For fine control over long–lived agents, you might like to run the agent using individual VM instances on Google Compute Engine. Or run Docker–based builds using a scalable cluster of agents on the Google Kubernetes Engine using Kubernetes.
 
 {:toc}
 
@@ -249,7 +249,7 @@ You can upload the [artifacts](/docs/builds/artifacts) created by your builds to
 export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="gs://my-bucket/$BUILDKITE_PIPELINE_ID/$BUILDKITE_BUILD_ID/$BUILDKITE_JOB_ID"
 ```
 
-Make sure the agent has permission to create new objects. If the agent is running on Google Compute Engine or Google Container Engine you can grant Storage Write permission to the instance or cluster, or restrict access more specifically using [a service account](https://cloud.google.com/compute/docs/access/service-accounts).
+Make sure the agent has permission to create new objects. If the agent is running on Google Compute Engine or Google Kubernetes Engine you can grant Storage Write permission to the instance or cluster, or restrict access more specifically using [a service account](https://cloud.google.com/compute/docs/access/service-accounts).
 
 You can also set the application credentials with the environment variable `BUILDKITE_GS_APPLICATION_CREDENTIALS`. From Agent v3.15.2 and above you can also use raw JSON with the `BUILDKITE_GS_APPLICATION_CREDENTIALS_JSON` variable. See the [Managing Pipeline Secrets](/docs/pipelines/secrets) documentation for how to securely set up environment variables.
 

--- a/vale/styles/Buildkite/existence-case-sensitive.yml
+++ b/vale/styles/Buildkite/existence-case-sensitive.yml
@@ -24,5 +24,10 @@ swap:
   (?i:Elastic CI Stack): Elastic CI Stack  # TODO: decide whether this should be "Elastic CI Stack" or "Elastic Stack"
   (?i:Elastic Stack): Elastic Stack
   (?i:Google Cloud Functions): Google Cloud Functions
+  (?i:Google Cloud Storage): Google Cloud Storage
+  (?i:Google Cloud): Google Cloud
+  (?i:Google Compute Engine): Google Compute Engine
+  (?i:Google Container Engine): Google Kubernetes Engine  # Google renamed Container to Kubernetes in 2017. See https://cloud.google.com/blog/products/gcp/introducing-certified-kubernetes-and-google-kubernetes-engine
+  (?i:Google Kubernetes Engine): Google Kubernetes Engine
   (?i:GraphQL): GraphQL
   (?i:IronWorker): IronWorker

--- a/vale/styles/Buildkite/existence-case-sensitive.yml
+++ b/vale/styles/Buildkite/existence-case-sensitive.yml
@@ -21,6 +21,8 @@ swap:
   (?i:AWS Lambda): AWS Lambda
   (?i:Bitbucket Server): Bitbucket Server
   (?i:CloudWatch) logs: CloudWatch Logs
+  (?i:Elastic CI Stack): Elastic CI Stack  # TODO: decide whether this should be "Elastic CI Stack" or "Elastic Stack"
+  (?i:Elastic Stack): Elastic Stack
   (?i:Google Cloud Functions): Google Cloud Functions
   (?i:GraphQL): GraphQL
   (?i:IronWorker): IronWorker

--- a/vale/styles/Buildkite/h2-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h2-h6_sentence_case.yml
@@ -22,6 +22,7 @@ exceptions:
   - Debian
   - Docker
   - Docker Compose
+  - Elastic CI Stack  # TODO: decide whether this should be "Elastic CI Stack" or "Elastic Stack"
   - Elastic Stack
   - FAQs
   - GitHub

--- a/vale/styles/Buildkite/h2-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h2-h6_sentence_case.yml
@@ -30,6 +30,8 @@ exceptions:
   - Google Cloud
   - Google Cloud Functions
   - Google Cloud Storage
+  - Google Compute Engine
+  - Google Kubernetes Engine
   - GraphQL
   - IdP  # TODO: unabbreviate this in headings
   - IDs

--- a/vale/styles/Buildkite/h2-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h2-h6_sentence_case.yml
@@ -20,6 +20,7 @@ exceptions:
   - CloudFormation
   - CloudWatch Logs
   - Debian
+  - Docker
   - Docker Compose
   - Elastic Stack
   - FAQs

--- a/vale/styles/Buildkite/h2-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h2-h6_sentence_case.yml
@@ -27,7 +27,9 @@ exceptions:
   - FAQs
   - GitHub
   - GitHub App
+  - Google Cloud
   - Google Cloud Functions
+  - Google Cloud Storage
   - GraphQL
   - IdP  # TODO: unabbreviate this in headings
   - IDs


### PR DESCRIPTION
This fixes the `pages/agent/v2` folder for sentence-case H2s, plus some consistency checks which fell out of this.

The only halfway interesting thing here is that while checking the capitalization of "Google Container Engine" I learned that Google renamed this to "Google Kubernetes Engine". There's now a consistency check both for the capitalization of the phrase and to use the new phrase in place of the former. Tidy!

(Less tidy: all of this is completely different from "Google Compute Engine". 🙄)