### PR TITLE
Use tidier GPG key download command on Debian/Ubuntu

### DIFF
--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -27,7 +27,7 @@ Now you can add our signed apt repository. The default version of the agent is `
 Download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
 
 ```shell
-wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
 Then add the signed source to your apt sources list:

--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -27,7 +27,7 @@ Now you can add our signed apt repository. The default version of the agent is `
 Download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
 
 ```shell
-curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo tee /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
 Then add the signed source to your apt sources list:

--- a/pages/agent/v3/ubuntu.md.erb
+++ b/pages/agent/v3/ubuntu.md.erb
@@ -11,7 +11,7 @@ First, add our signed apt repository. The default version of the agent is `stabl
 Next, download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):
 
 ```shell
-wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | tee /tmp/buildkite-agent-archive-keyring.gpg && sudo bash -c "cat /tmp/buildkite-agent-archive-keyring.gpg | gpg --dearmor > /usr/share/keyrings/buildkite-agent-archive-keyring.gpg"
+curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
 Then add the signed source to your list of apt sources:


### PR DESCRIPTION
I was setting up the agent for the first time today, using the Ubuntu install instructions, and felt somewhat confused/intimidated by the fairly involved set of commands we had in place for downloading the GPG key for our apt repo:

```
wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | tee /tmp/buildkite-agent-archive-keyring.gpg && sudo bash -c "cat /tmp/buildkite-agent-archive-keyring.gpg | gpg --dearmor > /usr/share/keyrings/buildkite-agent-archive-keyring.gpg"
```

