### PR TITLE
Add docs for enable-job-log-tmpfile

### DIFF
--- a/data/agent_attributes.yaml
+++ b/data/agent_attributes.yaml
@@ -53,6 +53,12 @@ attributes:
   required: false
   desc: |
       The number of idle seconds to wait before shutting down. When setting this option alongside `spawn`, all agents started by `spawn` must be idle before the timeout counter will begin. After the timeout, the spawned agents will all disconnect.
+- name: enable-job-log-tmpfile
+  env_var: BUILDKITE_ENABLE_JOB_LOG_TMPFILE
+  default_value: "false"
+  required: false
+  desc: |
+      Enables the writing of job logs into a temporary file which can be accessed via the `BUILDKITE_JOB_LOG_TMPFILE` environment variable. Must be using Agent v3.36.0 or above.
 - name: endpoint
   env_var: BUILDKITE_AGENT_ENDPOINT
   default_value: "https://agent.buildkite.com/v3"

--- a/data/agent_attributes.yaml
+++ b/data/agent_attributes.yaml
@@ -58,7 +58,7 @@ attributes:
   default_value: "false"
   required: false
   desc: |
-      Enables the writing of job logs into a temporary file which can be accessed via the `BUILDKITE_JOB_LOG_TMPFILE` environment variable. Must be using Agent v3.36.0 or above.
+      Enables the writing of job logs into a temporary file which can be accessed via the `BUILDKITE_JOB_LOG_TMPFILE` environment variable. Introduced in [v3.36](https://github.com/buildkite/agent/releases/tag/v3.36.0).
 - name: endpoint
   env_var: BUILDKITE_AGENT_ENDPOINT
   default_value: "https://agent.buildkite.com/v3"

--- a/data/environment_variables.yaml
+++ b/data/environment_variables.yaml
@@ -230,6 +230,11 @@ variables:
     The internal UUID Buildkite uses for this job.
   modifiable: false
   example: "e44f9784-e20e-4b93-a21d-f41fd5869db9"
+- name: BUILDKITE_JOB_LOG_TMPFILE
+  desc: |
+    The path to a temporary file containing the logs for this job. Requires enabling the `enable-job-log-tmpfile` [agent configuration option](/docs/agent/v3/configuration).
+  modifiable: false
+  example: "/tmp/buildkite_job_log1931317484"
 - name: BUILDKITE_LABEL
   desc: |
     The label/name of the current job.


### PR DESCRIPTION
Adding docs for the feature added in https://github.com/buildkite/agent/pull/1564

Preview:
**Agent configuration**
<img width="1407" alt="Screen Shot 2022-07-29 at 1 32 49 PM" src="https://user-images.githubusercontent.com/4969439/181839206-6050e1f8-f675-4253-9c01-388fec28452b.png">

**Environment variables**
<img width="1403" alt="Screen Shot 2022-07-29 at 1 32 36 PM" src="https://user-images.githubusercontent.com/4969439/181839234-d1e8589c-b80d-4e05-b464-14fc61ce5c1c.png">

