### PR TITLE
Hint that the webhook signature be generated off the request body

### DIFF
--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -83,7 +83,7 @@ Buildkite can optionally send an HMAC signature in place of a webhook token.
 
 The `X-Buildkite-Signature` header contains a timestamp and an HMAC signature. The timestamp is prefixed by `timestamp=` and the signature is prefixed by `signature=`.
 
-Buildkite generates the signature using HMAC-SHA256; a hash-based message authentication code [HMAC](https://en.wikipedia.org/wiki/HMAC) used with the [SHA-256](https://en.wikipedia.org/wiki/SHA-2) hash function and a secret key. The webhook token value is used as the secret key. The timestamp is an integer representation of a UTC timestamp.
+Buildkite generates the signature using HMAC-SHA256; a hash-based message authentication code [HMAC](https://en.wikipedia.org/wiki/HMAC) used with the [SHA-256](https://en.wikipedia.org/wiki/SHA-2) hash function and a secret key. The webhook token value is used as the secret key. The timestamp is an integer representation of a UTC timestamp. The raw request body is the signed message.
 
 The token value and header setting can be found under _Token_ in your _Webhook Notification service_.
 
@@ -91,7 +91,7 @@ The token value and header setting can be found under _Token_ in your _Webhook N
 
 When using HMAC signatures, you'll want to verify that the signature is legitimate.
 
-Using the token as the secret along with the timestamp and signature from the webhook, compute the authentication code. There should be a library available in the programming language you are using that can perform this operation.
+Using the token as the secret along with the timestamp from the webhook, compute the expected signature based on the raw request body. There should be a library available in the programming language you are using that can perform this operation.
 
 Compare the code to the signature received in the webhook. If they do not match, your payload has been altered.
 

--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -101,9 +101,9 @@ The below example in Ruby verifies the signature and timestamp using the OpenSSL
 require 'openssl'
 
 class BuildkiteWebhook
-  def self.valid?(payload, header, secret)
+  def self.valid?(webhook_request_body, header, secret)
     timestamp, signature = get_timestamp_and_signatures(header)
-    expected = OpenSSL::HMAC.hexdigest("sha256", secret, "#{timestamp}.#{payload}")
+    expected = OpenSSL::HMAC.hexdigest("sha256", secret, "#{timestamp}.#{webhook_request_body}")
     Rack::Utils.secure_compare(expected, signature)
   end
 


### PR DESCRIPTION
Change the variable name for the example webhook signature validation code from `payload` to `webhook_request_body`.

The variable name `payload` here could be misconstrued to be some kind of automatically deserialized request body data, when we actually want webhook recipients to use the raw body string itself.