### PR TITLE
🚸 Use comparison table to visualize API parity

### DIFF
--- a/app/assets/stylesheets/public/_comparison-table.scss
+++ b/app/assets/stylesheets/public/_comparison-table.scss
@@ -1,0 +1,61 @@
+.comparison-table {
+  th,
+  td {
+    background-color: white;
+    padding: 15px;
+
+    &:first-child {
+      padding-left: 0;
+    }
+
+    &:nth-child(even) {
+      background-color: #f8f8f8;
+    }
+  }
+
+  thead {
+    position: sticky;
+    top: 0;
+
+    @media (min-width: $screen-md) {
+      top: $header-height;
+    }
+
+    th {
+      @include blur-background;
+      vertical-align: bottom;
+
+      &:nth-child(even) {
+        @include blur-background(#f8f8f8);
+      }
+
+      &:not(:first-child) {
+        text-align: center;
+      }
+    }
+  }
+
+  tbody {
+    th {
+      font-weight: normal;
+    }
+
+    td {
+      text-align: center;
+      vertical-align: middle;
+    }
+
+    .comparison-table__tbody-header {
+      border-bottom: 0;
+
+      th,
+      td {
+        padding-bottom: 0;
+      }
+
+      + tr {
+        border-top: 0;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/public/utils/_blur-background.scss
+++ b/app/assets/stylesheets/public/utils/_blur-background.scss
@@ -1,0 +1,7 @@
+@mixin blur-background($background-color: white) {
+  @supports (backdrop-filter: blur(2px)) {
+    -webkit-backdrop-filter: blur(2px);
+    backdrop-filter: blur(2px);
+    background-color: rgba($background-color, .85);
+  }
+}

--- a/app/assets/stylesheets/public/utils/_pill.scss
+++ b/app/assets/stylesheets/public/utils/_pill.scss
@@ -1,57 +1,45 @@
 $_pills: (
-  agents: (
+  blue-light: (
     background-color: #EFF9FF,
     border-color: #EFF9FF,
     color: #333333,
-    content: "Agents"
+    content: ""
   ),
-  access-token: (
+  pink-light: (
     background-color: #FFEDF9,
     border-color: #FFEDF9,
     color: #333333,
-    content: "Access token"
+    content: ""
   ),
-  builds: (
+  orange-light: (
     background-color: #fff8e7,
     border-color: #fff8e7,
     color: #333333,
-    content: "Builds"
+    content: ""
   ),
-  jobs: (
+  purple-light: (
     background-color: #f1efff,
     border-color: #f1efff,
     color: #333333,
-    content: "Jobs"
+    content: ""
   ),
-  meta: (
+  gray-light: (
     background-color: #eeeeee,
     border-color: #eeeeee,
     color: #333333,
-    content: "Meta"
+    content: ""
   ),
-  notification-services: (
-    background-color: #F1EFFF,
-    border-color: #F1EFFF,
-    color: #333333,
-    content: "Notification services"
-  ),
-  organizations: (
+  aqua-light: (
     background-color: #FFEDF9,
     border-color: #FFEDF9,
     color: #333333,
-    content: "Organizations"
+    content: ""
   ),
-  pipelines: (
-    background-color: #ddfffa,
-    border-color: #ddfffa,
-    color: #333333,
-    content: "Pipelines"
-  ),
-  users: (
+  red-light: (
     background-color: #fdf5f5,
     border-color: #fdf5f5,
     color: #333333,
-    content: "Users"
+    content: ""
   ),
   beta: (
     background-color: rgba(255, 165, 0, .2),
@@ -89,6 +77,7 @@ $_pills: (
   line-height: 1;
   padding: 3px 7px;
   text-transform: uppercase;
+  white-space: nowrap;
 }
 
 @mixin pill-style($type) {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :notification_data
 
+  def api_parity_data
+    fetch_local_data('api_parity')
+  end
+  helper_method :api_parity_data
+
   # capture some extra data so we can log it with lograge
   def append_info_to_payload(payload)
     super

--- a/app/helpers/api_parity_table_helper.rb
+++ b/app/helpers/api_parity_table_helper.rb
@@ -1,0 +1,117 @@
+require "commonmarker"
+
+module ApiParityTableHelper
+  def api_parity_tables
+    data = api_parity_data
+    feature_parity_data = data["feature_parity"]
+    missing_features_data = data["missing_features"]
+
+    <<~HTML
+      <table class="comparison-table">
+        <thead>
+          <th width="34%">Task</th>
+          <th width="33%">REST</th>
+          <th width="33%">:graphql: GraphQL</th>
+        </thead>
+        #{rowgroups(feature_parity_data)}
+      </table>
+      #{render_missing_features(missing_features_data)}
+    HTML
+  end
+
+  private
+
+  def rowgroups(data)
+    html = ""
+
+    data.each do |key, value|
+      rest_data = value["rest"]
+      graphql_data = value["graphql"]
+
+      html << <<~HTML
+        <tbody>
+          #{rows(key, value["style"], rest_data, graphql_data)}
+        </tbody>
+      HTML
+    end
+
+    html
+  end
+
+  def rows(table_header, table_header_style, rest_data, graphql_data)
+    html = <<~HTML
+      <tr class="comparison-table__tbody-header">
+        <th width="33%">
+          <span class="pill pill--#{table_header_style}">#{table_header}</span>
+        </th>
+        <td aria-hidden></td>
+        <td aria-hidden></td>
+      </tr>
+    HTML
+
+    if rest_data
+      rest_data.each do |element|
+        rows = <<~HTML
+          <tr>
+            <th>
+              #{CommonMarker.render_html(element)}
+            </th>
+            <td>
+              :white_check_mark: <span class="OffScreen">Only available in REST</span>
+            </td>
+            <td>
+              <span class="OffScreen">Not available in GraphQL</span>
+            </td>
+          </tr>
+        HTML
+
+        html << rows
+      end
+    end
+
+    if graphql_data
+      graphql_data.each do |element|
+        rows = <<~HTML
+          <tr>
+            <th>
+              #{CommonMarker.render_html(element)}
+            </th>
+            <td>
+              <span class="OffScreen">Not available in REST</span>
+            </td>
+            <td>
+              :white_check_mark: <span class="OffScreen">Only available in GraphQL</span>
+            </td>
+          </tr>
+        HTML
+
+        html << rows
+      end
+    end
+
+    html
+  end
+
+  def render_missing_features(data)
+    unless data.empty?
+      html = ""
+
+      html << <<~HTML
+        <h2>Known missing API features<h2>
+        <p>These are known requested features that are currently missing from both REST and GraphQL APIs:</p>
+        <ul>
+      HTML
+
+      data.each do |key, value|
+        html << <<~HTML
+          <li>
+            <span class="pill pill--#{value["style"]}">#{key}</span>
+            #{value["description"]}
+          </li>
+        HTML
+      end
+
+      html << "</ul>"
+    end
+  end
+end

--- a/data/api_parity.yml
+++ b/data/api_parity.yml
@@ -1,0 +1,59 @@
+---
+feature_parity:
+  access_token:
+    rest:
+      - "[Display the information about the access token currently in use](/docs/apis/rest-api/access-token#get-the-current-token)"
+      - "[Revoke the current access token](/docs/apis/rest-api/access-token#revoke-the-current-token)"
+    style: pink-light
+  agents:
+    graphql: 
+      - "[Get a list of agent token IDs](/docs/apis/graphql/graphql-cookbook#get-a-list-of-agent-token-ids) (agent tokens are currently only available via GraphQL)"
+    style: blue-light
+  builds:
+    graphql:
+      - "[Get all environment variables set on a build](/docs/apis/graphql/graphql-cookbook#get-all-environment-variables-set-on-a-build)"
+      - "[Increase the next build number](/docs/apis/graphql/graphql-cookbook#increase-the-next-build-number)"
+      - "[Create annotations on a build](/docs/apis/rest-api/annotations)"
+    style: orange-light
+  jobs:
+    rest:
+      - "[Get an output of job logs](/docs/apis/rest-api/jobs#get-a-jobs-log-output)"
+      - "[Retry data for jobs](/docs/apis/rest-api/jobs#retry-a-job)"
+    graphql:
+      - "[Get all jobs in a given queue for a given timeframe](/docs/apis/graphql/graphql-cookbook#get-all-jobs-in-a-given-queue-for-a-given-timeframe)"
+      - "List job events"
+    style: purple-light
+  meta:
+    rest:
+      - "[Get a list of IPs from which Buildkite sends webhooks](/docs/apis/rest-api/meta#get-meta-information)"
+    style: gray-light
+  organizations:
+    graphql:
+      - "[Remove users from an organization](/docs/apis/graphql/graphql-cookbook#delete-an-organization-member)"
+      - "Manage teams - [add](/docs/apis/graphql/graphql-cookbook#add-an-existing-organization-user-to-a-team) or [remove](/docs/apis/graphql/graphql-cookbook#remove-a-team-member) a team member. Most of the team management features are only available for GraphQL. The REST API can only list teams and can create pipelines in teams"
+      - "[Set up SSO](/docs/integrations/sso/sso-setup-with-graphql)"
+      - "[Remove pipeline edit access from existing teams](/docs/apis/graphql/graphql-cookbook#set-teams-pipeline-edit-access-to-read-only-or-build-and-read)"
+    style: aqua-light
+  pipelines:
+    rest:
+      - "[Set provider properties](/docs/apis/rest-api/pipelines#provider-settings-properties) `provider_settings` allow configuring how the pipeline is triggered based on the source code provider's events; available on pipeline for all the pipeline inputs on pipeline create"
+    graphql:
+      - "[Get all the pipeline metrics from the dashboard from the API](/docs/apis/graphql/graphql-cookbook#get-pipeline-metrics)"
+      - "[Get the last build's creation date within every pipeline](/docs/apis/graphql/graphql-cookbook#get-the-creation-date-of-the-most-recent-build-in-every-pipeline)"
+      - "[Count the number of builds on a branch](/docs/apis/graphql/graphql-cookbook#count-the-number-of-builds-on-a-branch)"
+      - "[Get the creation date of the most recent build in every pipeline](/docs/apis/graphql/graphql-cookbook#get-the-creation-date-of-the-most-recent-build-in-every-pipeline)"
+      - "Filter results from pipeline listings"
+      - "Create and manage pipeline schedules"
+    style: aqua-light
+  users:
+    graphql:
+      - "[Create and revoke](/docs/apis/rest-api/access-token) user API tokens (while REST can only revoke user API tokens)"
+      - "[Create a user into a specific team and permissions set](/docs/apis/graphql/graphql-cookbook#create-a-user-add-them-to-a-team-and-set-user-permissions)"
+    style: red-light
+missing_features:
+  notification_services: 
+    description: There is no API for managing notification services
+    style: purple-light
+  users: 
+    description: display secondary user emails
+    style: red-light

--- a/pages/apis/api_differences.md.erb
+++ b/pages/apis/api_differences.md.erb
@@ -8,40 +8,6 @@ The strengths of the GraphQL API are in complex data queries, and the strengths 
 
 On this page, we've collected the known limitation where some API features are only available with either REST or GraphQL.
 
-## Features only available in the REST API
+## API comparison table
 
-* <%= pill "ACCESS TOKEN", "access-token" %> [display the information about the access token currently in use](/docs/apis/rest-api/access-token#get-the-current-token).
-* <%= pill "ACCESS TOKEN", "access-token" %> [revoke the current access token](/docs/apis/rest-api/access-token#revoke-the-current-token).
-* <%= pill "JOBS", "jobs" %> [get an output of job logs](/docs/apis/rest-api/jobs#get-a-jobs-log-output).
-* <%= pill "JOBS", "jobs" %> [retry data for jobs](/docs/apis/rest-api/jobs#retry-a-job).
-* <%= pill "META", "meta" %> [get a list of IPs from which Buildkite sends webhooks](/docs/apis/rest-api/meta#get-meta-information).
-* <%= pill "PIPELINES", "pipelines" %> [set provider properties](/docs/apis/rest-api/pipelines#provider-settings-properties) `provider_settings` allow configuring how the pipeline is triggered based on the source code provider's events; available on pipeline for all the pipeline inputs on pipeline create.
-
-## Features only available in the GraphQL API
-
-* <%= pill "AGENTS", "agents" %> [get a list of agent token IDs (agent tokens are currently only available via GraphQL)](/docs/apis/graphql/graphql-cookbook#get-a-list-of-agent-token-ids).
-* <%= pill "BUILDS", "builds" %> [get all environment variables set on a build](/docs/apis/graphql/graphql-cookbook#get-all-environment-variables-set-on-a-build).
-* <%= pill "BUILDS", "builds" %> [increase the next build number](/docs/apis/graphql/graphql-cookbook#increase-the-next-build-number).
-* <%= pill "BUILDS", "builds" %> [create annotations on a build](/docs/apis/rest-api/annotations).
-* <%= pill "JOBS", "jobs" %> [get all jobs in a given queue for a given timeframe](/docs/apis/graphql/graphql-cookbook#get-all-jobs-in-a-given-queue-for-a-given-timeframe).
-* <%= pill "JOBS", "jobs" %> list job events.
-* <%= pill "ORGANIZATIONS", "organizations" %> [remove users from an organization](/docs/apis/graphql/graphql-cookbook#delete-an-organization-member).
-* <%= pill "ORGANIZATIONS", "organizations" %> manage teams - [add](/docs/apis/graphql/graphql-cookbook#add-an-existing-organization-user-to-a-team) or [remove](/docs/apis/graphql/graphql-cookbook#remove-a-team-member) a team member. Most of the team management features are only available for GraphQL. The REST API can only list teams and can create pipelines in teams.
-* <%= pill "ORGANIZATIONS", "organizations" %> [set up SSO](/docs/integrations/sso/sso-setup-with-graphql).
-* <%= pill "ORGANIZATIONS", "organizations" %> [remove pipeline edit access from existing teams](/docs/apis/graphql/graphql-cookbook#set-teams-pipeline-edit-access-to-read-only-or-build-and-read).
-* <%= pill "PIPELINES", "pipelines" %> [get all the pipeline metrics from the dashboard from the API](/docs/apis/graphql/graphql-cookbook#get-pipeline-metrics).
-* <%= pill "PIPELINES", "pipelines" %> [get the last build's creation date within every pipeline](/docs/apis/graphql/graphql-cookbook#get-the-creation-date-of-the-most-recent-build-in-every-pipeline).
-* <%= pill "PIPELINES", "pipelines" %> [count the number of builds on a branch](/docs/apis/graphql/graphql-cookbook#count-the-number-of-builds-on-a-branch).
-* <%= pill "PIPELINES", "pipelines" %> [get the creation date of the most recent build in every pipeline](/docs/apis/graphql/graphql-cookbook#get-the-creation-date-of-the-most-recent-build-in-every-pipeline).
-* <%= pill "PIPELINES", "pipelines" %> filter results from pipeline listings.
-* <%= pill "PIPELINES", "pipelines" %> create and manage pipeline schedules.
-* <%= pill "USERS", "users" %> [create and revoke](/docs/apis/rest-api/access-token) user API tokens (while REST can only revoke user API tokens).
-* <%= pill "USERS", "users" %> [invite a user into a specific team with a specific role and permissions set](/docs/apis/graphql/graphql-cookbook#create-a-user-add-them-to-a-team-and-set-user-permissions).
-
-## Known missing API features
-
-These are known requested features that are currently missing from both REST and GraphQL APIs:
-
-* <%= pill "NOTIFICATION SERVICES", "notification-services" %> there is no API for managing notification services.
-* <%= pill "USERS", "users" %> display secondary user emails.
-
+<%= api_parity_tables %>


### PR DESCRIPTION
Proposing some usability and styling improvements to make the API parity page. I used a common design pattern similar to comparison tables.

Also uses a yaml file to manage the comparison data.

## Screenshots

### Before

Listing REST and GraphQL differences in two separate sections using list.

<img width="341" alt="Screen Shot 2022-07-30 at 12 12 48 am" src="https://user-images.githubusercontent.com/7202667/181778753-053ae9ac-c576-4ee4-b821-3d3c67c60ac0.png">

### After

Using a comparison table.

<img width="1170" alt="Screen Shot 2022-07-30 at 12 13 53 am" src="https://user-images.githubusercontent.com/7202667/181778948-372a2aae-dc85-41b7-b827-79cec71614f7.png">

A sticky table header persists so the REST and GraphQL table headers are always visible for reference.

<img width="1364" alt="Screen Shot 2022-07-30 at 12 15 20 am" src="https://user-images.githubusercontent.com/7202667/181779275-e9844d55-c9b3-432d-979a-0e762683030b.png">

## Tested in popular browsers

Manually tested on my macOS.

### Chrome

<img width="487" alt="Screen Shot 2022-07-30 at 12 16 35 am" src="https://user-images.githubusercontent.com/7202667/181779553-71ebe522-9a17-4a75-a4d9-3c24b4b4223b.png">

### Safari

<img width="1406" alt="Screen Shot 2022-07-30 at 12 17 07 am" src="https://user-images.githubusercontent.com/7202667/181779664-ce0152e6-8f71-4ff4-b36f-23358e04b120.png">

<img width="636" alt="Screen Shot 2022-07-30 at 12 17 27 am" src="https://user-images.githubusercontent.com/7202667/181779750-7eed2fdc-192b-4fe8-9f90-7f3961e9b85c.png">

### Firefox

<img width="1496" alt="Screen Shot 2022-07-30 at 12 18 18 am" src="https://user-images.githubusercontent.com/7202667/181779908-98103eb7-d67f-419d-a8c3-08a983015b9d.png">

<img width="455" alt="Screen Shot 2022-07-30 at 12 18 50 am" src="https://user-images.githubusercontent.com/7202667/181780005-e8f73bb5-5c93-4879-96d0-205fbd8e7331.png">

