### PR TITLE
Keep render previews for 2 days after the last commit instead of 5

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@
 # Schema documented at https://render.com/docs/yaml-spec
 #
 previewsEnabled: true
-previewsExpireAfterDays: 5
+previewsExpireAfterDays: 2
 services:
   - type: web # valid values: https://render.com/docs/yaml-spec#type
     name: buildkite-docs-review


### PR DESCRIPTION
To bring the cost of inactive open PRs down. If it's annoying we can revert. 