### PR TITLE
APT disparity page improvements

### DIFF
--- a/pages/apis/api_differences.md.erb
+++ b/pages/apis/api_differences.md.erb
@@ -36,7 +36,7 @@ On this page, we've collected the known limitation where some API features are o
 * <%= pill "PIPELINES", "pipelines" %> filter results from pipeline listings.
 * <%= pill "PIPELINES", "pipelines" %> create and manage pipeline schedules.
 * <%= pill "USERS", "users" %> [create and revoke](/docs/apis/rest-api/access-token) user API tokens (while REST can only revoke user API tokens).
-* <%= pill "USERS", "users" %> [create a user into a specific team and permissions set](/docs/apis/graphql/graphql-cookbook#create-a-user-add-them-to-a-team-and-set-user-permissions).
+* <%= pill "USERS", "users" %> [invite a user into a specific team with a specific role and permissions set](/docs/apis/graphql/graphql-cookbook#create-a-user-add-them-to-a-team-and-set-user-permissions).
 
 ## Known missing API features
 

--- a/pages/apis/graphql_api.md.erb
+++ b/pages/apis/graphql_api.md.erb
@@ -2,7 +2,7 @@
 
 The Buildkite GraphQL API provides an alternative to the [REST API](/docs/apis/rest-api). It allows for more efficient retrieval of data by enabling you to fetch multiple, nested resources in a single request.
 
-For the list of existing disparities between the REST API and the GraphQL API, see [API Differences](/docs/apis/api-differences).
+For the list of existing disparities between the GraphQL API and the REST API, see [API Differences](/docs/apis/api-differences).
 
 {:toc}
 


### PR DESCRIPTION
* Changes the link in the GraphQL overview to make GraphQL appear first
* Implements new feedback from @sj26 