### PR TITLE
💄 Provide up to 6 levels of nesting for lists

### DIFF
--- a/app/assets/stylesheets/public/utils/_text_content.scss
+++ b/app/assets/stylesheets/public/utils/_text_content.scss
@@ -3,32 +3,62 @@
 
   h2, h3, h4, blockquote, pre, p, table { margin: 1rem 0; }
   h2 { font-size: #{(24/18)}rem; margin-top: 1.5em; }
-  li { margin: 0.5em 0 0.5em 1.8em; }
-  ol > li {
-    list-style: decimal;
 
-    ol > li {
+  li {
+    margin-bottom: .5em;
+    margin-top: .5em;
+  }
+
+  ol {
+    list-style: decimal;
+    padding-left: 30px;
+
+    ol {
       list-style: lower-alpha;
 
-      ol > li {
+      ol {
         list-style: lower-roman;
-        margin-left: 2em;
+
+        ol {
+          list-style: decimal;
+      
+          ol {
+            list-style: lower-alpha;
+      
+            ol {
+              list-style: lower-roman;
+            }
+          }
+        }
       }
     }
   }
 
-  ul li {
+  ul {
     list-style: disc;
-    margin-left: 1em;
+    padding-left: 30px;
 
-    ul > li {
+    ul {
       list-style: circle;
 
-      ul > li {
+      ul {
         list-style: square;
+
+        ul {
+          list-style: disc;
+      
+          ul {
+            list-style: circle;
+      
+            ul {
+              list-style: square;
+            }
+          }
+        }
       }
     }
   }
+
   li ul,
   li p { margin-bottom: 0.5em; }
 


### PR DESCRIPTION
Following up with https://github.com/buildkite/docs/pull/1698 I think occasionally we may need deeper nested lists. In light of this, I've added up to 6 levels of nested lists to the CSS.

Unfortunately, CSS doesn't do something like `nth-level` selector, I think JavaScript is an overkill, and good content design shouldn't need to go beyond 6 levels of list nesting.

<img width="754" alt="Screen Shot 2022-08-16 at 4 00 52 pm" src="https://user-images.githubusercontent.com/7202667/184808657-1fe3f630-7c20-4c42-a3b5-c5a47bbf0077.png">
