### PR TITLE
H2 sentence-case linting (round 4)

### DIFF
--- a/pages/agent/v2.md.erb
+++ b/pages/agent/v2.md.erb
@@ -52,7 +52,7 @@ To start an agent you'll need your organization's agent token from the Agents pa
 
 The agent has a standard configuration file format on all systems to set meta-data, priority, etc. See the [configuration documentation](/docs/agent/v2/configuration) for more details.
 
-## Customising with Hooks
+## Customizing with Hooks
 
 The agent's behavior can be customized using hooks, which are shell scripts that exist on your build machines or in each pipeline's code repository. Hooks can be used to set up [secrets](/docs/pipelines/secrets) as well as overriding default behavior. See the [hooks](/docs/agent/v2/hooks) documentation for full details.
 

--- a/pages/agent/v2.md.erb
+++ b/pages/agent/v2.md.erb
@@ -52,10 +52,10 @@ To start an agent you'll need your organization's agent token from the Agents pa
 
 The agent has a standard configuration file format on all systems to set meta-data, priority, etc. See the [configuration documentation](/docs/agent/v2/configuration) for more details.
 
-## Customizing with Hooks
+## Customizing with hooks
 
 The agent's behavior can be customized using hooks, which are shell scripts that exist on your build machines or in each pipeline's code repository. Hooks can be used to set up [secrets](/docs/pipelines/secrets) as well as overriding default behavior. See the [hooks](/docs/agent/v2/hooks) documentation for full details.
 
-## Signal Handling
+## Signal handling
 
 When a build job is canceled the agent will send the build job process a `SIGTERM` signal to allow it to gracefully exit. If the process does not exit within 10 seconds it will be forcefully terminated with a `SIGKILL` signal.

--- a/pages/agent/v2/gcloud.md.erb
+++ b/pages/agent/v2/gcloud.md.erb
@@ -222,7 +222,7 @@ To add [agent hooks](/docs/agent/v2/hooks) add another config map and volume mou
 
 To add container startup scripts, add another config map with files and volume mount them into `/docker-entrypoint.d/`. Note: scripts in this directory must _not_ have any periods (`.`) or any file extensions since they are run by the `run-parts` util.
 
-See [our Docker setup instructions](/docs/agent/v2/docker) for more details on configuring and customising the Buildkite Agent running in Docker.
+See [our Docker setup instructions](/docs/agent/v2/docker) for more details on configuring and customizing the Buildkite Agent running in Docker.
 
 ## Uploading artifacts to Google Cloud Storage
 

--- a/pages/agent/v2/upgrading_to_v2.md.erb
+++ b/pages/agent/v2/upgrading_to_v2.md.erb
@@ -14,7 +14,7 @@ The Buildkite Agent has changed a lot in v2 but upgrade process is straight forw
 * The default install location has changed from `~/.buildbox` to `~/.buildkite-agent` (although each installer may install in different locations).
 * Agents can be configured with [a config file](configuration).
 * Agents register themselves with a organization-wide token, you no longer need to create them using the web.
-* Agents now have [hooks support](hooks) and there should be no reason to customise the `bootstrap.sh` file.
+* Agents now have [hooks support](hooks) and there should be no reason to customize the `bootstrap.sh` file.
 * There is built-in support for containerizing builds with [Docker and Docker Compose](/docs/tutorials/docker-containerized-builds).
 * There are [installer packages](installation) available for most systems.
 * Agents now have [meta-data](agent-meta-data).

--- a/pages/agent/v3.md.erb
+++ b/pages/agent/v3.md.erb
@@ -139,7 +139,7 @@ When the experiment is enabled, the agent will use different lock files from age
   <p>To use flock file locks, set <code>experiment="flock-file-locks"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.</p>
 </div>
 
-## Customising with hooks
+## Customizing with hooks
 
 The agent's behavior can be customized using hooks, which are shell scripts that exist on your build machines or in each pipeline's code repository. Hooks can be used to set up [secrets](/docs/pipelines/secrets) as well as overriding default behavior. See the [hooks](/docs/agent/v3/hooks) documentation for full details.
 

