### PR TITLE
Fixing bad query in cookbook

### DIFF
--- a/pages/apis/graphql/graphql_cookbook.md.erb
+++ b/pages/apis/graphql/graphql_cookbook.md.erb
@@ -110,7 +110,7 @@ query {
 
 ## Get all jobs in a given queue for a given timeframe
 
-Get all jobs in a named queue, created on or after a given date. Note that if you want all jobs in the default queue, you do not need to set a queue name, so can omit the `agentQueryRules` option.
+Get all jobs in a named queue, created on or after a given date. Note that if you want all jobs in the default queue, you do not need to set a queue name, so you can omit the `agentQueryRules` option.
 
 
 ```graphql

--- a/pages/apis/graphql/graphql_cookbook.md.erb
+++ b/pages/apis/graphql/graphql_cookbook.md.erb
@@ -110,7 +110,7 @@ query {
 
 ## Get all jobs in a given queue for a given timeframe
 
-Get all jobs in a named queue, created on or after a given date. Note that if you want all jobs in the default queue, you do not need to set a queue name, so can omit the `agentQueryRules` option. `createdAtFrom` is a parameter provided by the Buildkite GraphQL API. It takes an ISO-8601 encoded UTC date string.
+Get all jobs in a named queue, created on or after a given date. Note that if you want all jobs in the default queue, you do not need to set a queue name, so can omit the `agentQueryRules` option.
 
 
 ```graphql
@@ -124,7 +124,7 @@ query PipelineRecentBuildLastJobQueue {
             edges {
               node {
                 number
-                jobs(state: FINISHED, first: 1, agentQueryRules: "queue=queue-name", createdAtFrom: "DateTime") {
+                jobs(state: FINISHED, first: 1, agentQueryRules: "queue=queue-name") {
                   edges {
                     node {
                       ... on JobTypeCommand {


### PR DESCRIPTION
Current query is giving below error when used:

```
 "errors": [
    {
      "message": "Field 'jobs' doesn't accept argument 'createdAtFrom'",
      "locations": [
        {
          "line": 11,
          "column": 86
        }
      ],
```
This error is because "createdAtFrom" is not a valid field for jobs object as we can see from documentation here https://buildkite.com/user/graphql/documentation/type/Build

This PR is to fix this bad query