### PR TITLE
Add GraphQL example of setting multiple env vars

### DIFF
--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -1276,3 +1276,40 @@ mutation UpdateTeamPipelineReadonly {
   }
 }
 ```
+
+## Update multiple environment variables for a schedule
+
+This updates a schedules environment variables by using the new-line value "\n" as a delimiter.
+
+First, find the schedule's ID:
+
+```graphql
+query GetSchedules {
+  pipeline(slug: "organization/pipeline") {
+    schedules(first: 500) {
+      edges {
+        node {
+          id
+          label
+        }
+      }
+    }
+  }
+}
+```
+
+Then, use the ID to delete the user:
+
+```graphql
+mutation UpdateSchedule {
+  pipelineScheduleUpdate(input:{
+    id: "schedule-id"
+    env: "FOO=bar\nBAR=foo"
+  }) {
+    pipelineSchedule {
+      id
+      env
+    }
+  }
+}
+```

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -176,6 +176,24 @@ mutation PipelineDelete {
 }
 ```
 
+### Update pipeline schedule with multiple environment variables
+
+You can set multiple environment variables on a pipeline schedule by using the new-line value `\n` as a delimiter.
+
+```graphql
+mutation UpdateSchedule {
+  pipelineScheduleUpdate(input:{
+    id: "schedule-id"
+    env: "FOO=bar\nBAR=foo"
+  }) {
+    pipelineSchedule {
+      id
+      env
+    }
+  }
+}
+```
+
 ## Builds
 
 A collection of common tasks with builds using the GraphQL API.
@@ -403,7 +421,7 @@ mutation PipelineUpdate {
   nextBuildNumber: 300
   }) {
     pipeline {
-      name 
+      name
       nextBuildNumber
     }
   }
@@ -714,7 +732,7 @@ To obtain jobs within a cluster queue of a particular state, use the `clusterQue
 query getClusterQueueJobsByJobState {
   organization(slug: "organization-slug") {
     jobs(
-      first: 10, 
+      first: 10,
       clusterQueue: "cluster-queue-id",
       state: [WAITING, BLOCKED]
     ){
@@ -1242,7 +1260,7 @@ query TeamPipelineIDs {
     pipelines(first: 500) {
       edges {
         node {
-          id 
+          id
         }
       }
     }
@@ -1273,43 +1291,6 @@ mutation UpdateTeamPipelineReadonly {
       }
     }
     clientMutationId
-  }
-}
-```
-
-## Update multiple environment variables for a schedule
-
-This updates a schedules environment variables by using the new-line value "\n" as a delimiter.
-
-First, find the schedule's ID:
-
-```graphql
-query GetSchedules {
-  pipeline(slug: "organization/pipeline") {
-    schedules(first: 500) {
-      edges {
-        node {
-          id
-          label
-        }
-      }
-    }
-  }
-}
-```
-
-Then, use the ID to delete the user:
-
-```graphql
-mutation UpdateSchedule {
-  pipelineScheduleUpdate(input:{
-    id: "schedule-id"
-    env: "FOO=bar\nBAR=foo"
-  }) {
-    pipelineSchedule {
-      id
-      env
-    }
   }
 }
 ```


### PR DESCRIPTION
I had a question from a customer:

`AS the document shows PipelineScheduleUpdateInput has env: String not [String] . How can I update env with a list of variables such as env: [“bar=foo”, “var1"=“val1”, “var12"=“good”] ?`

Here's the mutation https://buildkite.com/user/graphql/console/2ad2ddd5-dd14-485c-b87d-af5751b3ec5b if you would like to check it out.

This probably applies to anything we take in as a String and separate with a new line - so there may be more opportunities.

Here is what the change looks like:

<img width="888" alt="Screen Shot 2022-08-16 at 4 17 11 pm" src="https://user-images.githubusercontent.com/585588/184815842-d0695b74-bfe6-4501-9ef9-5f122730e4df.png">

You may want to consider linking to this recipe or adding something in https://buildkite.com/docs/apis/graphql/schemas/pipelinescheduleupdateinput to let folks know.

Another thing - this is kinda hacky; a better alternative would be to have its value that accepts an Array. I am not sure if that is on the Product roadmap, but just a FYI.

