### PR TITLE
Add note about not supporting gitlab commit status

### DIFF
--- a/pages/integrations/gitlab.md.erb
+++ b/pages/integrations/gitlab.md.erb
@@ -39,4 +39,4 @@ If you host your repositories on [gitlab.com](https://gitlab.com/) enter your gi
 
 ## Commit statuses
 
-We don't support updating commit statuses on GitLab at the moment. Please get in touch with us at support@buildkite.com if you like this feature.
+Updating commit statuses on GitLab is not supported at the moment. If you would like this feature to be added at some point, please let us know at support@buildkite.com.

--- a/pages/integrations/gitlab.md.erb
+++ b/pages/integrations/gitlab.md.erb
@@ -36,3 +36,7 @@ If you host your repositories on [gitlab.com](https://gitlab.com/) enter your gi
 ## Build skipping
 
 <%= render_markdown partial: 'integrations/build_skipping' %>
+
+## Commit statuses
+
+We don't support updating commit statuses on GitLab at the moment. Please get in touch with us at support@buildkite.com if you like this feature.


### PR DESCRIPTION
We've had a few support questions about gitlab commit statuses but unfortunately, we don't support them at the moment. So this is to clarify that.

I'm not sure if we want to put any reason or other information in here though