--- a/pages/agent/v3/aws/vpc.md.erb
+++ b/pages/agent/v3/aws/vpc.md.erb
@@ -108,5 +108,5 @@ S3. The private subnet route tables are configured forward the endpoint's
 IP-prefix list to the endpoint, instead of the NAT gateway. In-region S3 access
 from the private subnets will routed directly over the VPC endpoint, and bypass
 the NAT gateway. By default, the VPC endpoint has a permissive “Full Access”
-policy. Should you wish to customise this, or the security group that the
+policy. Should you wish to customize this, or the security group that the
 endpoint belongs to, create a fork of the CloudFormation template.

--- a/pages/agent/v3/aws/vpc.md.erb
+++ b/pages/agent/v3/aws/vpc.md.erb
@@ -36,7 +36,12 @@ access the internet directly. You can use
 [security groups](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html)
 to limit traffic and block inbound network connections to your instances.
 
+<!-- vale Buildkite.h2-h6_sentence_case = NO -->
+<!-- I'm not sure why, but Vale doesn't like the slash here -->
+
 ## Private/public subnets
+
+<!-- vale Buildkite.h2-h6_sentence_case = YES -->
 
 For an added layer of defence against unwanted inbound connectivity, you can
 place your instances in a private subnet. A private subnet provides the greatest

--- a/pages/agent/v3/aws/vpc.md.erb
+++ b/pages/agent/v3/aws/vpc.md.erb
@@ -36,12 +36,7 @@ access the internet directly. You can use
 [security groups](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html)
 to limit traffic and block inbound network connections to your instances.
 
-<!-- vale Buildkite.h2-h6_sentence_case = NO -->
-<!-- I'm not sure why, but Vale doesn't like the slash here -->
-
-## Private/public subnets
-
-<!-- vale Buildkite.h2-h6_sentence_case = YES -->
+## Using private subnets for added security
 
 For an added layer of defence against unwanted inbound connectivity, you can
 place your instances in a private subnet. A private subnet provides the greatest

