### PR TITLE
Regularize test collector intros

### DIFF
--- a/pages/test_analytics/elixir_collectors.md.erb
+++ b/pages/test_analytics/elixir_collectors.md.erb
@@ -1,6 +1,6 @@
 # Elixir Collectors
 
-Test Analytics ships with a ExUnit test collector :github: [`test_collector_elixir`](https://github.com/buildkite/test_collector_elixir).
+To use Test Analytics with your Elixir projects use :github: [`test_collector_elixir`](https://github.com/buildkite/test_collector_elixir) with ExUnit.
 
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 

--- a/pages/test_analytics/golang_collectors.md.erb
+++ b/pages/test_analytics/golang_collectors.md.erb
@@ -1,6 +1,6 @@
 # Configuring Golang with Test Analytics
 
-To use Test Analytics with your Golang projects, generate JUnit XML files with [gotestsum](https://github.com/gotestyourself/gotestsum), and then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) to Test Analytics.
+To use Test Analytics with your Go language projects use [gotestsum](https://github.com/gotestyourself/gotestsum) to generate JUnit XML files, then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) to Test Analytics.
 
 {:notoc}
 

--- a/pages/test_analytics/javascript_collectors.md.erb
+++ b/pages/test_analytics/javascript_collectors.md.erb
@@ -1,6 +1,7 @@
 # JavaScript Collectors
 
-Test Analytics ships with a Jest test collector, and [more are coming soon](https://github.com/buildkite/test-collector-javascript/issues?q=is%3Aissue+is%3Aopen+label%3A%22test+frameworks%22).
+To use Test Analytics with your JavaScript (npm) projects use the :github: [`test-collector-javascript`](https://github.com/buildkite/test-collector-javascript) package with Jest.
+
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
 {:toc}

--- a/pages/test_analytics/python_collectors.md.erb
+++ b/pages/test_analytics/python_collectors.md.erb
@@ -1,6 +1,7 @@
 # Python Collectors
 
-Test Analytics collectors for Python are provided by the [`buildkite-test-collector`](https://pypi.org/project/buildkite-test-collector/) package.
+To use Test Analytics with your Python projects use the [`buildkite-test-collector`](https://pypi.org/project/buildkite-test-collector/) package with pytest.
+
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
 {:notoc}

--- a/pages/test_analytics/ruby_collectors.md.erb
+++ b/pages/test_analytics/ruby_collectors.md.erb
@@ -1,6 +1,6 @@
 # Ruby Collectors
 
-Test Analytics ships with Ruby collectors :github: [`test-collectors-ruby`](https://github.com/buildkite/test-collector-ruby).
+To use Test Analytics with your Ruby projects use the :github: [`test-collectors-ruby`](https://github.com/buildkite/test-collector-ruby) gem with RSpec or minitest.
 
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 

--- a/pages/test_analytics/rust_collectors.md.erb
+++ b/pages/test_analytics/rust_collectors.md.erb
@@ -1,6 +1,6 @@
 # Rust Collector
 
-Test Analytics ships with a Rust collector :github: [`test-collector-rust`](https://github.com/buildkite/test-collector-rust).
+To use Test Analytics with your Rust projects use the :github: [`test-collector-rust`](https://github.com/buildkite/test-collector-rust) package with `cargo test`.
 
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 

--- a/pages/test_analytics/swift_collectors.md.erb
+++ b/pages/test_analytics/swift_collectors.md.erb
@@ -1,6 +1,6 @@
 # Swift Collectors
 
-Test Analytics ships with Swift collectors :github: [`test-collector-swift`](https://github.com/buildkite/test-collector-swift), and [more coming soon](https://github.com/buildkite/test-collector-swift/labels/test%20framework).
+To use Test Analytics with your Swift projects use the :github: [`test-collector-swift`](https://github.com/buildkite/test-collector-swift) package with XCTest.
 
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 

--- a/pages/tutorials/parallel_builds.md.erb
+++ b/pages/tutorials/parallel_builds.md.erb
@@ -96,7 +96,7 @@ You can use these two environment variables to divide your application's tests b
 The following libraries have built-in support the `BUILDKITE_PARALLEL_JOB` and `BUILDKITE_PARALLEL_JOB_COUNT` environment variables:
 
 * [Knapsack](https://github.com/ArturT/knapsack)
-<br>Knapsack is a ruby gem for automatically dividing your tests between parallel jobs, as well as making sure each job runs in comparable time. It supports RSpec, Cucumber, and Minitest.
+<br>Knapsack is a ruby gem for automatically dividing your tests between parallel jobs, as well as making sure each job runs in comparable time. It supports RSpec, Cucumber, and minitest.
 
 * [Knapsack Pro](https://knapsackpro.com/?utm_source=buildkite&utm_medium=docs&utm_campaign=buildkite-parallel-builds)
 <br>A commercially supported version of Knapsack that provides a hosted service for test timing data and additional job distribution modes for Ruby, JavaScript, and more. See the [documentation](https://github.com/KnapsackPro/knapsack_pro-ruby#info-for-buildkitecom-users) and [step-by-step tutorial](http://docs.knapsackpro.com/2017/auto-balancing-7-hours-tests-between-100-parallel-jobs-on-ci-buildkite-example) for Ruby setup instructions and example pipelines. For other programming languages please check [integrations](https://docs.knapsackpro.com/integration/).

--- a/vale/styles/Buildkite/existence-case-sensitive.yml
+++ b/vale/styles/Buildkite/existence-case-sensitive.yml
@@ -48,3 +48,4 @@ swap:
   (?i:PowerShell): PowerShell
   (?i:Windows Subsystem for Linux 2): Windows Subsystem for Linux 2
   (?i:XCTest): XCTest
+  (?i:minitest): minitest


### PR DESCRIPTION
This is an incremental piece of DOC-369. It attempts to improve the collector intros for increased clarity (avoiding some nerdview around "shipping") and maintainability (making them look alike).

Unfortunately, collectors aren't very alike yet. There's four likely patterns available to collector docs authors:

## Pattern 1, with only one supported testing framework

> To use Test Analytics with your [language] projects use [link to package] with [testing framework].
>
> You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).

## Pattern 2, with two supported testing frameworks

> To use Test Analytics with your [language] projects use [link to package] with [testing framework 1] or [testing framework 2].
>
> You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).

## Pattern 3, with three or more supported testing frameworks

> To use Test Analytics with your [language] projects use [link to package] with:
> 
> - [testing framework 1]
> - [testing framework 2]
> - [testing framework …]
> - [testing framework n]
>
> You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).

## Pattern 4, with some custom approach

> To use Test Analytics with your [language] projects use [some specific language approach, probably swallowing up the next paragraph in the process].
>
> You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).