### PR TITLE
Add missing documentation on span objects 'detail' attribute

### DIFF
--- a/app/models/test_analytics_json.rb
+++ b/app/models/test_analytics_json.rb
@@ -1,5 +1,6 @@
 TEST_ANALYTICS_JSON = {
   "history" => YAML.load_file('data/test_analytics_json_fields_history.yaml'),
   "span" => YAML.load_file('data/test_analytics_json_fields_span.yaml'),
-  "test_result" => YAML.load_file('data/test_analytics_json_fields_test_result.yaml')
+  "test_result" => YAML.load_file('data/test_analytics_json_fields_test_result.yaml'),
+  "detail" => YAML.load_file('data/test_analytics_json_fields_detail.yaml')
 }.freeze

--- a/data/test_analytics_json_fields_detail.yaml
+++ b/data/test_analytics_json_fields_detail.yaml
@@ -13,23 +13,23 @@ fields:
     - OPTIONS
     - TRACE
   desc: |
-      A HTTP request method (required if parent span has a 'section' of 'http')
+      A HTTP request method (required if parent span has a `section` of `http`)
   examples:
 - name: url
   required: false
   type: string
   desc: |
-      The URL requested (required if parent span has a 'section' of 'http')
+      The URL requested (required if parent span has a `section` of `http`)
   examples:
 - name: lib
   required: false
   type: string
   desc: |
-     The library used to make the HTTP request (required if parent span has a 'section' of 'http')
+     The library used to make the HTTP request (required if parent span has a `section` of `http`)
   examples:
 - name: query
   required: false
   type: string
   desc: |
-     The SQL query (required if parent span has a 'section' of 'sql')
+     The SQL query (required if parent span has a `section` of `sql`)
   examples:

--- a/data/test_analytics_json_fields_detail.yaml
+++ b/data/test_analytics_json_fields_detail.yaml
@@ -1,0 +1,35 @@
+fields:
+- name: method
+  required: false
+  type: string
+  enumerated_values:
+    - GET
+    - POST
+    - PUT
+    - DELETE
+    - PATCH
+    - HEAD
+    - CONNECT
+    - OPTIONS
+    - TRACE
+  desc: |
+      A HTTP request method (required if parent span has a 'section' of 'http')
+  examples:
+- name: url
+  required: false
+  type: string
+  desc: |
+      The URL requested (required if parent span has a 'section' of 'http')
+  examples:
+- name: lib
+  required: false
+  type: string
+  desc: |
+     The library used to make the HTTP request (required if parent span has a 'section' of 'http')
+  examples:
+- name: query
+  required: false
+  type: string
+  desc: |
+     The SQL query (required if parent span has a 'section' of 'sql')
+  examples:

--- a/data/test_analytics_json_fields_span.yaml
+++ b/data/test_analytics_json_fields_span.yaml
@@ -31,6 +31,6 @@ fields:
 - name: detail
   required : false
   desc: |
-      A detail object containing further details on the span. Required when 'section' is 'http', or 'sql'.
+      A detail object containing further details on the span. Required when `section` is `http`, or `sql`.
       Read [Detail objects](/docs/test-analytics/importing-json#json-test-results-data-reference-detail-objects)
   examples:

--- a/data/test_analytics_json_fields_span.yaml
+++ b/data/test_analytics_json_fields_span.yaml
@@ -28,3 +28,9 @@ fields:
   desc: |
       How long the span took to run
   examples:
+- name: detail
+  required : false
+  desc: |
+      A detail object containing further details on the span. Required when 'section' is 'http', or 'sql'.
+      Read [Detail objects](/docs/test-analytics/importing-json#json-test-results-data-reference-detail-objects)
+  examples:

--- a/pages/test_analytics/importing_json.md.erb
+++ b/pages/test_analytics/importing_json.md.erb
@@ -133,10 +133,10 @@ Schematically, the JSON test results data is like this:
 <!-- markdownlint-capture -->
 <!-- markdownlint-disable MD007 -->
 
-* A test result array of:
-   - [Test result](#json-test-results-data-reference-test-result-objects)
-      * [History](#json-test-results-data-reference-history-objects)
-         - [Spans](#json-test-results-data-reference-span-objects)
+- [Test results](#json-test-results-data-reference-test-result-objects)
+   + [History](#json-test-results-data-reference-history-objects)
+       - [Spans](#json-test-results-data-reference-span-objects)
+         + [Detail](#json-test-results-data-reference-detail-objects)
 
 <!-- markdownlint-restore -->
 
@@ -315,5 +315,56 @@ It represents, for example, the duration of an individual database query within 
   "start_at": 347611.734956,
   "end_at": 347611.735647,
   "duration": 0.0006910000229254365
+  "detail": {
+    ...
+  }
 }
 ```
+
+### Detail objects
+
+Detail objects contains additional information about the span.
+
+<table class="responsive-table">
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% TEST_ANALYTICS_JSON['detail']['fields'].each do |field| -%>
+      <tr>
+        <td><code><%= field['name'] %></code> <%= '(required)' if field['required'] %></td>
+        <td><%= field['type'] %> <%= render_enumerated_values(field['enumerated_values']) %></td>
+        <td>
+          <%= render_markdown(text: field['desc']) %>
+        </td>
+      </tr>
+    <% end -%>
+  </tbody>
+</table>
+
+**HTTP Example:**
+
+```js
+{
+  "detail": {
+    method: "POST",
+    url: "https://example.com",
+    lib: "curl
+  }
+}
+```
+
+**SQL Example:**
+
+```js
+{
+  "detail": {
+    query: "SELECT * FROM ..."
+  }
+}
+```
+


### PR DESCRIPTION
PIE-1010

The docs are missing attributes for span objects (for HTTP and SQL).

A customer reached out about this as they were trying to figure out how
to POST the URL, method, and library details to the span object.

Customer message
https://buildkite-community.slack.com/archives/C03HXN4ARB5/p1660262430972669?thread_ts=1660256140.870549&cid=C03HXN4ARB5

Relevant code
https://github.com/buildkite/buildkite/blob/1e04bd5774c1c54927d15668b35c9bdfeae479f9/app/models/analytics/execution/ingestion_result.rb#L123

Docs page
https://buildkite.com/docs/test-analytics/importing-json#json-test-results-data-reference-test-result-objects
