### PR TITLE
🔥 No need to specify image sizes

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -74,14 +74,12 @@ $color-green: rgb(3, 165, 98);
   h3 + p { margin-top: 0; }
   h4 { font-size: 1rem; font-weight: 600; }
   h5 { font-size: .9rem; font-weight: 600; }
-  img.no-decoration, .responsive-image-container.no-decoration { padding: 0; border: none; margin: 0; }
+  img.no-decoration { padding: 0; border: none; margin: 0; }
   img.emoji { padding: 0; border: none; }
   hr + h2 { margin-top: 0; }
   th { font-weight:600; }
   thead th { font-weight: 600; }
   .image, img { max-width: 100%; }
-  .responsive-image-container { margin: .5rem 0 2rem 0; }
-  li .responsive-image-container { margin: .5rem 0 0 0; }
 }
 
 .Docs__article .Docs__api-param-eg {

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -79,7 +79,10 @@ $color-green: rgb(3, 165, 98);
   hr + h2 { margin-top: 0; }
   th { font-weight:600; }
   thead th { font-weight: 600; }
-  .image, img { max-width: 100%; }
+  .image, img {
+    height: auto;
+    max-width: 100%;
+  }
   .image-container {
     margin-bottom: 1rem;
     margin-top: 1rem;

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -80,6 +80,10 @@ $color-green: rgb(3, 165, 98);
   th { font-weight:600; }
   thead th { font-weight: 600; }
   .image, img { max-width: 100%; }
+  .image-container {
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+  }
 }
 
 .Docs__article .Docs__api-param-eg {

--- a/app/assets/stylesheets/public/utils/_responsive_image_container.scss
+++ b/app/assets/stylesheets/public/utils/_responsive_image_container.scss
@@ -1,7 +1,0 @@
-.responsive-image-container {
-  max-width: 100%;
-  img {
-    height: auto;
-    max-width: 100%;
-  }
-}

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -24,7 +24,7 @@ class Page
         args[:height] = height
       end
 
-      content_tag :div, @view_helpers.image_tag(image_url(name), args)
+      content_tag :div, @view_helpers.image_tag(image_url(name), args), :class => "image-container"
     end
 
     def image_url(name)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -24,16 +24,7 @@ class Page
         args[:height] = height
       end
 
-      if args.include?(:width) && args.include?(:height)
-        args[:max_width] = args[:width]
-
-        responsive_image_tag(image_url(name),
-                             args[:width],
-                             args[:height],
-                             args.except(:width, :height))
-      else
-        @view_helpers.image_tag(image_url(name), args)
-      end
+      content_tag :div, @view_helpers.image_tag(image_url(name), args)
     end
 
     def image_url(name)
@@ -69,17 +60,6 @@ class Page
                end
 
       Page::Renderer.render(text).html_safe
-    end
-
-    def responsive_image_tag(image, width, height, image_tag_options={}, &block)
-      max_width = image_tag_options.delete(:max_width)
-      container = content_tag :div, image_tag(image, image_tag_options), class: ["responsive-image-container", image_tag_options[:class]]
-
-      if max_width
-        content_tag :div, container, style: "max-width: #{max_width}px", class: image_tag_options[:class]
-      else
-        container
-      end
     end
   end
 

--- a/styleguide/STYLE.md
+++ b/styleguide/STYLE.md
@@ -455,8 +455,8 @@ This information was aggregated by going over the existing screenshots in the do
 
 ### Taking and processing screenshots
 * **Format:** PNG
-* **Ratio:** arbitrary, but **strictly even number of pixels** for both height and width. Recommended size `width: 1024px, height: 880px` when you're taking a full-width screen
-* **Size:** the largest possible resolution that makes sense. It's preferable that you take the screenshots on a Mac laptop with a Retina screen using Safari. Images should be exported at double (`@2x`) the original screen. Recommended dimension is `width: 2048/2, height: 880/2` to get the best possible view across different screen sizes.
+* **Ratio:** arbitrary, Recommended size `width: 1024px, height: 880px` when you're taking a full-width screen
+* **Size:** the largest possible resolution that makes sense
 * **No feature flag:** please remember to turn off all experimental features when taking screenshots
 * **Border:** no border
 * **Drop shadow:** no
@@ -468,14 +468,11 @@ This information was aggregated by going over the existing screenshots in the do
 * **Naming screenshots:** lowercase, words separated by hyphens; number after the title, for example, "installation-1"
 
 ### Adding screenshots or other images
-> Before you proceed, make sure that both the width and the height of the image are an even number of pixels!
-
 Steps for adding add an image to a documentation page:
 1. Name the image file (lowercase, separate words using hyphens; add a number to the filename, for example, 'installation-1' if you are adding several images to the same page)
 2. Put the file into the corresponding `images` folder (a folder with the same name as the page you are adding this image to; create such folder if it doesn't exist yet)
 3. Compose relevant alt text for the image file using Title case
-4. Add your image file to the documentation page using the following code example `<%= image "your-image.png", width: 1110, height: 1110, alt: "Screenshot of Important Feature" %>`.
-For large images/screenshots taken on a retina screen, use `<%= image "your-image.png", width: 1110/2, height: 1110/2, alt: "Screenshot of Important Feature" %>`.
+4. Add your image file to the documentation page using the following code example `<%= image "your-image.png", alt: "Screenshot of Important Feature" %>`
 
 ## GraphQL API schemas
 


### PR DESCRIPTION
To improve the technical writing experience (WX 😋) for adding screenshots, I propose to simply not include the `width` and `height` arguments in the image render methods.

In this PR, I've made the following changes:

1. Removed screenshot instructions relating to size attributes in `STYLE.md`
2. Removed code relating to `.responsive-image-container`

I don't see the a lot of UX value in `.responsive-image-container`. After looking at the stylesheets and the method in `page.rb`, all it's doing is apply a `max-width` to contain the image.

All `img` tags already have the standard responsive styling applied (i.e. `max-width: 100%;`) so it won't break mobile view.

For upcoming work I'd like to do the following:

- Fixed page container, so images (as well as other page elements) will fit nicely into the page for better legibility
- Proper retina image handling: so we can upload a @2x size image and then use something like `srcset` to render the image file for the right image density
 
We also don't need to remove width and height for existing images.

## Screenshots 

<img width="1078" alt="Screen Shot 2022-08-11 at 3 18 26 pm" src="https://user-images.githubusercontent.com/7202667/184068859-2dcd5882-501b-471d-8fed-1cf121857fe5.png">

<img width="373" alt="Screen Shot 2022-08-11 at 3 19 05 pm" src="https://user-images.githubusercontent.com/7202667/184068909-005b1ef4-cd8c-48c3-87f1-2d33430c7786.png">