Fortunately, I'd also just followed Docker's [Ubuntu install instructions](https://docs.docker.com/engine/install/ubuntu/), which included a much more concise command for doing the same:

```
curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
```

I thought it might be helpful to copy across to our docs too 😄 

Here's what's actually different:

1. We eliminate spurious output by using `curl -fsS` instead of `wget -O` (see bottom for examples)
2. We write the GPG key directly to its intended location rather than to a temporary file first

Interestingly, on Debian we write the downloaded GPG fingerprint immediately to the target file, but on Ubuntu we run it through `gpg --dearmor -o` first. These two processes definitely result in different files. The former is plain text, while the latter is a binary file with this type: `OpenPGP Public Key Version 4, Created Tue Jan 27 06:25:14 2015, RSA (Encrypt or Sign, 2048 bits); User ID; Signature; OpenPGP Certificate`.

---

<details>
<summary>Command output when running <code>wget -O-</code></summary>

```
--2022-08-04 07:31:56--  https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198
Resolving keys.openpgp.org (keys.openpgp.org)... 2a00:c6c0:0:154:1::1, 37.218.245.50
Connecting to keys.openpgp.org (keys.openpgp.org)|2a00:c6c0:0:154:1::1|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1676 (1.6K) [application/pgp-keys]
Saving to: ‘STDOUT’

-                                                 0%[                                                                                                      ]       0  --.-KB/s               -----BEGIN PGP PUBLIC KEY BLOCK-----

xsBNBFTHL0oBCADvaU++EoRRDk4KIOmD7ckUflNla3zF1As3WLD2iR8SdnlqZvgX
GuX0PyjTzFerS0eYO+0dyj8MqjrCH39N83Mj3hEfXCQdCO/wnzOZytmuowR0hg8T
4ESy/84TXnoXo+c7S+1a2Wz0IX9jrf390hKa70uSTvQ20CBbdiGI7JmoqiBGE1Ve
WWWY+utjEznY2HKrPRU6tBJbEH8laAqnJQra/nIGNQJ5iUZU+be0Q6DUvVDrsg50
t4zgBoJ6g/yEuWdkP2DwaYdd1RA5EGTNYr4xuYYAK6h/3HCcSSHef3eYDPzH0UUE
v7ttlnaXvMREhKsgsD0xb8kCyFnRqJf9TKDXABEBAAHNHUJ1aWxka2l0ZSA8ZGV2
QGJ1aWxka2l0ZS5jb20+wsB3BBMBCgAhBQJUxy9KAhsDBQsJCAcDBRUKCQgLBRYD
AgEAAh4BAheAAAoJEKeSBmlkUtGYqk4H/jIEqQZN8ILAH4eukwn3wejUZte+gAdm
rQJ0rxwtmYlR3/dKZ4npnir1h30rUBncaB3lYIH1zyJk9ZbbnmmXQG/FuHY81qIY
B6xdmBnQJK4OrKR8SMN3E/jDfefykK+BBtv8wOMfKLgaoJTPGbfoX0BdVj4rHta8
kGVFgiKcmFRwozUi/oqBRTgd6z7kbQksoEcZp7zG7bO/8HuagwtYZJzF3x2UxAiF
hLwcj+pGva/I8VzQWjUn0YHZhT/T66arMwvoGOq1OuHXGVr+j9c1p77BNuq6JLE3
zcf7/N7ipwtzM6lIxC+ulh9eLnE3tmkEwBUfUK4hd5lCStT5GJ5ox+vOwE0EVMcv
SgEIAKq7uI9/+MBbtEjxdbupGicqY3D3FaLzh1xR7to0znfpgOUTLySPGleKtFZe
sIIPj/UXIdSeS99gzvn35lIWfUnLjfqBb2odfLOoPmqWGFp3G2K72Cm53139yZWy
bWSgBaFtRx7otnY5g6Wmd0pmFQcNRGdYgEDp/Bxz4pTuQKLMInsU9eujXLRaJSQp
/8gaAGI/alsTkrQ6g1NxZuw1pomiKdQ6dNAVYp4Mjs8FPPNLfR3GNrZwdkOWt4MY
eXm7nQpf8SSyomqWg+GGPktCSJ21e/WQxtWzSURol7BsgXQlhcPuMCmwBiTdP+nx
A7qGsI420H+Ee0bvRzBvAB5SBKUAEQEAAcLAXwQYAQoACQUCVMcvSgIbDAAKCRCn
kgZpZFLRmAV1B/9iBTgld2tnxJZAcuUo88Lw9S1gZ600rwsmPnTOqrNpalVnd2Ac
9ue6jfkFyr6AGc+tXzsAkb0hJy8xu49qDFHqoGDBaAri7Q1tmfeLJ3h209TXQqzo
m/myWsSIB+pKvbq8LNj202Idsc+K4mIdhjCXLqJWp1XYWAag5PkM6/yBKIckaz8U
IM+SFKOxCAFHC02Wezl6v6jUnodUQxhIQ3pVF3NJFf41DShbtrInG8wc3XwSOcQ2
q75ifcZdHTSdzmJhWQToMlr0Ii7qc1g0et6iNxtZ3FVyr2S2+aVtJ3oDUxtbZoib
96C4AcFesjihZv++ChVBBLBoED8FwNXIvxV6
=QZjb
-----END PGP PUBLIC KEY BLOCK-----
-                                               100%[=====================================================================================================>]   1.64K  --.-KB/s    in 0s

2022-08-04 07:31:59 (663 MB/s) - written to stdout [1676/1676]
```
</details>

<details>
<summary>Command output when running <code>curl -fsS</code> (much cleaner!)</summary>

```
-----BEGIN PGP PUBLIC KEY BLOCK-----

xsBNBFTHL0oBCADvaU++EoRRDk4KIOmD7ckUflNla3zF1As3WLD2iR8SdnlqZvgX
GuX0PyjTzFerS0eYO+0dyj8MqjrCH39N83Mj3hEfXCQdCO/wnzOZytmuowR0hg8T
4ESy/84TXnoXo+c7S+1a2Wz0IX9jrf390hKa70uSTvQ20CBbdiGI7JmoqiBGE1Ve
WWWY+utjEznY2HKrPRU6tBJbEH8laAqnJQra/nIGNQJ5iUZU+be0Q6DUvVDrsg50
t4zgBoJ6g/yEuWdkP2DwaYdd1RA5EGTNYr4xuYYAK6h/3HCcSSHef3eYDPzH0UUE
v7ttlnaXvMREhKsgsD0xb8kCyFnRqJf9TKDXABEBAAHNHUJ1aWxka2l0ZSA8ZGV2
QGJ1aWxka2l0ZS5jb20+wsB3BBMBCgAhBQJUxy9KAhsDBQsJCAcDBRUKCQgLBRYD
AgEAAh4BAheAAAoJEKeSBmlkUtGYqk4H/jIEqQZN8ILAH4eukwn3wejUZte+gAdm
rQJ0rxwtmYlR3/dKZ4npnir1h30rUBncaB3lYIH1zyJk9ZbbnmmXQG/FuHY81qIY
B6xdmBnQJK4OrKR8SMN3E/jDfefykK+BBtv8wOMfKLgaoJTPGbfoX0BdVj4rHta8
kGVFgiKcmFRwozUi/oqBRTgd6z7kbQksoEcZp7zG7bO/8HuagwtYZJzF3x2UxAiF
hLwcj+pGva/I8VzQWjUn0YHZhT/T66arMwvoGOq1OuHXGVr+j9c1p77BNuq6JLE3
zcf7/N7ipwtzM6lIxC+ulh9eLnE3tmkEwBUfUK4hd5lCStT5GJ5ox+vOwE0EVMcv
SgEIAKq7uI9/+MBbtEjxdbupGicqY3D3FaLzh1xR7to0znfpgOUTLySPGleKtFZe
sIIPj/UXIdSeS99gzvn35lIWfUnLjfqBb2odfLOoPmqWGFp3G2K72Cm53139yZWy
bWSgBaFtRx7otnY5g6Wmd0pmFQcNRGdYgEDp/Bxz4pTuQKLMInsU9eujXLRaJSQp
/8gaAGI/alsTkrQ6g1NxZuw1pomiKdQ6dNAVYp4Mjs8FPPNLfR3GNrZwdkOWt4MY
eXm7nQpf8SSyomqWg+GGPktCSJ21e/WQxtWzSURol7BsgXQlhcPuMCmwBiTdP+nx
A7qGsI420H+Ee0bvRzBvAB5SBKUAEQEAAcLAXwQYAQoACQUCVMcvSgIbDAAKCRCn
kgZpZFLRmAV1B/9iBTgld2tnxJZAcuUo88Lw9S1gZ600rwsmPnTOqrNpalVnd2Ac
9ue6jfkFyr6AGc+tXzsAkb0hJy8xu49qDFHqoGDBaAri7Q1tmfeLJ3h209TXQqzo
m/myWsSIB+pKvbq8LNj202Idsc+K4mIdhjCXLqJWp1XYWAag5PkM6/yBKIckaz8U
IM+SFKOxCAFHC02Wezl6v6jUnodUQxhIQ3pVF3NJFf41DShbtrInG8wc3XwSOcQ2
q75ifcZdHTSdzmJhWQToMlr0Ii7qc1g0et6iNxtZ3FVyr2S2+aVtJ3oDUxtbZoib
96C4AcFesjihZv++ChVBBLBoED8FwNXIvxV6
=QZjb
-----END PGP PUBLIC KEY BLOCK-----
```
</details>