### PR TITLE
update the step flag explanation

### DIFF
--- a/pages/agent/v3/help/_artifact_download.md
+++ b/pages/agent/v3/help/_artifact_download.md
@@ -54,7 +54,7 @@ You can also use the step&#39;s jobs id (provided by the environment variable $B
 <!-- vale off -->
 
 <table class="Docs__attribute__table">
-<tr id="step"><th><code>--step value</code> <a class="Docs__attribute__link" href="#step">#</a></th><td><p>Scope the search to a particular step by using either its name or job ID<br /><strong>Environment variable</strong>: <code></code></p></td></tr>
+<tr id="step"><th><code>--step value</code> <a class="Docs__attribute__link" href="#step">#</a></th><td><p>Scope the search to a particular step by using either its label, key or job ID<br /><strong>Environment variable</strong>: <code></code></p></td></tr>
 <tr id="build"><th><code>--build value</code> <a class="Docs__attribute__link" href="#build">#</a></th><td><p>The build that the artifacts were uploaded to<br /><strong>Environment variable</strong>: <code>$BUILDKITE_BUILD_ID</code></p></td></tr>
 <tr id="include-retried-jobs"><th><code>--include-retried-jobs </code> <a class="Docs__attribute__link" href="#include-retried-jobs">#</a></th><td><p>Include artifacts from retried jobs in the search<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS</code></p></td></tr>
 <tr id="agent-access-token"><th><code>--agent-access-token value</code> <a class="Docs__attribute__link" href="#agent-access-token">#</a></th><td><p>The access token used to identify the agent<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_ACCESS_TOKEN</code></p></td></tr>

--- a/pages/agent/v3/help/_artifact_download.md
+++ b/pages/agent/v3/help/_artifact_download.md
@@ -54,7 +54,7 @@ You can also use the step&#39;s jobs id (provided by the environment variable $B
 <!-- vale off -->
 
 <table class="Docs__attribute__table">
-<tr id="step"><th><code>--step value</code> <a class="Docs__attribute__link" href="#step">#</a></th><td><p>Scope the search to a particular step by using either its label, key or job ID<br /><strong>Environment variable</strong>: <code></code></p></td></tr>
+<tr id="step"><th><code>--step value</code> <a class="Docs__attribute__link" href="#step">#</a></th><td><p>Scope the search to a particular step by using either its label, key, or job ID<br /><strong>Environment variable</strong>: <code></code></p></td></tr>
 <tr id="build"><th><code>--build value</code> <a class="Docs__attribute__link" href="#build">#</a></th><td><p>The build that the artifacts were uploaded to<br /><strong>Environment variable</strong>: <code>$BUILDKITE_BUILD_ID</code></p></td></tr>
 <tr id="include-retried-jobs"><th><code>--include-retried-jobs </code> <a class="Docs__attribute__link" href="#include-retried-jobs">#</a></th><td><p>Include artifacts from retried jobs in the search<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS</code></p></td></tr>
 <tr id="agent-access-token"><th><code>--agent-access-token value</code> <a class="Docs__attribute__link" href="#agent-access-token">#</a></th><td><p>The access token used to identify the agent<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_ACCESS_TOKEN</code></p></td></tr>


### PR DESCRIPTION
Currently it states step name but there is no concept of name for a step. It should be either step label, key or job id which needs to be used as input to --step flag.