### PR TITLE
Fix webhooks overview overflow bug

### DIFF
--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -55,6 +55,7 @@ $color-green: rgb(3, 165, 98);
 .Docs__article {
   flex: 7;
   font-weight: 400;
+  overflow: hidden;
 
   @media (min-width: $screen-md) {
     margin-left: $sidebar-width + 30px;

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -94,6 +94,7 @@ $color-green: rgb(3, 165, 98);
     grid-template-columns: minmax(10px, 1fr) 250px;
     position: relative;
     gap: 30px;
+    grid-template-columns: 1fr $sidebar-width;
 
     &--is-landing-page {
       display: block;

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -60,6 +60,21 @@ $color-green: rgb(3, 165, 98);
     margin-left: $sidebar-width + 30px;
   }
 
+  @media (min-width: $screen-lg) { //TOC as side column on larger screens
+    display: grid;
+    grid-template-columns: minmax(10px, 1fr) 250px;
+    position: relative;
+    gap: 30px;
+
+    //overflow: scroll;
+    //min-width: 0px;
+
+
+    &--is-landing-page {
+      display: block;
+    }
+  }
+
   h1, h2, h3, h4, h5 {
     font-weight: bold;
     font-family: inherit;
@@ -86,23 +101,6 @@ $color-green: rgb(3, 165, 98);
 
 .Docs__article .Docs__api-param-eg {
   margin: .25em 0 0 0;
-}
-
-@media (min-width: $screen-lg) { //TOC as side column on larger screens
-  .Docs__article {
-    display: grid;
-    grid-template-columns: minmax(10px, 1fr) 250px;
-    position: relative;
-    gap: 30px;
-
-    //overflow: scroll;
-    //min-width: 0px;
-
-
-    &--is-landing-page {
-      display: block;
-    }
-  }
 }
 
 .Docs__note {

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -94,7 +94,6 @@ $color-green: rgb(3, 165, 98);
     grid-template-columns: minmax(10px, 1fr) 250px;
     position: relative;
     gap: 30px;
-    grid-template-columns: 1fr $sidebar-width;
 
     &--is-landing-page {
       display: block;

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -93,7 +93,6 @@ $color-green: rgb(3, 165, 98);
     display: grid;
     grid-template-columns: minmax(10px, 1fr) 250px;
     position: relative;
-    display: grid;
     gap: 30px;
     grid-template-columns: 1fr $sidebar-width;
 

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -55,7 +55,6 @@ $color-green: rgb(3, 165, 98);
 .Docs__article {
   flex: 7;
   font-weight: 400;
-  overflow: hidden;
 
   @media (min-width: $screen-md) {
     margin-left: $sidebar-width + 30px;

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -94,7 +94,10 @@ $color-green: rgb(3, 165, 98);
     grid-template-columns: minmax(10px, 1fr) 250px;
     position: relative;
     gap: 30px;
-    grid-template-columns: 1fr $sidebar-width;
+
+    //overflow: scroll;
+    //min-width: 0px;
+
 
     &--is-landing-page {
       display: block;

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -65,11 +65,7 @@ $color-green: rgb(3, 165, 98);
     grid-template-columns: minmax(10px, 1fr) 250px;
     position: relative;
     gap: 30px;
-
-    //overflow: scroll;
-    //min-width: 0px;
-
-
+    
     &--is-landing-page {
       display: block;
     }

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -61,12 +61,12 @@ $color-green: rgb(3, 165, 98);
     margin-left: $sidebar-width + 30px;
   }
 
-  @media (min-width: $screen-lg) { //TOC as side column on larger screens
+  @media (min-width: $screen-lg) { // TOC as side column on larger screens
     display: grid;
     grid-template-columns: minmax(10px, 1fr) 250px;
     position: relative;
     gap: 30px;
-    
+
     &--is-landing-page {
       display: block;
     }
@@ -94,6 +94,22 @@ $color-green: rgb(3, 165, 98);
   .image, img { max-width: 100%; }
   .responsive-image-container { margin: .5rem 0 2rem 0; }
   li .responsive-image-container { margin: .5rem 0 0 0; }
+
+  table.fixed-width {
+    // In general, the width of our tables within articles depends on the size of their content. This works great except
+    // when we have text such as a HTTP response snippet that includes a long unbroken string. When that happens, the
+    // table overflows outside of its bounding box and doesn't wrap or scroll nicely, causing text cropping. Use this
+    // "fixed-width" class for a table that won't overflow it's bounding box horizontally and forces text wrapping.
+
+    table-layout: fixed;
+    width: 100%;
+    th {
+      width: 25%;
+    }
+    tr {
+      width: 75%;
+    }
+  }
 }
 
 .Docs__article .Docs__api-param-eg {

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -162,6 +162,7 @@
           <li class="HomepageCategory__list-item"><%= link_to "Agent REST API", "/docs/apis/agent-api", class: 'HomepageCategory__list-item-link' %></li>
           <li class="HomepageCategory__list-item"><%= link_to "GraphQL API", "/docs/apis/graphql-api", class: 'HomepageCategory__list-item-link' %></li>
           <li class="HomepageCategory__list-item"><%= link_to "API tokens", "/docs/apis/managing-api-tokens", class: 'HomepageCategory__list-item-link' %></li>
+          <li class="HomepageCategory__list-item"><%= link_to "Webhooks", "/docs/apis/webhooks", class: 'HomepageCategory__list-item-link' %></li>
         </ul>
       </article>
       <article class="HomepageCategory">

--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -41,7 +41,7 @@ One of either the [Token](/docs/apis/webhooks#webhook-token) or [Signature](/doc
 
 Your selection in the _Webhook Notification service_ will determine which is sent:
 
-<table>
+<table class="fixed-width">
 <tbody>
   <tr><th><code>X-Buildkite-Token</code></th><td>The webhook's token. <p class="Docs__api-param-eg"><em>Example:</em> <code>309c9c842g8565adecpd7469x6005989</code></p></td></tr>
   <tr><th><code>X-Buildkite-Signature</code></th><td>The signature created from your webhook payload, webhook token, and the SHA-256 hash function.<p class="Docs__api-param-eg"><em>Example:</em> <code>timestamp=1619071700,signature=30222eb518dc3fb61ec9e64dd78d163f62cb134a6ldb768f1d40e0edbn6e43f0</code></p></td></tr>

--- a/styleguide/STYLE.md
+++ b/styleguide/STYLE.md
@@ -397,6 +397,18 @@ Line 3, column 1  | Line 3, column 2
 
 The `{: class="two-column"}` class added at the end of a two-column table is what allows the custom table style to work.
 
+#### Fixed-width tables
+To use a custom style for two column tables that include long text without whitespace that are rendered like the table in the [Webhooks HTTP headers](/docs/apis/webhooks#http-headers) section, use the following syntax:
+
+```
+Column header 1   | Column header 2
+----------------- | ----------------
+Line 1, column 1  | Line 1, column 2
+Line 2, column 1  | Line 2, column 2
+Line 3, column 1  | Line 3, column 2
+{: class="fixed-width"}
+```
+
 #### Responsive tables
 Append `{: class="responsive-table"}` to any table to render it with responsive behaviour. Use the following syntax:
 


### PR DESCRIPTION
Linear: https://linear.app/buildkite/issue/ONB-16/

Docs [Webhooks Overview page](https://buildkite.com/docs/apis/webhooks) content overflows to the right. This introduces a horizontal scrollbar where one is not expected or desired. Not identified on any other pages.

Impacting all viewport widths. Present with and without new nav banner.

<img width="1518" alt="Screen Shot 2022-09-06 at 11 36 00 am" src="https://user-images.githubusercontent.com/1191571/188805976-6a2f91b4-cbaa-4480-b88d-bdfd2f44e4ce.png">

Tracked root cause to the second HTTP headers table which has a long string of example text in it: `timestamp=1619071700,signature=30222eb518dc3fb61ec9e64dd78d163f62cb134a6ldb768f1d40e0edbn6e43f0` This doesn't have any whitespace in it and therefore isn't wrapping nicely

Tried a few options to fix, including adding spaces to the string (fixed the issue but traded off accuracy of the documentation) and trying unsuccessfully to get the text to wrap through various means. Landed on adding the option to make a table "fixed width". This forces the text to wrap.

This won't fix overflow in the future but gives us a tool to use when we encounter it without changing overall table design across docs, clipping content or reducing accuracy of documentation.

Fixed version:
<img width="1622" alt="Screen Shot 2022-09-07 at 4 44 48 pm" src="https://user-images.githubusercontent.com/1191571/188807858-24a51c02-c728-49e5-a10a-65ace9a1b2c6.png">

Also in this PR:
* Minor refactor to group media queries for `Docs__article` together. 
* Removed redundant CSS in `@media (min-width: $screen-lg)`
* Added Webhooks to API section of homepage
* Added `fixed-width` to styleguide

