### PR TITLE
H2 sentence-case linting (round 5)

### DIFF
--- a/pages/integrations/pagerduty.md.erb
+++ b/pages/integrations/pagerduty.md.erb
@@ -1,6 +1,6 @@
 # PagerDuty
 
-The [PagerDuty](http://pagerduty.com/) integration in Buildkite can send [Change Events](https://support.pagerduty.com/docs/change-events) to PagerDuty when your builds finish.
+The [PagerDuty](http://pagerduty.com/) integration in Buildkite can send [change events](https://support.pagerduty.com/docs/change-events) to PagerDuty when your builds finish.
 
 <%= image "overview.png", width: 2202/2, height: 638/2, alt: "Screenshot of the recent events in PagerDuty" %>
 
@@ -14,7 +14,7 @@ In [PagerDuty](http://pagerduty.com/), go to the "Service Directory":
 
 <%= image "menu.png", width: 854/2, height: 324/2, alt: "Screenshot of the Service Directory link in the menu" %>
 
-Then choose the service you'd like Buildkite to send Change Events to:
+Then choose the service you'd like Buildkite to send change events to:
 
 <%= image "service-item.png", width: 2842/2, height: 412/2, alt: "Screenshot of the chosen service in the Service Directory" %>
 
@@ -28,11 +28,11 @@ For "Integration Type", choose "Buildkite".
 
 Once you've filled out this form, select "Add Integration".
 
-Copy the "Integration Key" from your Integrations list and  use it in [Sending Change Events from your pipeline](#sending-change-events-from-your-pipeline).
+Copy the "Integration Key" from your Integrations list and  use it in [Sending change events from your pipeline](#sending-change-events-from-your-pipeline).
 
 <%= image "integration-with-key.png", width: 2262/2, height: 822/2, alt: "Screenshot of the Buildkite integration in PagerDuty" %>
 
-## Sending Change Events from your pipeline
+## Sending change events from your pipeline
 
 By default, after you've added an Integration API Key, Buildkite will send PagerDuty a Change Event every build regardless of whether the build passed or failed.
 
@@ -53,7 +53,7 @@ notify:
 
 <%= image "change-event.png", width: 2304/2, height: 1096/2, alt: "Screenshot of a Change Event inside PagerDuty sent from Buildkite" %>
 
-To send Change Events only when the build passes, add a [condition](/docs/pipelines/conditionals) to your build configuration:
+To send change events only when the build passes, add a [condition](/docs/pipelines/conditionals) to your build configuration:
 
 ```yaml
 notify:
@@ -63,4 +63,4 @@ notify:
 
 ## Support
 
-For those of you coming from [pagerduty.com](https://pagerduty.com) looking for assistance on this integration please reach out to us at [support@buildkite.com](mailto:support@buildkite.com?subject=PagerDuty%20Change%20Events%20Integration).
+For those of you coming from [the PagerDuty website](https://pagerduty.com) looking for assistance on this integration please reach out to us at [support@buildkite.com](mailto:support@buildkite.com?subject=PagerDuty%20Change%20Events%20Integration).

--- a/pages/integrations/sso/adfs.md.erb
+++ b/pages/integrations/sso/adfs.md.erb
@@ -33,7 +33,7 @@ With these wizards, you'll set up your domain for SSO and retrieve the informati
 <h3 class="Docs__note__heading">This guide was written for, and tested using, Windows Server 2016</h3>
 <p>Some of the wizard pages and dialog tab names have changed across versions of Windows Server.</p>
 
-<p>For a guide written for Windows Server 2012, the <a href="https://www.pagerduty.com/docs/guides/adfs-sso-guide/">Pagerduty SSO integration guide</a> is very similar to Buildkite. Follow the Pagerduty instructions, and substitute in the Buildkite values from the instructions below.</p>
+<p>For a guide written for Windows Server 2012, the <a href="https://www.pagerduty.com/docs/guides/adfs-sso-guide/">PagerDuty SSO integration guide</a> is very similar to Buildkite. Follow the PagerDuty instructions, and substitute in the Buildkite values from the instructions below.</p>
 </div>
 
 ### Step 2.1 Add a relying party trust

--- a/pages/pipelines/build_meta_data.md.erb
+++ b/pages/pipelines/build_meta_data.md.erb
@@ -37,9 +37,9 @@ Assuming that the "release-version" key was set with the value from the Setting 
 <p>The `get` command has a `default` flag. You can use this to return a value in the case that the key has not been set.</p>
 </div>
 
-## Using meta-data on the Dashboard
+## Using meta-data on the dashboard
 
-Meta-data is not widely exposed in the Buildkite Dashboard, but it can be added to most builds URLs to filter down the list of builds shown to only those with certain meta-data.
+Meta-data is not widely exposed in the Buildkite dashboard, but it can be added to most builds URLs to filter down the list of builds shown to only those with certain meta-data.
 
 To list builds in a pipeline which have a "release-version" of "1.1" you could use:
 

--- a/pages/pipelines/job_minutes.md.erb
+++ b/pages/pipelines/job_minutes.md.erb
@@ -22,9 +22,9 @@ The [Usage page](https://buildkite.com/organizations/~/usage) is available on ev
 
 <%= image "usage.png", width: 554, height: 794, alt: "Job minute usage page" %>
 
-## Limits for the Free plan
+## Limits for the free plan
 
-The Free plan has a limit of 10,000 job minutes per month. When this limit is reached, builds are not cancelled, but jobs will not be run. The limit is reset when your billing period rolls over, or your organization is upgraded to a different plan.
+The free plan has a limit of 10,000 job minutes per month. When this limit is reached, builds are not cancelled, but jobs will not be run. The limit is reset when your billing period rolls over, or your organization is upgraded to a different plan.
 
 
 ### Build timeouts

--- a/pages/pipelines/notifications.md.erb
+++ b/pages/pipelines/notifications.md.erb
@@ -329,9 +329,9 @@ Webhook notifications happen at the following [events](/docs/apis/webhooks#event
 * `build blocked`
 * `build finished`
 
-## PagerDuty Change Events
+## PagerDuty change events
 
-If you've set up a [PagerDuty integration](/docs/integrations/pagerduty) you can send Change Events from your pipeline using the `pagerduty_change_event` attribute of the `notify` YAML block:
+If you've set up a [PagerDuty integration](/docs/integrations/pagerduty) you can send change events from your pipeline using the `pagerduty_change_event` attribute of the `notify` YAML block:
 
 ```yaml
 steps:

--- a/pages/pipelines/permissions.md.erb
+++ b/pages/pipelines/permissions.md.erb
@@ -4,7 +4,7 @@ Customers on the Buildkite [Business and Enterprise](https://buildkite.com/prici
 
 {:toc}
 
-## Permissions with Teams
+## Permissions with teams
 
 Enabling Teams for your organizations gives you control over each pipeline's permissions in one place. Teams can be enabled from your Organization Settings in the Teams section.
 

--- a/vale/styles/Buildkite/existence-case-sensitive.yml
+++ b/vale/styles/Buildkite/existence-case-sensitive.yml
@@ -44,6 +44,7 @@ swap:
   (?i:Mac): Mac
   (?i:Markdown): Markdown
   (?i:NVMe): NVMe
+  (?i:PagerDuty): PagerDuty
   (?i:PowerShell): PowerShell
   (?i:Windows Subsystem for Linux 2): Windows Subsystem for Linux 2
   (?i:XCTest): XCTest

--- a/vale/styles/Buildkite/h2-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h2-h6_sentence_case.yml
@@ -46,6 +46,7 @@ exceptions:
   - macOS
   - Markdown
   - OpenTelemetry
+  - PagerDuty
   - PowerShell
   - Windows
   - Windows Subsystem for Linux 2


### PR DESCRIPTION
~~This PR has a little bit of overlap with https://github.com/buildkite/docs/pull/1730. It might be better to review that one first.~~

Cleaning up some branches revealed this being more or less ready to go. Fixes mostly the `pipelines` folder. Highlights:

- 📟 PagerDuty "change events" are not capitalized
- "Teams" is no longer capitalized in one heading. This will get us passing lint, though it doesn't make this consistent throughout ("Teams" versus "teams" is mixed up everywhere, including the UI).