--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -49,7 +49,7 @@ Annotations do not support GitHub-style syntax highlighting, task lists, user me
 
 CommonMark supports HTML inside Markdown blocks, but will revert to Markdown parsing on newlines. For more information about how HTML is parsed and which tags CommonMark supports please refer to the [CommonMark spec](https://spec.commonmark.org).
 
-## Supported CSS Classes
+## Supported CSS classes
 
 A number of CSS classes are accepted in annotations. These include a subset of layout and formatting controls based on [Basscss](http://basscss.com), and colored console output.
 

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -81,7 +81,7 @@ You can find the location of your configuration file in your platform's installa
 </table>
 <!-- vale on -->
 
-## Deprecated Configuration Settings
+## Deprecated configuration settings
 
 <table>
   <tbody>

--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -70,13 +70,13 @@ Update your Buildkite agent entries in `/etc/apt/sources.list.d/buildkite-agent.
 deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main
 ```
 
-## SSH Key Configuration
+## SSH key configuration
 
 <%= render_markdown partial: 'agent/v3/ssh_key_with_buildkite_agent_user' %>
 
 See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details.
 
-## File Locations
+## File locations
 
 <%= render_markdown partial: 'agent/v3/apt_locations' %>
 

--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -37,7 +37,7 @@ An Elastic CI Stack for AWS deployment contains an Auto Scaling group and a laun
 After booting, the Elastic CI Stack for AWS instances require network access to [buildkite.com](https://buildkite.com/buildkite). This access can be provided by booting them in a VPC subnet with a routing table that has Internet connectivity, either directly using an Internet Gateway or indirectly using a NAT Instance or NAT Gateway.
 
 By default, the template creates a public subnet VPC for your EC2 instances. The
-VPC in which your stack's instances are booted can be customised using the `VpcId`,
+VPC in which your stack's instances are booted can be customized using the `VpcId`,
 and `Subnets` template parameters. If you choose to use a VPC with split
 public/private subnets, the `AssociatePublicIpAddress` parameter can be used to
 turn off public IP association for your instances. See the [VPC](/docs/agent/v3/aws/vpc)
@@ -47,7 +47,7 @@ documentation for guidance on choosing a VPC layout suitable for your use case.
 
 The [Elastic CI Stack for AWS](https://github.com/buildkite/elastic-ci-stack-for-aws/) repository hasn't been reviewed by security researchers so exercise caution with what credentials you make available to your builds.
 
-The S3 buckets that Buildkite Agent creates for secrets don't allow public access. The stack's default VPC configuration does provide EC2 instances with a public IPv4 address. If you wish to customise this, the best practice is to create your own VPC and provide values for the [Network Configuration](/docs/agent/v3/elastic-ci-aws/parameters#network-configuration) template section:
+The S3 buckets that Buildkite Agent creates for secrets don't allow public access. The stack's default VPC configuration does provide EC2 instances with a public IPv4 address. If you wish to customize this, the best practice is to create your own VPC and provide values for the [Network Configuration](/docs/agent/v3/elastic-ci-aws/parameters#network-configuration) template section:
 
 * `VpcId`
 * `Subnets`
@@ -334,7 +334,7 @@ You can customize your stack's instances by using the `BootstrapScriptUrl` stack
 
 * An S3 bucket containing the script, for example `s3://my_bucket_name/my_bootstrap.sh`
 * A URL such as `https://www.example.com/config/bootstrap.sh`
-* A local file name `file:///usr/local/bin/my_bootstrap.sh` (this is particularly useful if you're customising the AMI and are able to include a bootstrap script that way).
+* A local file name `file:///usr/local/bin/my_bootstrap.sh` (this is particularly useful if you're customizing the AMI and are able to include a bootstrap script that way).
 
 If the file is private, you also need to create an IAM policy to allow the instances to read the file, for example:
 

--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -105,7 +105,7 @@ The Buildkite Elastic CI Stack for AWS supports:
 * Configurable auto-scaling based on build activity
 * Docker and Docker Compose
 * Per-pipeline S3 secret storage (with SSE encryption support)
-* Docker Registry push/pull
+* Docker registry push/pull
 * CloudWatch Logs for system and Buildkite agent events
 * CloudWatch metrics from the Buildkite API
 * Support for stable, beta or edge Buildkite Agent releases
@@ -241,7 +241,7 @@ You can set `BuildkiteTerminateInstanceAfterJob` to `true` to force the instance
 
 It is best to find an alternative to this setting if at all possible. The turn around time for replacing these instances is currently slow (5-10 minutes depending on other stack configuration settings). If you need single use jobs, we suggest looking at our container plugins like `docker`, `docker-compose`, and `ecs`, all which can be found [here](https://buildkite.com/plugins).
 
-## Docker Registry support
+## Docker registry support
 
 If you want to push or pull from registries such as [Docker Hub](https://hub.docker.com/) or [Quay](https://quay.io/) you can use the `environment` hook in your secrets bucket to export the following environment variables:
 

--- a/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md.erb
+++ b/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md.erb
@@ -85,7 +85,7 @@ You do not need to install the `buildkite-agent` in your template AMI, the
 `buildkite-agent` will be installed at boot time by the launch template's
 `UserData` script.
 
-## Step 3: Associate your AMI with a Customer managed license in AWS License Manager
+## Step 3: Associate your AMI with a customer managed license in AWS License Manager
 
 To launch an instance using a host resource group, the instance AMI must be
 associated with a *Customer managed license* in *AWS License Manager*.
@@ -198,7 +198,7 @@ EC2 Mac instances are slower to boot and terminate than Linux instances. If want
 to match your *Desired capacity* to your workload, consider configuring
 [scheduled scaling for your Auto Scaling group](https://docs.aws.amazon.com/autoscaling/ec2/userguide/schedule_time.html)
 
-## Frequently Asked Questions
+## Frequently asked questions
 
 ### My Auto Scaling group doesn't launch any instances
 

--- a/pages/agent/v3/gcloud.md.erb
+++ b/pages/agent/v3/gcloud.md.erb
@@ -239,7 +239,7 @@ To add [agent hooks](/docs/agent/v3/hooks) add another config map and volume mou
 
 To add container startup scripts, add another config map with files and volume mount them into `/docker-entrypoint.d/`. Note: scripts in this directory must _not_ have any periods (`.`) or any file extensions since they are run by the `run-parts` util.
 
-See [our Docker setup instructions](/docs/agent/v3/docker) for more details on configuring and customising the Buildkite Agent running in Docker.
+See [our Docker setup instructions](/docs/agent/v3/docker) for more details on configuring and customizing the Buildkite Agent running in Docker.
 
 ## Uploading artifacts to Google Cloud Storage
 

--- a/pages/agent/v3/tracing.md.erb
+++ b/pages/agent/v3/tracing.md.erb
@@ -12,8 +12,8 @@ To use the Datadog APM integration, start the Buildkite agent with the `--tracin
 
 Once this is done, the agent will start sending tracing information to Datadog. You can observe traces as they come in in the APM > Traces screen in your Datadog instance.
 
-## Using OpenTelemetry Tracing
+## Using OpenTelemetry tracing
 
-To use OpenTelemetry Tracing, start the Buildkite Agent with the `--tracing-backend opentelemetry` option. This will enable OpenTelemetry tracing, and start sending traces to an OpenTelemetry collector.
+To use OpenTelemetry tracing, start the Buildkite Agent with the `--tracing-backend opentelemetry` option. This will enable OpenTelemetry tracing, and start sending traces to an OpenTelemetry collector.
 
 The Buildkite agent's OpenTelemetry implementation uses the OTLP gRPC exporter to export trace information. This means that there must be a collector capable of ingesting OTLP gRPC traces accessible by the Buildkite agent. By default, the Buildkite agent will export trace information to `https://localhost:4317`, but this can be overridden by passing in an environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` containing the endpoint for the collector.

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -60,7 +60,7 @@ deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://
 
 See the [Agent SSH Keys](/docs/agent/v3/ssh-keys) documentation for more details.
 
-## File Locations
+## File locations
 
 <%= render_markdown partial: 'agent/v3/apt_locations' %>
 

--- a/pages/integrations/artifactory.md.erb
+++ b/pages/integrations/artifactory.md.erb
@@ -23,7 +23,7 @@ _Required environment vars:_
   <tr>
     <td><code>BUILDKITE_ARTIFACTORY_URL</code></td>
     <td>
-      Your Artifactory instance URL, including the /artifactory postfix<br>
+      Your Artifactory instance URL, including the <code>/artifactory</code> suffix<br>
       <em>Example:</em> <code>https://my-artifactory-server/artifactory</code><br>
     </td>
   </tr>

--- a/pages/integrations/docker_hub.md.erb
+++ b/pages/integrations/docker_hub.md.erb
@@ -102,7 +102,7 @@ images in use you may continue to hit Docker Hub rate limits.
 
 ## Running a read-through caching registry
 
-There are two popular options for running a private caching docker registry,
+There are two popular options for running a private caching registry,
 where requests for missing images result in the image being fetched from an
 origin registry (like Docker Hub).
 

--- a/pages/integrations/docker_hub.md.erb
+++ b/pages/integrations/docker_hub.md.erb
@@ -102,7 +102,7 @@ images in use you may continue to hit Docker Hub rate limits.
 
 ## Running a read-through caching registry
 
-There are two popular options for running a private caching registry,
+There are two popular options for running a private caching Docker registry,
 where requests for missing images result in the image being fetched from an
 origin registry (like Docker Hub).
 

--- a/pages/integrations/sso/azure_ad.md.erb
+++ b/pages/integrations/sso/azure_ad.md.erb
@@ -94,7 +94,7 @@ Then go to your [Azure Admin Console](https://portal.azure.com/) and select the 
 4. Disable group synchronization:
     1. Expand _Mappings_, then click _Provision Azure Active Directory Groups_.
     2. Toggle _Enabled_ to _No_ and click _Save_.
-5. Customise the User mappings:
+5. Customize the User mappings:
     1. Expand _Mappings_, then click _Provision Azure Active Directory Users_.
     2. Keep the following four mappings, and delete any others:
         - _userPrincipalName_ to _userName_

--- a/pages/tutorials/getting_started.md.erb
+++ b/pages/tutorials/getting_started.md.erb
@@ -29,7 +29,7 @@ Choose a sample pipeline to use as your first pipeline:
 
     <a class="inline-block" href="https://buildkite.com/new?template=https://github.com/buildkite/bash-example" target="_blank" rel="nofollow"><img src="https://buildkite.com/button.svg" alt="Add Bash Example to Buildkite" class="no-decoration" width="160" height="30"></a>
 
-    [powershell-example test repository](https://github.com/buildkite/powershell-example)
+    [`powershell-example` test repository](https://github.com/buildkite/powershell-example)
 
     <a class="inline-block" href="https://buildkite.com/new?template=https://github.com/buildkite/powershell-example" target="_blank" rel="nofollow"><img src="https://buildkite.com/button.svg" alt="Add PowerShell Example to Buildkite" class="no-decoration" width="160" height="30"></a>
 

--- a/vale/styles/Buildkite/existence-case-sensitive.yml
+++ b/vale/styles/Buildkite/existence-case-sensitive.yml
@@ -32,3 +32,4 @@ swap:
   (?i:Google Kubernetes Engine): Google Kubernetes Engine
   (?i:GraphQL): GraphQL
   (?i:IronWorker): IronWorker
+  (?i:PowerShell): PowerShell

--- a/vale/styles/Buildkite/existence-case-sensitive.yml
+++ b/vale/styles/Buildkite/existence-case-sensitive.yml
@@ -18,9 +18,13 @@ swap:
   # Or use a regular string to capture a specific, frequent case error
   # Example: `Bell Hooks: bell hooks`
   (?<!-)(?i:BitBucket): Bitbucket  # (?<!-) ignores bitbucket with a preceding dash, as in `buildkite-bitbucket-aws-terraform`
+  (?i:Amazon Web Services): Amazon Web Services
   (?i:AWS Lambda): AWS Lambda
+  (?i:AWS License Manager): AWS License Manager
   (?i:Bitbucket Server): Bitbucket Server
   (?i:CloudWatch) logs: CloudWatch Logs
+  (?i:CloudWatch): CloudWatch
+  (?i:Datadog): Datadog
   (?i:Elastic CI Stack(?! for AWS)): Elastic CI Stack for AWS
   (?i:Elastic Stack CI): Elastic CI Stack for AWS
   (?i:Elastic Stack): Elastic CI Stack for AWS
@@ -32,4 +36,7 @@ swap:
   (?i:Google Kubernetes Engine): Google Kubernetes Engine
   (?i:GraphQL): GraphQL
   (?i:IronWorker): IronWorker
+  (?i:Mac): Mac
+  (?i:Markdown): Markdown
   (?i:PowerShell): PowerShell
+  (?i:Windows Subsystem for Linux 2): Windows Subsystem for Linux 2

--- a/vale/styles/Buildkite/existence-case-sensitive.yml
+++ b/vale/styles/Buildkite/existence-case-sensitive.yml
@@ -26,7 +26,6 @@ swap:
   (?i:CloudWatch) logs: CloudWatch Logs
   (?i:CloudWatch): CloudWatch
   (?i:Datadog): Datadog
-  (?i:Docker Registry): Docker Registry
   (?i:Elastic CI Stack(?! for AWS)): Elastic CI Stack for AWS
   (?i:Elastic Stack CI): Elastic CI Stack for AWS
   (?i:Elastic Stack): Elastic CI Stack for AWS

--- a/vale/styles/Buildkite/existence-case-sensitive.yml
+++ b/vale/styles/Buildkite/existence-case-sensitive.yml
@@ -26,6 +26,7 @@ swap:
   (?i:CloudWatch) logs: CloudWatch Logs
   (?i:CloudWatch): CloudWatch
   (?i:Datadog): Datadog
+  (?i:Docker Registry): Docker Registry
   (?i:Elastic CI Stack(?! for AWS)): Elastic CI Stack for AWS
   (?i:Elastic Stack CI): Elastic CI Stack for AWS
   (?i:Elastic Stack): Elastic CI Stack for AWS

--- a/vale/styles/Buildkite/existence-case-sensitive.yml
+++ b/vale/styles/Buildkite/existence-case-sensitive.yml
@@ -19,6 +19,7 @@ swap:
   # Example: `Bell Hooks: bell hooks`
   (?<!-)(?i:BitBucket): Bitbucket  # (?<!-) ignores bitbucket with a preceding dash, as in `buildkite-bitbucket-aws-terraform`
   (?i:Amazon Web Services): Amazon Web Services
+  (?i:Artifactory): Artifactory
   (?i:AWS Lambda): AWS Lambda
   (?i:AWS License Manager): AWS License Manager
   (?i:Bitbucket Server): Bitbucket Server

--- a/vale/styles/Buildkite/existence.yml
+++ b/vale/styles/Buildkite/existence.yml
@@ -11,6 +11,8 @@ ignorecase: True
 # swap maps tokens in form of bad: good
 swap:
   blacklist: blocklist
+  customise: customize
+  customising: customizing
   oauth: OAuth
   plugin directory: plugins directory
   whitelist: allowlist

--- a/vale/styles/Buildkite/h2-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h2-h6_sentence_case.yml
@@ -27,6 +27,8 @@ exceptions:
   - Debian
   - Docker
   - Docker Compose
+  - Docker Hub
+  - Docker Registry
   - Elastic CI Stack
   - FAQs
   - GitHub

--- a/vale/styles/Buildkite/h2-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h2-h6_sentence_case.yml
@@ -12,6 +12,7 @@ exceptions:
   - '^(Agent|Build|Job) ([A-Z]\w+(ed|ing)|Lost)$'  # Exceptions for /pages/integrations/amazon_eventbridge.md.erb
   - '^(Step|Method) \d: [A-Z]\w+'  # Allow caps after colon. Examples: "Step 3: Do the thing", "Method 2: Deploy keys"
   - Amazon Web Services
+  - Artifactory
   - Auto Scaling
   - AWS Console
   - AWS Lambda

--- a/vale/styles/Buildkite/h2-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h2-h6_sentence_case.yml
@@ -11,14 +11,18 @@ match: $sentence
 exceptions:
   - '^(Agent|Build|Job) ([A-Z]\w+(ed|ing)|Lost)$'  # Exceptions for /pages/integrations/amazon_eventbridge.md.erb
   - '^(Step|Method) \d: [A-Z]\w+'  # Allow caps after colon. Examples: "Step 3: Do the thing", "Method 2: Deploy keys"
+  - Amazon Web Services
   - Auto Scaling
   - AWS Console
   - AWS Lambda
+  - AWS License Manager
   - AWS Systems Manager Session Manager
   - Bitbucket Server
   - Buildkite
   - CloudFormation
+  - CloudWatch
   - CloudWatch Logs
+  - Datadog
   - Debian
   - Docker
   - Docker Compose
@@ -36,6 +40,10 @@ exceptions:
   - IDs
   - IronWorker
   - M1
+  - Mac
   - macOS
+  - Markdown
   - OpenTelemetry
   - PowerShell
+  - Windows
+  - Windows Subsystem for Linux 2

--- a/vale/styles/Buildkite/h2-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h2-h6_sentence_case.yml
@@ -28,7 +28,6 @@ exceptions:
   - Docker
   - Docker Compose
   - Docker Hub
-  - Docker Registry
   - Elastic CI Stack
   - FAQs
   - GitHub

--- a/vale/styles/Buildkite/h2-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h2-h6_sentence_case.yml
@@ -38,3 +38,4 @@ exceptions:
   - M1
   - macOS
   - OpenTelemetry
+  - PowerShell


### PR DESCRIPTION
This PR makes fixes for H2s sentence-case linting for the remainder of the `pages/agent` tree (plus some consistency fixes that flow from that).

Highlights from this round:

- 🇺🇸 Caught some non-American English-isms (customise → customize)
- 🔪 Slashes in headings seem to break Vale a little