### PR TITLE
Markdown compatible notes

### DIFF
--- a/app/assets/stylesheets/public/_callout.scss
+++ b/app/assets/stylesheets/public/_callout.scss
@@ -55,26 +55,3 @@
 .Docs__attribute__table .callout {
   margin: 0;
 }
-
-<<<<<<< HEAD
-.callout--troubleshooting {
-  @extend .callout;
-
-  border-color: #FFBA11;
-
-  .callout__title {
-    color: #FFBA11;
-  }
-}
-
-.callout--wip {
-  @extend .callout;
-
-  border-color: #FFBA11;
-
-  .callout__title {
-    color: #FFBA11;
-  }
-}
-=======
->>>>>>> e30f3c1a (fixup! Refactor `.Docs__notes` into `.callout` elements)

--- a/app/assets/stylesheets/public/_callout.scss
+++ b/app/assets/stylesheets/public/_callout.scss
@@ -17,12 +17,6 @@
   p + p { margin-top: .5rem; }
 }
 
-.Docs__note--footer-typo {
-  @extend .Docs__note;
-
-  margin-top: 3rem;
-}
-
 .Docs__wip-note {
   @extend .Docs__note;
 

--- a/app/assets/stylesheets/public/_callout.scss
+++ b/app/assets/stylesheets/public/_callout.scss
@@ -17,23 +17,8 @@
   p + p { margin-top: .5rem; }
 }
 
-.Docs__wip-note {
-  @extend .Docs__note;
-
-  border-left-color: orange;
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-
-  .Docs__wip-heading {
-    font: inherit;
-    color: inherit;
-    font-weight: bold;
-    color: orange;
-
-    &:before {
-      content: '🛠 ';
-    }
-  }
+.Docs__attribute__table .Docs__note {
+  margin: 0;
 }
 
 .Docs__troubleshooting-note {
@@ -51,5 +36,20 @@
     &:before {
       content: '⚠️';
     }
+  }
+}
+
+.Docs__wip-note {
+  @extend .Docs__note;
+
+  border-left-color: orange;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+
+  .note-title {
+    font: inherit;
+    color: inherit;
+    font-weight: bold;
+    color: orange;
   }
 }

--- a/app/assets/stylesheets/public/_callout.scss
+++ b/app/assets/stylesheets/public/_callout.scss
@@ -1,0 +1,61 @@
+.Docs__note {
+  border-left: 3px solid #14CC80;
+  padding-left: 1rem;
+  font-size: #{(16/18)}rem;
+  color: #666;
+  margin-top: 1.5rem;
+  margin-bottom: 2rem;
+
+  p { margin: 0; }
+
+  .Docs__note__heading {
+    color: #14CC80;
+    font-weight: 400;
+    font-size: 1rem;
+  }
+
+  p + p { margin-top: .5rem; }
+}
+
+.Docs__note--footer-typo {
+  @extend .Docs__note;
+
+  margin-top: 3rem;
+}
+
+.Docs__wip-note {
+  @extend .Docs__note;
+
+  border-left-color: orange;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+
+  .Docs__wip-heading {
+    font: inherit;
+    color: inherit;
+    font-weight: bold;
+    color: orange;
+
+    &:before {
+      content: '🛠 ';
+    }
+  }
+}
+
+.Docs__troubleshooting-note {
+  @extend .Docs__note;
+  border-left-color: orange;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+
+  h1, h3 {
+    font: inherit;
+    color: inherit;
+    font-weight: bold;
+    color: orange;
+
+    &:before {
+      content: '⚠️';
+    }
+  }
+}

--- a/app/assets/stylesheets/public/_callout.scss
+++ b/app/assets/stylesheets/public/_callout.scss
@@ -1,51 +1,80 @@
-.Docs__note {
-  border-left: 3px solid #14CC80;
-  padding-left: 1rem;
-  font-size: #{(16/18)}rem;
+@mixin callout($callout_color) {
+  border-left: 3px solid $callout_color;
   color: #666;
-  margin-top: 1.5rem;
-  margin-bottom: 2rem;
+  font-size: #{(16/18)}rem;
+  margin: 1.5rem 0 2rem 0;
+  padding: 0 0 0 1rem;
+
+  .callout__title {
+    color: $callout_color;
+    font-size: 1rem;
+    font-weight: 700;
+
+    position: relative;
+
+    .callout__anchor {
+      text-decoration: none;
+
+      &:link,
+      &:visited,
+      &:hover,
+      &:active,
+      &:focus {
+        color: $callout_color;
+      }
+
+      &:hover:before {
+        color: #666;
+        content: '#';
+        font-size: 1rem;
+        font-weight: normal;
+        left: -23px;
+        margin-left: .5rem;
+        position: absolute;
+      }
+    }
+  }
 
   p { margin: 0; }
 
-  .Docs__note__heading {
-    color: #14CC80;
-    font-weight: 400;
-    font-size: 1rem;
-  }
-
-  p + p { margin-top: .5rem; }
+  p + p { margin: 0.5rem 0 0 0; }
 }
 
-.Docs__attribute__table .Docs__note {
+.callout {
+  @include callout(#4b19d5);
+}
+
+.callout--troubleshooting {
+  @include callout(#ffba11);
+}
+
+.callout--wip {
+  @include callout(#ffba11);
+}
+
+.Docs__attribute__table .callout {
   margin: 0;
 }
 
-.Docs__troubleshooting-note {
-  @extend .Docs__note;
-  border-left-color: orange;
-  margin-top: 2rem;
-  margin-bottom: 2rem;
+<<<<<<< HEAD
+.callout--troubleshooting {
+  @extend .callout;
 
-  .note-title {
-    font: inherit;
-    color: inherit;
-    font-weight: bold;
-    color: orange;
+  border-color: #FFBA11;
+
+  .callout__title {
+    color: #FFBA11;
   }
 }
 
-.Docs__wip-note {
-  @extend .Docs__note;
+.callout--wip {
+  @extend .callout;
 
-  border-left-color: orange;
-  margin-top: 2rem;
-  margin-bottom: 2rem;
+  border-color: #FFBA11;
 
-  .note-title {
-    font: inherit;
-    color: inherit;
-    font-weight: bold;
-    color: orange;
+  .callout__title {
+    color: #FFBA11;
   }
 }
+=======
+>>>>>>> e30f3c1a (fixup! Refactor `.Docs__notes` into `.callout` elements)

--- a/app/assets/stylesheets/public/_callout.scss
+++ b/app/assets/stylesheets/public/_callout.scss
@@ -27,15 +27,11 @@
   margin-top: 2rem;
   margin-bottom: 2rem;
 
-  h1, h3 {
+  .note-title {
     font: inherit;
     color: inherit;
     font-weight: bold;
     color: orange;
-
-    &:before {
-      content: '⚠️';
-    }
   }
 }
 

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -197,10 +197,6 @@ $color-green: rgb(3, 165, 98);
     font-size: 0.8em;
   }
 
-  .Docs__wip-note {
-    margin: 0;
-  }
-
   .Docs__attribute__example {
     align-content: baseline;
     display: grid;

--- a/app/assets/stylesheets/public/_docs.scss
+++ b/app/assets/stylesheets/public/_docs.scss
@@ -115,27 +115,6 @@ $color-green: rgb(3, 165, 98);
   margin: .25em 0 0 0;
 }
 
-.Docs__note {
-  border-left: 3px solid #14CC80;
-  padding-left: 1rem;
-  font-size: #{(16/18)}rem;
-  color: #666;
-  margin-top: 1.5rem;
-  margin-bottom: 2rem;
-  p { margin: 0; }
-  .Docs__note__heading {
-    color: #14CC80;
-    font-weight: 400;
-    font-size: 1rem;
-  }
-  p + p { margin-top: .5rem; }
-}
-
-.Docs__note--footer-typo {
-  @extend .Docs__note;
-  margin-top: 3rem;
-}
-
 .Docs__attribute__table {
   table-layout: fixed;
   width: 100%;
@@ -259,15 +238,18 @@ a.Docs__example-repo {
     flex: none;
     transform: translateY(3px);
   }
+
   .detail {
     flex: 1;
   }
+
   .description {
     color: currentColor;
     display: block;
     font-size: #{(16/18)}rem;
     font-weight: normal;
   }
+
   .repo {
     color: #666;
     display: block;
@@ -294,38 +276,6 @@ a.Docs__example-repo {
     vertical-align: middle;
     margin-top: -3px;
     margin-right: 4px;
-  }
-}
-
-.Docs__wip-note {
-  @extend .Docs__note;
-  border-left-color: orange;
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-  .Docs__wip-heading {
-    font: inherit;
-    color: inherit;
-    font-weight: bold;
-    color: orange;
-    &:before {
-      content: '🛠 ';
-    }
-  }
-}
-
-.Docs__troubleshooting-note {
-  @extend .Docs__note;
-  border-left-color: orange;
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-  h1, h3 {
-    font: inherit;
-    color: inherit;
-    font-weight: bold;
-    color: orange;
-    &:before {
-      content: '⚠️ ';
-    }
   }
 }
 

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -110,7 +110,7 @@ class Page::Renderer
             <li class="Toc__list-item"><a class="Toc__link" href="##{heading['id']}">#{heading.text.strip}</a></li>
           HTML
         }.join("").strip
-        
+
         node.replace(<<~HTML.strip)
           <nav class="Toc">
             <p class="Toc__title"><strong>On this page:</strong></p>
@@ -121,14 +121,14 @@ class Page::Renderer
         HTML
       end
     end
-    
+
     doc
   end
 
   def fix_curl_highlighting(doc)
     doc.search('.//code').each do |node|
       next unless node.text.starts_with?('curl ')
-    
+
       node.replace(node.to_html.gsub(/\{.*?\}/mi) {|uri_template|
         %(<span class="o">) + uri_template + %(</span>)
       })
@@ -160,10 +160,10 @@ class Page::Renderer
       node.previous_element['id'] = id
       node.remove
     end
-    
+
     doc
   end
-  
+
   def add_custom_classes(doc)
     doc.search('./p').each do |node|
       next unless node.text.starts_with?('{: class=')
@@ -173,7 +173,7 @@ class Page::Renderer
       node.previous_element['class'] = css_class
       node.remove
     end
-    
+
     doc
   end
 
@@ -185,7 +185,7 @@ class Page::Renderer
         table.search('./tbody/tr').each do |tr|
           tr.search('./td').each_with_index do |td, i|
             faux_th = "<th aria-hidden class=\"responsive-table__faux-th\">#{thead_ths[i].children}</th>"
-            
+
             td.add_previous_sibling(faux_th)
           end
         end
@@ -194,5 +194,4 @@ class Page::Renderer
 
     doc
   end
-
 end

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -175,8 +175,10 @@ class Page::Renderer
       paras = lines[1..].map { |e| "<p>#{e}</p>" }.join
 
       callout_template = <<~HTML
-        <section class='callout callout--#{class_name}'>
-          <p class='callout__title' id='#{title.to_url}'>#{title}</p>
+        <section class='callout callout--#{class_name}' id='#{title.to_url}'>
+          <p class='callout__title'>
+            <a class='callout__anchor' href='##{title.to_url}'>#{title}</a>
+          </p>
           #{paras}
         </section>
       HTML

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -5,7 +5,6 @@ class Page::Renderer
 
   CALLOUT_TYPE = {
     '📘': 'info',
-    '👍': 'okay',
     '🚧': 'troubleshooting',
     '🛠': 'wip'
   }.freeze

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -3,12 +3,6 @@
 class Page::Renderer
   require "rouge/plugins/redcarpet"
 
-  CALLOUT_TYPE = {
-    '📘': 'info',
-    '🚧': 'troubleshooting',
-    '🛠': 'wip'
-  }.freeze
-
   def self.render(text, options = {})
     new.render(text, options)
   end
@@ -162,28 +156,9 @@ class Page::Renderer
     doc.search('./blockquote').each do |node|
       callout = node.children.compact_blank.join.chr.to_sym
 
-      next unless CALLOUT_TYPE.key? callout
+      next unless Page::Renderers::Callout::CALLOUT_TYPE.key? callout
 
-      class_name = CALLOUT_TYPE[callout]
-      lines = node
-              .children
-              .inner_html
-              .split("\n")
-              .reject(&:empty?)
-
-      title = lines.first
-      paras = lines[1..].map { |e| "<p>#{e}</p>" }.join
-
-      callout_template = <<~HTML
-        <section class='callout callout--#{class_name}' id='#{title.to_url}'>
-          <p class='callout__title'>
-            <a class='callout__anchor' href='##{title.to_url}'>#{title}</a>
-          </p>
-          #{paras}
-        </section>
-      HTML
-
-      node.replace(callout_template)
+      Page::Renderers::Callout.new(node, callout).process
     end
 
     doc

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -175,8 +175,8 @@ class Page::Renderer
       paras = lines[1..].map { |e| "<p>#{e}</p>" }.join
 
       callout_template = <<~HTML
-        <section class='Docs__note Docs__#{class_name}-note'>
-          <p class='note-title' id='#{title.to_url}'>#{title}</p>
+        <section class='callout callout--#{class_name}'>
+          <p class='callout__title' id='#{title.to_url}'>#{title}</p>
           #{paras}
         </section>
       HTML

--- a/app/models/page/renderers/callout.rb
+++ b/app/models/page/renderers/callout.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class Page::Renderers::Callout
+  require "rouge/plugins/redcarpet"
+
+  CALLOUT_TYPE = {
+    '📘': 'info',
+    '🚧': 'troubleshooting',
+    '🛠': 'wip'
+  }.freeze
+
+  attr_accessor :node, :callout
+
+  def initialize(node, callout)
+    @node = node
+    @callout = callout
+  end
+
+  def process
+    node.replace(template)
+  end
+
+  private
+
+  def class_name
+    CALLOUT_TYPE[callout]
+  end
+
+  def lines
+    @lines ||= node.children.inner_html.split("\n").reject(&:empty?)
+  end
+
+  def title
+    lines.first
+  end
+
+  def paragraphs
+    lines[1..].map { |e| "<p>#{e}</p>" }.join
+  end
+
+  def template
+    @template = <<~HTML
+      <section class='callout callout--#{class_name}' id='#{title.to_url}'>
+        <p class='callout__title'>
+          <a class='callout__anchor' href='##{title.to_url}'>#{title}</a>
+        </p>
+        #{paragraphs}
+      </section>
+    HTML
+  end
+end

--- a/app/models/page/renderers/callout.rb
+++ b/app/models/page/renderers/callout.rb
@@ -40,12 +40,28 @@ class Page::Renderers::Callout
 
   def template
     @template = <<~HTML
-      <section class='callout callout--#{class_name}' id='#{title.to_url}'>
+      <section class='callout callout--#{class_name}'>
         <p class='callout__title'>
-          <a class='callout__anchor' href='##{title.to_url}'>#{title}</a>
+          #{formatted_title}
         </p>
         #{paragraphs}
       </section>
     HTML
+  end
+
+  def url
+    title.to_url
+  end
+
+  def formatted_title
+    if url.present?
+      anchor
+    else
+      title
+    end
+  end
+
+  def anchor
+    "<a class='callout__anchor' href='##{url}' id='#{url}'>#{title}</a>"
   end
 end

--- a/config/algolia.json
+++ b/config/algolia.json
@@ -23,7 +23,6 @@
   "selectors_exclude": [
     "[data-algolia-exclude]",
     ".Docs__toc",
-    ".Docs__note--footer-typo",
     ".HomepageCategory"
   ],
   "custom_settings": {

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -87,17 +87,17 @@ variables:
   example: "/var/lib/buildkite-agent/builds/agent-1/pipeline-2"
 - name: BUILDKITE_BUILD_AUTHOR
   desc: |
-    The name of the user who authored the commit being built. May be **[unverified](#unverified)**. This value can be blank in some situations, including builds manually triggered using API or Buildkite web interface.
+    The name of the user who authored the commit being built. May be **[unverified](#unverified-commits)**. This value can be blank in some situations, including builds manually triggered using API or Buildkite web interface.
   modifiable: false
   example: "Carol Danvers"
 - name: BUILDKITE_BUILD_AUTHOR_EMAIL
   desc: |
-    The notification email of the user who authored the commit being built. May be **[unverified](#unverified)**. This value can be blank in some situations, including builds manually triggered using API or Buildkite web interface.
+    The notification email of the user who authored the commit being built. May be **[unverified](#unverified-commits)**. This value can be blank in some situations, including builds manually triggered using API or Buildkite web interface.
   modifiable: false
   example: "cdanvers@kree-net.com"
 - name: BUILDKITE_BUILD_CREATOR
   desc: |
-    The name of the user who created the build. May be **[unverified](#unverified)**.
+    The name of the user who created the build. May be **[unverified](#unverified-commits)**.
   modifiable: false
   example: "Carol Danvers"
 - name: BUILDKITE_BUILD_CREATOR_EMAIL
@@ -107,7 +107,7 @@ variables:
   example: "cdanvers@kree-net.com"
 - name: BUILDKITE_BUILD_CREATOR_TEAMS
   desc: |
-    A colon separated list of **[unverified](#unverified)** non-private team slugs that the build creator belongs to.
+    A colon separated list of **[unverified](#unverified-commits)** non-private team slugs that the build creator belongs to.
   modifiable: false
   example: "everyone:platform"
 - name: BUILDKITE_BUILD_ID

--- a/pages/agent/v2.md.erb
+++ b/pages/agent/v2.md.erb
@@ -1,9 +1,7 @@
 # The Buildkite Agent
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3">see the latest version of this document</a>.
 
 <!--alex ignore easy-->
 

--- a/pages/agent/v2/aws.md.erb
+++ b/pages/agent/v2/aws.md.erb
@@ -1,9 +1,7 @@
 # Running Buildkite Agent on AWS
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/aws">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/aws">see the latest version of this document</a>.
 
 The Buildkite Agent can be run on AWS using our Elastic CI Stack for AWS.
 

--- a/pages/agent/v2/cli_artifact.md.erb
+++ b/pages/agent/v2/cli_artifact.md.erb
@@ -1,9 +1,7 @@
 # `buildkite-agent artifact`
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_artifact">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_artifact">see the latest version of this document</a>.
 
 The Buildkite Agent's `artifact` command provides support for uploading and downloading of build artifacts, allowing you to share binary data between build steps no matter the machine or network.
 

--- a/pages/agent/v2/cli_meta_data.md.erb
+++ b/pages/agent/v2/cli_meta_data.md.erb
@@ -1,9 +1,7 @@
 # `buildkite-agent meta-data`
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_meta_data">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_meta_data">see the latest version of this document</a>.
 
 The Buildkite Agent's `meta-data` command provides your build pipeline with a powerful key/value data-store that works across build steps and build agents, no matter the machine or network.
 

--- a/pages/agent/v2/cli_pipeline.md.erb
+++ b/pages/agent/v2/cli_pipeline.md.erb
@@ -1,9 +1,7 @@
 # `buildkite-agent pipeline`
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_pipeline">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_pipeline">see the latest version of this document</a>.
 
 The Buildkite Agent's `pipeline` command allows you to add and replace build steps in the running build. The steps are defined using YAML or JSON and can be read from a file or streamed from the output of a script.
 

--- a/pages/agent/v2/cli_start.md.erb
+++ b/pages/agent/v2/cli_start.md.erb
@@ -1,9 +1,7 @@
 # `buildkite-agent start`
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_start">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/cli_start">see the latest version of this document</a>.
 
 The Buildkite Agent's `start` command is used to manually start an agent and register it with Buildkite.
 

--- a/pages/agent/v2/configuration.md.erb
+++ b/pages/agent/v2/configuration.md.erb
@@ -1,9 +1,7 @@
 # Buildkite Agent Configuration
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/configuration">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/configuration">see the latest version of this document</a>.
 
 Every agent installer comes with a configuration file. You can also customize many of the configuration values using environment variables.
 

--- a/pages/agent/v2/debian.md.erb
+++ b/pages/agent/v2/debian.md.erb
@@ -1,9 +1,7 @@
 # Installing Buildkite Agent on Debian
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/debian">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/debian">see the latest version of this document</a>.
 
 The Buildkite Agent can be installed on Debian versions 7.x and 8.x using our signed apt repository.
 

--- a/pages/agent/v2/debian.md.erb
+++ b/pages/agent/v2/debian.md.erb
@@ -15,9 +15,8 @@ Firstly, ensure your list of packages is up to date:
 sudo apt-get update
 ```
 
-<div class="Docs__note">
-<p>Debian doesn't always have <code>sudo</code> available, so you can run these commands as root and omit the <code>sudo</code>, or install the sudo package as root first.</p>
-</div>
+>📘
+> Debian doesn't always have <code>sudo</code> available, so you can run these commands as root and omit the <code>sudo</code>, or install the sudo package as root first.
 
 Next, ensure you have the `apt-transport-https` package installed for the HTTPS package repository, and the `dirmngr` package installed for adding the signing key:
 

--- a/pages/agent/v2/docker.md.erb
+++ b/pages/agent/v2/docker.md.erb
@@ -1,9 +1,7 @@
 # Running Buildkite Agent with Docker
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/docker">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/docker">see the latest version of this document</a>.
 
 You can run the Buildkite Agent inside a Docker container using the official Docker images.
 

--- a/pages/agent/v2/docker.md.erb
+++ b/pages/agent/v2/docker.md.erb
@@ -5,10 +5,8 @@
 
 You can run the Buildkite Agent inside a Docker container using the official Docker images.
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">Running each build in its own container</h3>
-<p>These instructions cover how to run the agent using Docker. If you want to learn how to isolate each build using Docker and any of our standard Linux-based installers read the <a href="/docs/tutorials/docker-containerized-builds">Docker-Based Builds</a> guide.</p>
-</div>
+>📘 Running each build in its own container
+> These instructions cover how to run the agent using Docker. If you want to learn how to isolate each build using Docker and any of our standard Linux-based installers read the <a href="/docs/tutorials/docker-containerized-builds">Docker-Based Builds</a> guide.
 
 {:toc}
 

--- a/pages/agent/v2/freebsd.md.erb
+++ b/pages/agent/v2/freebsd.md.erb
@@ -1,9 +1,7 @@
 # Installing Buildkite Agent on FreeBSD
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/freebsd">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/freebsd">see the latest version of this document</a>.
 
 You can install Buildkite Agent on most FreeBSD systems.
 

--- a/pages/agent/v2/gcloud.md.erb
+++ b/pages/agent/v2/gcloud.md.erb
@@ -1,9 +1,7 @@
 # Running Buildkite Agent on Google Cloud Platform
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/gcloud">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/gcloud">see the latest version of this document</a>.
 
 The Buildkite Agent can be run on [Google Cloud Platform](https://cloud.google.com). For fine control over long–lived agents, you might like to run the agent using individual VM instances on Google Compute Engine. Or run Docker–based builds using a scalable cluster of agents on the Google Kubernetes Engine using Kubernetes.
 

--- a/pages/agent/v2/github_ssh_keys.md.erb
+++ b/pages/agent/v2/github_ssh_keys.md.erb
@@ -1,9 +1,7 @@
 # GitHub SSH Keys
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/github_ssh_keys">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/github_ssh_keys">see the latest version of this document</a>.
 
 The Buildkite Agent clones your source code directly from GitHub or GitHub Enterprise. The easiest way to provide it with access is by creating a “Buildkite Agent” machine user in your organization, and adding it to a team that has access to the relevant repositories.
 

--- a/pages/agent/v2/github_ssh_keys.md.erb
+++ b/pages/agent/v2/github_ssh_keys.md.erb
@@ -5,9 +5,8 @@
 
 The Buildkite Agent clones your source code directly from GitHub or GitHub Enterprise. The easiest way to provide it with access is by creating a “Buildkite Agent” machine user in your organization, and adding it to a team that has access to the relevant repositories.
 
-<div class="Docs__note">
-<p>If you're running a build agent on a local development machine which already has access to GitHub then you can skip this setup and start running builds.</p>
-</div>
+>📘
+> If you're running a build agent on a local development machine which already has access to GitHub then you can skip this setup and start running builds.
 
 {:toc}
 

--- a/pages/agent/v2/hooks.md.erb
+++ b/pages/agent/v2/hooks.md.erb
@@ -1,9 +1,7 @@
 # Buildkite Agent Hooks
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/hooks">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/hooks">see the latest version of this document</a>.
 
 Every agent installer comes with a hooks directory which can be used to override and extend the built-in agent behavior. For example you could create a global `checkout` hook which speeds up a fresh `git clone` on a new build machine, a global `environment` hook which exports secret API keys as environment variables, or a pipeline-level `command` hook which runs the pipeline's steps inside a custom containerized environment.
 

--- a/pages/agent/v2/hooks.md.erb
+++ b/pages/agent/v2/hooks.md.erb
@@ -8,10 +8,8 @@ Every agent installer comes with a hooks directory which can be used to override
 
 {:toc}
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">Windows support</h3>
-<p>Agent hooks aren't available in this version. They are introduced in <a href="/docs/agent/v3/hooks">Agent v3</a></p>
-</div>
+>📘 Windows support
+> Agent hooks aren't available in this version. They are introduced in <a href="/docs/agent/v3/hooks">Agent v3</a>
 
 ## Overview
 

--- a/pages/agent/v2/installation.md.erb
+++ b/pages/agent/v2/installation.md.erb
@@ -1,9 +1,7 @@
 # How to Install Buildkite Agent
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/installation">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/installation">see the latest version of this document</a>.
 
 {:notoc}
 

--- a/pages/agent/v2/linux.md.erb
+++ b/pages/agent/v2/linux.md.erb
@@ -1,9 +1,7 @@
 # Installing Buildkite Agent on Linux
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/linux">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/linux">see the latest version of this document</a>.
 
 You can install Buildkite Agent on most Linux based systems (including macOS).
 

--- a/pages/agent/v2/osx.md.erb
+++ b/pages/agent/v2/osx.md.erb
@@ -1,9 +1,7 @@
 # Installing Buildkite Agent on macOS
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/macos">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/macos">see the latest version of this document</a>.
 
 The Buildkite Agent can be installed on macOS 10.9 or higher using Homebrew or our installer script, and supports pre-release versions of both OS X and Xcode.
 

--- a/pages/agent/v2/prioritization.md.erb
+++ b/pages/agent/v2/prioritization.md.erb
@@ -1,9 +1,7 @@
 # Buildkite Agent Prioritization
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/prioritization">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/prioritization">see the latest version of this document</a>.
 
 {:notoc}
 

--- a/pages/agent/v2/queues.md.erb
+++ b/pages/agent/v2/queues.md.erb
@@ -1,9 +1,7 @@
 # Buildkite Agent Job Queues
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/queues">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/queues">see the latest version of this document</a>.
 
 Each pipeline has the ability to separate jobs using queues. This allows you isolate a set of jobs and/or agents, making sure they only run jobs that are intended to be assigned to them.
 

--- a/pages/agent/v2/redhat.md.erb
+++ b/pages/agent/v2/redhat.md.erb
@@ -1,9 +1,7 @@
 # Installing Buildkite Agent on Red Hat, CentOS and Amazon Linux
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/redhat">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/redhat">see the latest version of this document</a>.
 
 The Buildkite Agent can be installed on Red Hat, CentOS and Amazon Linux using our yum repository.
 

--- a/pages/agent/v2/securing.md.erb
+++ b/pages/agent/v2/securing.md.erb
@@ -1,9 +1,7 @@
 # Securing Your Buildkite Agent
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/securing">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/securing">see the latest version of this document</a>.
 
 In cases where a Buildkite Agent is being deployed into a sensitive environment there are a few default settings and techniques which may be adjusted.
 

--- a/pages/agent/v2/ssh_keys.md.erb
+++ b/pages/agent/v2/ssh_keys.md.erb
@@ -1,9 +1,7 @@
 # Buildkite Agent SSH Keys
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/ssh_keys">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/ssh_keys">see the latest version of this document</a>.
 
 If your agent needs to clone your repositories using git and SSH, you'll need to configure your agent with a valid SSH key.
 

--- a/pages/agent/v2/ubuntu.md.erb
+++ b/pages/agent/v2/ubuntu.md.erb
@@ -1,9 +1,7 @@
 # Installing Buildkite Agent on Ubuntu
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/ubuntu">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/ubuntu">see the latest version of this document</a>.
 
 The Buildkite Agent can be installed on Ubuntu versions 14.04 and above using our signed apt repository.
 

--- a/pages/agent/v2/upgrading_to_v2.md.erb
+++ b/pages/agent/v2/upgrading_to_v2.md.erb
@@ -1,9 +1,7 @@
 # Upgrading to Buildkite Agent v2
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/upgrading">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/upgrading">see the latest version of this document</a>.
 
 The Buildkite Agent has changed a lot in v2 but upgrade process is straight forward. We'll cover what's changed and how to upgrade to new agents.
 

--- a/pages/agent/v2/windows.md.erb
+++ b/pages/agent/v2/windows.md.erb
@@ -1,9 +1,7 @@
 # Installing Buildkite Agent on Windows
 
-<section class="Docs__troubleshooting-note">
-  <p>This page references the out-of-date Buildkite Agent v2.</p>
-  <p>For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/windows">see the latest version of this document</a>.
-</section>
+>🚧 This page references the out-of-date Buildkite Agent v2.
+> For docs referencing the Buildkite Agent v3, <a href="/docs/agent/v3/windows">see the latest version of this document</a>.
 
 The Buildkite Agent can be installed on both 64bit and 32bit editions of Windows XP and later.
 

--- a/pages/agent/v3.md.erb
+++ b/pages/agent/v3.md.erb
@@ -94,10 +94,8 @@ See [redacted-vars](/docs/pipelines/managing-log-output#redacted-environment-var
 
 Maintain a single bare git mirror for each repository on a host that is shared amongst multiple agents and pipelines. Checkouts reference the git mirror using `git clone --reference`, as do submodules.
 
-<div class="Docs__wip-note">
-  <p class="Docs__wip-heading">Experimental feature</p>
-  <p>To use it, set <code>experiment="git-mirrors"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.</p>
-</div>
+>🛠 Experimental feature
+> To use it, set <code>experiment="git-mirrors"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.
 
 See the following agent configuration options for more information:
 
@@ -109,19 +107,15 @@ See the following agent configuration options for more information:
 
 Outputs inline ANSI timestamps for each line of log output which enables toggle-able timestamps in the Buildkite UI.
 
-<div class="Docs__wip-note">
-  <p class="Docs__wip-heading">Experimental feature</p>
-  <p>To use it, set <code>experiment="ansi-timestamps"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.</p>
-</div>
+>🛠 Experimental feature
+> To use it, set <code>experiment="ansi-timestamps"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.
 
 ### Normalised upload paths
 
 Artifacts uploaded by `buildkite-agent artifact upload` will be uploaded using URI/Unix-style paths, even on Windows. This makes sure that artifacts uploaded from Windows agents are stored in a URI-compatible URL.
 
-<div class="Docs__wip-note">
-  <p class="Docs__wip-heading">Experimental feature</p>
-  <p>To use it, set <code>experiment="normalised-upload-paths"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.</p>
-</div>
+>🛠 Experimental feature
+> To use it, set <code>experiment="normalised-upload-paths"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.
 
 Artifact names displayed in Buildkite's web UI, as well as in the API, are changed by this.
 
@@ -131,10 +125,8 @@ For example, when using this experimental feature `buildkite-agent artifact uplo
 
 After repository checkout, resolve `BUILDKITE_COMMIT` to a commit hash. This makes `BUILDKITE_COMMIT` useful for builds triggered against non-commit-hash refs such as `HEAD`.
 
-<div class="Docs__wip-note">
-  <p class="Docs__wip-heading">Experimental feature</p>
-  <p>To use it, set <code>experiment="resolve-commit-after-checkout"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.</p>
-</div>
+>🛠 Experimental feature
+> To use it, set <code>experiment="resolve-commit-after-checkout"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.
 
 ### Flock file locks
 
@@ -142,10 +134,8 @@ Changes the file lock implementation from `github.com/nightlyone/lockfile` to `g
 
 When the experiment is enabled, the agent will use different lock files from agents where the experiment is disabled, so the agents with this experiment enabled should not be run on the same host as the agents where the experiment is disabled.
 
-<div class="Docs__wip-note">
-  <p class="Docs__wip-heading">Experimental feature</p>
-  <p>To use flock file locks, set <code>experiment="flock-file-locks"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.</p>
-</div>
+>🛠 Experimental feature
+> To use flock file locks, set <code>experiment="flock-file-locks"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.
 
 ## Customizing with hooks
 

--- a/pages/agent/v3.md.erb
+++ b/pages/agent/v3.md.erb
@@ -80,9 +80,8 @@ experiment="experiment1,experiment2"
 
 If an experiment doesn't exist, no error will be raised.
 
-<div class="Docs__troubleshooting-note">
-Please note that there is every chance we will remove or change these experiments, so using them should be at your own risk and without the expectation that they will work in future!
-</div>
+>🚧
+> Please note that there is every chance we will remove or change these experiments, so using them should be at your own risk and without the expectation that they will work in future!
 
 ### Redacted variables
 

--- a/pages/agent/v3.md.erb
+++ b/pages/agent/v3.md.erb
@@ -178,10 +178,8 @@ The agent reports its activity to Buildkite using exit codes. The most common ex
   </tr>
 </table>
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">Jobs terminated by signals</h3>
-<p>When a job is terminated by a signal, the exit code will be set to 128 + the signal number. For more information about how shells manage commands terminated by signals, see the Wiki page on <a href="https://en.wikipedia.org/wiki/Exit_status#Shell_and_scripts">Exit Signals</a>.</p>
-</div>
+>📘 Jobs terminated by signals
+> When a job is terminated by a signal, the exit code will be set to 128 + the signal number. For more information about how shells manage commands terminated by signals, see the Wiki page on <a href="https://en.wikipedia.org/wiki/Exit_status#Shell_and_scripts">Exit Signals</a>.
 
 Exit codes for common signals:
 

--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -129,9 +129,8 @@ Console output in annotations can be displayed with ANSI colors when wrapped in 
 <%= image "annotations-terminal-output.png", alt: "Screenshot of colored terminal output in an annotation" %>
 
 
-<div class="Docs__note">
-<p>Make sure you escape the backticks (<code>`</code>) that demarcate the code block if you're echoing to the terminal, so it doesn't get interpreted as a shell interpreted command.</p>
-</div>
+>📘
+> Make sure you escape the backticks (<code>`</code>) that demarcate the code block if you're echoing to the terminal, so it doesn't get interpreted as a shell interpreted command.
 
 The following pipeline prints an escaped Markdown block, adds line breaks using `\n` and formats `test` using the red ANSI code `\033[0;31m` before resetting the remainder of the output with `\033[0m`. Passing `-e` to the echo commands ensures that the backslash escapes codes are interpreted (the default is not to interpret them).
 

--- a/pages/agent/v3/cli_annotation.md.erb
+++ b/pages/agent/v3/cli_annotation.md.erb
@@ -4,10 +4,8 @@ The Buildkite Agent's `annotation` command allows manipulating existing build an
 
 Annotations are added using [the `buildkite-agent annotate` command](cli-annotate).
 
-<section class="Docs__note">
-  <h3>Newly-added feature</h3>
-  <p>This feature was introduced in <a href="https://github.com/buildkite/agent/releases/tag/v3.28.1">v3.28.1</a> of the agent.</p>
-</section>
+>📘 Newly-added feature
+> This feature was introduced in <a href="https://github.com/buildkite/agent/releases/tag/v3.28.1">v3.28.1</a> of the agent.
 
 {:toc}
 

--- a/pages/agent/v3/cli_start.md.erb
+++ b/pages/agent/v3/cli_start.md.erb
@@ -56,10 +56,8 @@ steps:
 
 Partial wildcard matching (for example, `postgres=1.9*` or `postgres=*1.9`) is not yet supported.
 
-<section class="Docs__note">
-  <h3>Setting agent defaults</h3>
-  <p>Use a top-level <code>agents</code> block to <a href="/docs/pipelines/defining-steps#step-defaults">set defaults</a> for all steps in a pipeline.</p>
-</section>
+>📘 Setting agent defaults
+> Use a top-level <code>agents</code> block to <a href="/docs/pipelines/defining-steps#step-defaults">set defaults</a> for all steps in a pipeline.
 
 If you specify multiple tags, your build will only run on agents that have **all** the specified tags.
 
@@ -81,9 +79,7 @@ You can load an Agent's tags from the underlying Google Cloud metadata using `--
 
 You can configure your agent and your pipeline steps so that the steps run on the same agent that performed `pipeline upload`. This is sometimes referred to as "node affinity", but note that what we describe here does not involve Kubernetes (where the term is more widely used).
 
-<div class="Docs__note">
-  <p>Normally, we recommend against doing this. The usual practice is to allow jobs to run on whichever agent is available, or to target according to specific criteria (for example, you might want certain jobs to run on a particular operating system). Targeting a specific agent can cause reliability issues (the job can't run if the agent is offline), and can result in work being unevenly distributed between agents (which is inefficient).</p>
-</div>
+>📘 Normally, we recommend against doing this. The usual practice is to allow jobs to run on whichever agent is available, or to target according to specific criteria (for example, you might want certain jobs to run on a particular operating system). Targeting a specific agent can cause reliability issues (the job can't run if the agent is offline), and can result in work being unevenly distributed between agents (which is inefficient).
 
 First, set the agent hostname tag.
 

--- a/pages/agent/v3/configuration.md.erb
+++ b/pages/agent/v3/configuration.md.erb
@@ -67,9 +67,7 @@ You can find the location of your configuration file in your platform's installa
           </th>
           <td>
             <% if attr['experimental'] %>
-              <div class="Docs__wip-note">
-                <p class="Docs__wip-heading">Experimental feature</p>
-              </div>
+              <%= render_markdown(text: ">🛠 Experimental feature") -%>
             <% end -%>
 
             <%= render_markdown(text: attr['desc']) -%>

--- a/pages/agent/v3/debian.md.erb
+++ b/pages/agent/v3/debian.md.erb
@@ -12,9 +12,8 @@ Firstly, ensure your list of packages is up to date:
 sudo apt-get update
 ```
 
-<div class="Docs__note">
-<p>Debian doesn't always have <code>sudo</code> available, so you can run these commands as root and omit the <code>sudo</code>, or install the sudo package as root first.</p>
-</div>
+>📘
+> Debian doesn't always have <code>sudo</code> available, so you can run these commands as root and omit the <code>sudo</code>, or install the sudo package as root first.
 
 Next, ensure you have the `apt-transport-https` package installed for the HTTPS package repository, and the `dirmngr` package installed for adding the signing key:
 

--- a/pages/agent/v3/docker.md.erb
+++ b/pages/agent/v3/docker.md.erb
@@ -23,10 +23,8 @@ A much larger Ubuntu-based image is also available:
 docker run -d -t --name buildkite-agent buildkite/agent:3-ubuntu start --token "<your-agent-token>"
 ```
 
-<section class="Docs__troubleshooting-note">
-  <h3>Caveats for builds that need Docker access.</h3>
-  <p>If your build jobs require Docker access, and you're passing through the Docker socket, you must ensure the build path is consistent between the Docker host and the agent container. See <a href="#allowing-builds-to-use-docker">Allowing builds to use Docker</a> for more details.</a>.
-</section>
+>🚧 Caveats for builds that need Docker access.
+> If your build jobs require Docker access, and you're passing through the Docker socket, you must ensure the build path is consistent between the Docker host and the agent container. See <a href="#allowing-builds-to-use-docker">Allowing builds to use Docker</a> for more details.</a>.
 
 ## Version tagging
 
@@ -118,10 +116,8 @@ docker run \
   buildkite/agent:3 start --token "<your-agent-token>"
 ```
 
-<section class="Docs__troubleshooting-note">
-  <h3>Security considerations</h3>
-  <p>Providing builds with a Docker socket gives them access to whatever the docker daemon has access to on the host system. Typically this is <code>root</code>, which means builds have full root system access. This can be mitigated somewhat with <a href="https://docs.docker.com/engine/security/userns-remap/">user namespace remapping</a>, but caution should still be exercised.</p>
-</section>
+>🚧 Security considerations
+> Providing builds with a Docker socket gives them access to whatever the docker daemon has access to on the host system. Typically this is <code>root</code>, which means builds have full root system access. This can be mitigated somewhat with <a href="https://docs.docker.com/engine/security/userns-remap/">user namespace remapping</a>, but caution should still be exercised.
 
 ## Exposing build secrets into the container
 

--- a/pages/agent/v3/docker.md.erb
+++ b/pages/agent/v3/docker.md.erb
@@ -2,10 +2,8 @@
 
 You can run the Buildkite Agent inside a Docker container using the [official image on Docker Hub](https://hub.docker.com/r/buildkite/agent).
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">Running each build in its own container</h3>
-<p>These instructions cover how to run the agent using Docker. If you want to learn how to isolate each build using Docker and any of our standard Linux-based installers read the <a href="/docs/tutorials/docker-containerized-builds">Containerized Builds with Docker</a> guide.</p>
-</div>
+>📘 Running each build in its own container
+> These instructions cover how to run the agent using Docker. If you want to learn how to isolate each build using Docker and any of our standard Linux-based installers read the <a href="/docs/tutorials/docker-containerized-builds">Containerized Builds with Docker</a> guide.
 
 {:toc}
 

--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -171,9 +171,8 @@ rm myenv
 
 <!-- date -->
 
-<div class="Docs__note">
-Currently (as of June 2021), you must use the default KMS key for S3. Follow <a href="https://github.com/buildkite/elastic-ci-stack-for-aws/issues/235" target="_blank">issue #235</a> for progress on using specific KMS keys.
-</div>
+>📘
+> Currently (as of June 2021), you must use the default KMS key for S3. Follow <a href="https://github.com/buildkite/elastic-ci-stack-for-aws/issues/235" target="_blank">issue #235</a> for progress on using specific KMS keys.
 
 If you want to store your secrets unencrypted, you can disable encryption entirely by setting `BUILDKITE_USE_KMS=false` in your Elastic CI Stack for AWS configuration.
 

--- a/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md.erb
+++ b/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md.erb
@@ -4,10 +4,8 @@ You can run your builds on AWS EC2 Mac using Buildkite's [CloudFormation templat
 Buildkite agent. Using Buildkite agents, you can run pipelines and build
 Xcode-based software projects for macOS, iOS, iPadOS, tvOS, and watchOS.
 
-<div class="Docs__troubleshooting-note">
-<p>As you must prepare and supply your own AMI (Amazon Machine Image) for this template, macOS support has
-<b>not</b> been incorporated into the Elastic CI Stack for AWS.</p>
-</div>
+>🚧
+> As you must prepare and supply your own AMI (Amazon Machine Image) for this template, macOS support has <b>not</b> been incorporated into the Elastic CI Stack for AWS.
 
 Using an Auto Scaling group for your instances ensures booting your macOS
 Buildkite Agents is repeatable, and enables automatic instance replacement when
@@ -28,10 +26,8 @@ You must also choose an AWS Region with EC2 Mac instances available. See
 [Amazon EC2 Dedicated Hosts Pricing](https://aws.amazon.com/ec2/dedicated-hosts/pricing/)
 for details on which regions have EC2 Mac Dedicated Hosts.
 
-<div class="Docs__troubleshooting-note">
-<h3 class="Docs__note__heading">Minimum allocation</h3>
-<p>Dedicated macOS <strong>hosts</strong> on AWS have a <a href="https://aws.amazon.com/ec2/dedicated-hosts/pricing/#on-demand">minimum billing period</a> of 24 hours. However you can scale instances running on the host at will.</p>
-</div>
+>🚧 Minimum allocation
+>Dedicated macOS <strong>hosts</strong> on AWS have a <a href="https://aws.amazon.com/ec2/dedicated-hosts/pricing/#on-demand">minimum billing period</a> of 24 hours. However you can scale instances running on the host at will.
 
 See also the [Amazon EC2 Mac instances User Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-mac-instances.html)
 for more details on AWS EC2 Mac instances.

--- a/pages/agent/v3/github_ssh_keys.md.erb
+++ b/pages/agent/v3/github_ssh_keys.md.erb
@@ -2,9 +2,8 @@
 
 The Buildkite Agent clones your source code directly from GitHub or GitHub Enterprise. The easiest way to provide it with access is by creating a “Buildkite Agent” machine user in your organization, and adding it to a team that has access to the relevant repositories.
 
-<div class="Docs__note">
-<p>If you're running a build agent on a local development machine which already has access to GitHub then you can skip this setup and start running builds.</p>
-</div>
+>📘
+> If you're running a build agent on a local development machine which already has access to GitHub then you can skip this setup and start running builds.
 
 {:toc}
 

--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -148,10 +148,8 @@ This has a few implications:
 * `$0` contains the location of the copy of the script that is running from `$TMPDIR`
 * the shebang line of the hook script has no effect
 
-<section class="Docs__troubleshooting-note">
-  <p class="Docs__note__heading">"Permission denied" error when trying to execute hooks</p>
-  <p>If your hooks don't execute, and throw a <code>Permission denied</code> error, it might mean that they were copied to a temporary directory on the agent that isn't executable. Configure the directory that hooks are copied to before execution using the <code>$TMPDIR</code> environment variable on the Buildkite agent, or make sure the existing directory is marked as executable..</p>
-</section>
+>🚧 "Permission denied" error when trying to execute hooks
+> If your hooks don't execute, and throw a <code>Permission denied</code> error, it might mean that they were copied to a temporary directory on the agent that isn't executable. Configure the directory that hooks are copied to before execution using the <code>$TMPDIR</code> environment variable on the Buildkite agent, or make sure the existing directory is marked as executable.
 
 To write job lifecycle hooks in another programming language, you need to
 execute them from within the shell script, and explicitly pass any Buildkite

--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -94,10 +94,8 @@ launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist
 tail -f ~/.buildkite-agent/log/buildkite-agent.log
 ```
 
-<section class="Docs__troubleshooting-note">
-  <h3>Troubleshooting: <code>launchctl</code> fails with "Could not find domain for"</h3>
-  <p>Ensure that you have a user logged in to the macOS host, then re-run:<br><code>launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist</code></p>
-  </section>
+>🚧 Troubleshooting: <code>launchctl</code> fails with "Could not find domain for"
+> Ensure that you have a user logged in to the macOS host, then re-run:<br><code>launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist</code>
 
 ## Running multiple agents
 

--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -97,7 +97,7 @@ tail -f ~/.buildkite-agent/log/buildkite-agent.log
 <section class="Docs__troubleshooting-note">
   <h3>Troubleshooting: <code>launchctl</code> fails with "Could not find domain for"</h3>
   <p>Ensure that you have a user logged in to the macOS host, then re-run:<br><code>launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist</code></p>
-</section>
+  </section>
 
 ## Running multiple agents
 

--- a/pages/agent/v3/securing.md.erb
+++ b/pages/agent/v3/securing.md.erb
@@ -40,10 +40,8 @@ Command line evaluation can be disabled by setting [`no-command-eval`](/docs/age
 * Command line flag: `--no-command-eval`
 * Configuration setting: `no-command-eval=true`
 
-<div class="Docs__troubleshooting-note">
-  <h3>Custom hooks</h3>
-  <p>If you have a custom <code>command</code> hook, using <code>no-command-eval</code> will have no effect on your command execution. See <a href="#allowing-a-list-of-plugins">Allowing a List of Plugins</a> and <a href="#customizing-the-bootstrap">Custom bootstrap scripts</a> for examples of how to completely lock down your agent from arbitrary code execution.</p>
-</div>
+>🚧 Custom hooks
+> If you have a custom <code>command</code> hook, using <code>no-command-eval</code> will have no effect on your command execution. See <a href="#allowing-a-list-of-plugins">Allowing a List of Plugins</a> and <a href="#customizing-the-bootstrap">Custom bootstrap scripts</a> for examples of how to completely lock down your agent from arbitrary code execution.
 
 ## Disabling plugins
 
@@ -67,12 +65,8 @@ setting.
 
 If local hooks are disabled and one is in the checkout, the job will fail.
 
-<div class="Docs__troubleshooting-note">
-  <h3>Building untrusted commits</h3>
-  <p>If you build untrusted commits, be careful to contain the build scripts
-  and anything else that may be influenced by the repository contents within
-  chroots, containers, VMs, etc as is appropriate for your needs.</p>
-</div>
+>🚧 Building untrusted commits
+>If you build untrusted commits, be careful to contain the build scripts and anything else that may be influenced by the repository contents within chroots, containers, VMs, etc as is appropriate for your needs.
 
 ## Strict checks using a `pre-bootstrap` hook
 

--- a/pages/agent/v3/ssh_keys.md.erb
+++ b/pages/agent/v3/ssh_keys.md.erb
@@ -98,9 +98,8 @@ id_rsa.pipeline-1  id_rsa.pipeline-1.pub
 
 Alternatively, you can use a shorter approach to creating multiple SSH keys by adding pipeline-specific environments:
 
-<section class="Docs__note">
-  <p>Note that if you are using Elastic CI Stack for AWS, the following approach is redundant as <a href="https://github.com/buildkite/elastic-ci-stack-for-aws#build-secrets">secrets support</a> allows you to specify an SSH key per pipeline as <code>/{pipeline-slug}/private_ssh_key</code>.</p>
-</section>
+>📘
+> Note that if you are using Elastic CI Stack for AWS, the following approach is redundant as <a href="https://github.com/buildkite/elastic-ci-stack-for-aws#build-secrets">secrets support</a> allows you to specify an SSH key per pipeline as <code>/{pipeline-slug}/private_ssh_key</code>.
 
 1. Add a pipeline-specific environment (for example, by using [Elastic CI Stack for AWS's secrets support](https://github.com/buildkite/elastic-ci-stack-for-aws#build-secrets) or by having an Agent environment hook that switches on the repository URL or the pipeline slug):  
 

--- a/pages/agent/v3/windows.md.erb
+++ b/pages/agent/v3/windows.md.erb
@@ -58,9 +58,8 @@ There are two options to be aware of for this initial setup:
     shell="C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
     ```
 
-<div class="Docs__note">
-<p>Using PowerShell Core (PowerShell 6 or 7) causes unusual behavior around pipeline upload. Refer to <a href="https://buildkite.com/docs/pipelines/defining-steps#step-defaults-pipeline-dot-yml-file">Defining steps: pipeline.yml file</a> for details.</p>
-</div>
+>📘
+> Using PowerShell Core (PowerShell 6 or 7) causes unusual behavior around pipeline upload. Refer to <a href="https://buildkite.com/docs/pipelines/defining-steps#step-defaults-pipeline-dot-yml-file">Defining steps: pipeline.yml file</a> for details.
 
 ## Upgrading
 
@@ -70,9 +69,8 @@ Rerun the install script.
 
 While the agent will work without Git installed, you will require [Git for Windows](https://gitforwindows.org/) to interact with Git. You will need Git Bash to use SSH on Windows 7 or below.
 
-<div class="Docs__note">
-<p>Buildkite does not currently support using Git Bash to run Bash scripts as part of your pipeline. We recommend using CMD (default) or PowerShell 5.x. You can also use PowerShell Core, but be aware of the odd behavior around pipeline upload steps. Refer to <a href="https://buildkite.com/docs/pipelines/defining-steps#step-defaults-pipeline-dot-yml-file">Defining steps: pipeline.yml file</a>for more information.</p>
-</div>
+>📘
+> Buildkite does not currently support using Git Bash to run Bash scripts as part of your pipeline. We recommend using CMD (default) or PowerShell 5.x. You can also use PowerShell Core, but be aware of the odd behavior around pipeline upload steps. Refer to <a href="https://buildkite.com/docs/pipelines/defining-steps#step-defaults-pipeline-dot-yml-file">Defining steps: pipeline.yml file</a>for more information.
 
 ## Running as a service
 
@@ -103,9 +101,8 @@ You can use Buildkite on Windows through WSL2, but it has limitations. At presen
 
 To install the agent on WSL2, follow the [generic Linux installation guide](/docs/agent/v3/linux). Do not use the guides for Ubuntu, Debian, and so on, even if that is the Linux distro you are using with WSL2.
 
-<div class="Docs__note">
-<p>Using WSL2 causes unusual behavior during pipeline upload. Refer to <a href="https://buildkite.com/docs/pipelines/defining-steps#step-defaults-pipeline-dot-yml-file">Defining steps: pipeline.yml file</a> for details.</p>
-</div>
+>📘
+> Using WSL2 causes unusual behavior during pipeline upload. Refer to <a href="https://buildkite.com/docs/pipelines/defining-steps#step-defaults-pipeline-dot-yml-file">Defining steps: pipeline.yml file</a> for details.
 
 ## Security considerations
 

--- a/pages/apis/graphql/graphql_cookbook.md.erb
+++ b/pages/apis/graphql/graphql_cookbook.md.erb
@@ -511,9 +511,9 @@ query getOrgTeams {
 
 Then, add a team member. You can get the `user-id` using the example in [Search for an organization member by email address](#search-for-an-organization-member-by-email-address).
 
-<section class="Docs__note">
-<code>clientMutationId</code> is null when the mutation is successful.
-</section>
+>📘
+> <code>clientMutationId</code> is null when the mutation is successful.
+
 
 ```graphql
 mutation addTeamMember{
@@ -658,15 +658,12 @@ mutation createPipeline {
 }
 ```
 
-<div class="Docs__note">
-<p>When setting pipeline steps using the API, you must pass in a string that Buildkite parses as valid YAML, escaping quotes and line breaks.</p>
-<p> To avoid writing an entire YAML file in a single string, you can place a <code>pipeline.yml</code> file in a <code>.buildkite</code> directory at the root of your repo, and use the <code>pipeline upload</code> command in your pipeline steps to tell Buildkite where to find it. This means you only need the following:</p>
-<p>
-<code>
+>📘
+When setting pipeline steps using the API, you must pass in a string that Buildkite parses as valid YAML, escaping quotes and line breaks.
+> To avoid writing an entire YAML file in a single string, you can place a <code>pipeline.yml</code> file in a <code>.buildkite</code> directory at the root of your repo, and use the <code>pipeline upload</code> command in your pipeline steps to tell Buildkite where to find it. This means you only need the following:
+> <code>
 steps: { yaml: "steps:\n - command: \"buildkite-agent pipeline upload\"" }
 </code>
-</p>
-</div>
 
 ## Revoke an agent token
 
@@ -744,9 +741,8 @@ query TeamMembersQuery {
 
 Then delete a team member. Check that you have the team member ID and not the user ID:
 
-<section class="Docs__note">
-<code>clientMutationId</code> is null when the mutation is successful.
-</section>
+>📘
+> <code>clientMutationId</code> is null when the mutation is successful.
 
 ```graphql
 mutation deleteTeamMember {

--- a/pages/apis/graphql_api.md.erb
+++ b/pages/apis/graphql_api.md.erb
@@ -16,10 +16,8 @@ See our [Getting started tutorial](https://building.buildkite.com/tutorial-getti
 
 You can also use Buildkite's [GraphQL Console](https://buildkite.com/user/graphql/console), or the command line. See our [Tutorial](/docs/apis/graphql/graphql-tutorial) to get started.
 
-<section class="Docs__note">
-  <h3>Note for contributors to public and open-source projects</h3>
-  <p>You need to be a member of the Buildkite organisation to be able to generate and use an API token for it.</p>
-</section>
+>📘 Note for contributors to public and open-source projects
+> You need to be a member of the Buildkite organisation to be able to generate and use an API token for it.
 
 ## Endpoint
 

--- a/pages/apis/managing_api_tokens.md.erb
+++ b/pages/apis/managing_api_tokens.md.erb
@@ -10,10 +10,8 @@ On the [API Access Audit](https://buildkite.com/organizations/~/api-access-audit
 
 When you create a token, select the organizations it grants access to, and for REST APIS the scope of the access. GraphQL tokens cannot be limited by scope.
 
-<section class="Docs__note">
-  <h3>Note for contributors to public and open-source projects</h3>
-  <p>You need to be a member of the Buildkite organisation to be able to generate and use an API token for it.</p>
-</section>
+>📘 Note for contributors to public and open-source projects
+> You need to be a member of the Buildkite organisation to be able to generate and use an API token for it.
 
 REST API scopes are very granular, you can select some or all of the following:
 
@@ -60,9 +58,8 @@ Click through the token you'd like to remove, then click the 'Remove Organizatio
 
 Removing access from a token will send a notification email to the token's owner.
 
-<div class="Docs__note">
-<p>Removing access from a token does not delete the token. Token owners can re-add your organization to their token's scope.</p>
-</div>
+>📘
+> Removing access from a token does not delete the token. Token owners can re-add your organization to their token's scope.
 
 ## Programmatically managing tokens
 

--- a/pages/apis/rest_api.md.erb
+++ b/pages/apis/rest_api.md.erb
@@ -55,10 +55,8 @@ To authenticate using a token, set the <code>Authorization</code> HTTP header to
 curl -H "Authorization: Bearer $TOKEN" https://api.buildkite.com/v2/user
 ```
 
-<section class="Docs__troubleshooting-note">
-  <h3>Basic authentication</h3>
-  <p>Access using basic HTTP authentication is no longer available.</p>
-</section>
+>🚧 Basic authentication
+> Access using basic HTTP authentication is no longer available.
 
 ## Pagination
 

--- a/pages/apis/rest_api/access_token.md.erb
+++ b/pages/apis/rest_api/access_token.md.erb
@@ -2,9 +2,8 @@
 
 The Access Token API allows you to inspect and revoke an API Access Token. This can be useful if you find a token, can't identify its owner, and you want to revoke it.
 
-<div class="Docs__note">
-  <p>All the endpoints expect the token to be provided using the <a href="/docs/apis/rest-api#authentication">Authorization HTTP header</a>.
-</div>
+>📘
+> All the endpoints expect the token to be provided using the <a href="/docs/apis/rest-api#authentication">Authorization HTTP header</a>.
 
 {:toc}
 

--- a/pages/apis/rest_api/agents.md.erb
+++ b/pages/apis/rest_api/agents.md.erb
@@ -139,15 +139,10 @@ Success response: `200 OK`
 
 ## Stop an agent
 
-<div class="Docs__note">
-  <p class="Docs__note__heading">Required permissions</p>
-To stop an agent you need either
-    <ul>
-       <li>An Admin user API token with `write_agents` <a href="/docs/apis/managing-api-tokens#token-scopes">scope</a></li>
-       <li>Or, if you're using <a href="/docs/pipelines/permissions#member-permissions">Member Permissions</a>, a user token with the <em>Stop Agents</em> permission</li>
-    </ul>
-  </p>
-</div>
+>📘 Required permissions
+> To stop an agent you need either
+- An Admin user API token with `write_agents` <a href="/docs/apis/managing-api-tokens#token-scopes">scope</a>
+- Or, if you're using <a href="/docs/pipelines/permissions#member-permissions">Member Permissions</a>, a user token with the <em>Stop Agents</em> permission
 
 Instruct an agent to stop accepting new build jobs and shut itself down.
 

--- a/pages/apis/rest_api/annotations.md.erb
+++ b/pages/apis/rest_api/annotations.md.erb
@@ -21,9 +21,8 @@ An annotation is a snippet of Markdown uploaded by your agent during the executi
 
 Returns a [paginated list](<%= paginated_resource_docs_url %>) of a build's annotations.
 
-<section class="Docs__note">
-Note that you need the <a href="/docs/apis/rest-api/builds#build-number-vs-build-id">build number</a> to retrieve annotations, not the build ID.
-</section>
+>📘
+> Note that you need the <a href="/docs/apis/rest-api/builds#build-number-vs-build-id">build number</a> to retrieve annotations, not the build ID.
 
 ```bash
 curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.slug}/builds/{build.number}/annotations"

--- a/pages/apis/rest_api/artifacts.md.erb
+++ b/pages/apis/rest_api/artifacts.md.erb
@@ -22,10 +22,8 @@ An artifact is a file uploaded by your agent during the execution of a build's j
 </tbody>
 </table>
 
-<section class="Docs__troubleshooting-note">
-  <h3>Deprecated fields</h3>
-  <p>Artifacts previously included <code>glob_path</code> and <code>original_path</code> but these were <a href="https://buildkite.com/changelog/71-artifacts-glob-path-and-original-path-fields-are-deprecated">deprecated</a> and now return <code>null</code>.</p>
-</section>
+>🚧 Deprecated fields
+>Artifacts previously included <code>glob_path</code> and <code>original_path</code> but these were <a href="https://buildkite.com/changelog/71-artifacts-glob-path-and-original-path-fields-are-deprecated">deprecated</a> and now return <code>null</code>.
 
 ## List artifacts for a build
 

--- a/pages/apis/rest_api/pipelines.md.erb
+++ b/pages/apis/rest_api/pipelines.md.erb
@@ -680,9 +680,9 @@ curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{
   }'
 ```
 
-<div class="Docs__troubleshooting-note">
-  <p>Patch requests can only update attributes already present in the pipeline YAML.</p>
-</div>
+>🚧
+> Patch requests can only update attributes already present in the pipeline YAML.
+
 
 ```json
 {
@@ -818,9 +818,8 @@ Error responses:
 </tbody>
 </table>
 
-<div class="Docs__troubleshooting-note">
-  <p>To update a pipeline's teams, please use the <a href="/docs/apis/graphql-api">GraphQL API</a>.</p>
-</div>
+>🚧
+> To update a pipeline's teams, please use the <a href="/docs/apis/graphql-api">GraphQL API</a>.
 
 ## Archive a pipeline
 

--- a/pages/apis/rest_api/pipelines.md.erb
+++ b/pages/apis/rest_api/pipelines.md.erb
@@ -177,15 +177,14 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines" \
     }'
 ```
 
-<div class="Docs__note">
-<p>When setting pipeline configuration using the API, you must pass in a string that Buildkite parses as valid YAML, escaping quotes and line breaks.</p>
-<p> To avoid writing an entire YAML file in a single string, you can place a <code>pipeline.yml</code> file in a <code>.buildkite</code> directory at the root of your repo, and use the <code>pipeline upload</code> command in your configuration to tell Buildkite where to find it. This means you only need the following:</p>
-<p>
+>📘
+> When setting pipeline configuration using the API, you must pass in a string that Buildkite parses as valid YAML, escaping quotes and line breaks.
+> To avoid writing an entire YAML file in a single string, you can place a <code>pipeline.yml</code> file in a <code>.buildkite</code> directory at the root of your repo, and use the <code>pipeline upload</code> command in your configuration to tell Buildkite where to find it. This means you only need the following:
+>
 <code>
 "configuration": "steps:\n - command: \"buildkite-agent pipeline upload\""
 </code>
-</p>
-</div>
+
 
 The response contains information about your new pipeline:
 

--- a/pages/apis/webhooks.md.erb
+++ b/pages/apis/webhooks.md.erb
@@ -64,10 +64,8 @@ Each event's data is sent JSON encoded in the request body. See each event's doc
 }
 ```
 
-<div class="Docs__troubleshooting-note">
-  <h3>Fast transitions and webhooks</h3>
-  <p>Note that if a builds transitions between states very quickly, for example from blocked (<code>finished</code>) to unblocked (<code>running</code>), the webhook may be in a different state from the actual build. This is a known limitation of webhooks, in that they may represent a later version of the object than the one that triggered the event.</p>
-</div>
+>🚧 Fast transitions and webhooks
+> Note that if a builds transitions between states very quickly, for example from blocked (<code>finished</code>) to unblocked (<code>running</code>), the webhook may be in a different state from the actual build. This is a known limitation of webhooks, in that they may represent a later version of the object than the one that triggered the event.
 
 ## Webhook token
 

--- a/pages/apis/webhooks/build_events.md.erb
+++ b/pages/apis/webhooks/build_events.md.erb
@@ -62,7 +62,6 @@ Example request body for blocked build:
   }
 }
 ```
-<div class="Docs__note">
-  <h3 class="Docs__note__heading">To determine if an Eventbridge notification is blocked</h3>
-  <p>However, to determine if an Eventbridge notification is blocked, look for <code>"state": "blocked". </code>, like in this <a href="/docs/integrations/amazon-eventbridge#events-build-blocked">sample Eventbridge request</a>.</p>
-</div>
+
+>📘 To determine if an Eventbridge notification is blocked
+> However, to determine if an Eventbridge notification is blocked, look for <code>"state": "blocked". </code>, like in this <a href="/docs/integrations/amazon-eventbridge#events-build-blocked">sample Eventbridge request</a>.

--- a/pages/deployments/deploying_to_kubernetes.md.erb
+++ b/pages/deployments/deploying_to_kubernetes.md.erb
@@ -55,16 +55,8 @@ Let's start with manifest file. This sample file creates a Deployment with
 three replicas (horizontal scale in Kubernetes lingo) each listening port
 `3000`. Change the `containerPort` to fit your application.
 
-<section class="Docs__note">
-  <p>
-    The <a
-    href="https://kubernetes.io/docs/concepts/workloads/controllers/deployment/">official
-    deployment documentation</a> covers much more than what fits in this
-    tutorial. Refer back to these docs for information on setting CPU and
-    memory, controlling networking, deployment update strategies, and how to
-    expose your application to the internet.
-  </p>
-</section>
+>📘
+> The <a href="https://kubernetes.io/docs/concepts/workloads/controllers/deployment/">official deployment documentation</a> covers much more than what fits in this tutorial. Refer back to these docs for information on setting CPU and memory, controlling networking, deployment update strategies, and how to expose your application to the internet.
 
 Let's call this file `k8s/deployment.yml`.
 

--- a/pages/integrations/bitbucket_server.md.erb
+++ b/pages/integrations/bitbucket_server.md.erb
@@ -4,9 +4,8 @@ Buildkite integrates with Bitbucket Server to provide automated builds based on 
 
 Bitbucket Enterprise Server is available to customers on the Buildkite [Business and Enterprise](https://buildkite.com/pricing) plans.
 
-<div class="Docs__note">
-This guide shows you how to set up your Bitbucket Server builds with Buildkite. It was written using Bitbucket Server version 7.11.1
-</div>
+>📘
+> This guide shows you how to set up your Bitbucket Server builds with Buildkite. It was written using Bitbucket Server version 7.11.1
 
 {:toc}
 

--- a/pages/integrations/github.md.erb
+++ b/pages/integrations/github.md.erb
@@ -10,10 +10,8 @@ To complete this integration, you need admin privileges for your GitHub reposito
 
 You can use the [Buildkite app for GitHub](#connect-your-buildkite-account-to-github-using-the-github-app) to connect a Buildkite organization to a GitHub organization.
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">Benefits of using the GitHub App</h3>
-<p>Using GitHub App removes the reliance on individual user connections to report build statuses. See the <a href="https://buildkite.com/changelog/102-github-app-integration">changelog announcement</a></p>
-</div>
+>📘 Benefits of using the GitHub App
+> Using GitHub App removes the reliance on individual user connections to report build statuses. See the <a href="https://buildkite.com/changelog/102-github-app-integration">changelog announcement</a>
 
 If you want to [connect using OAuth](#connect-your-buildkite-account-to-github-using-oauth) you can still do so from your _Personal Settings_.
 
@@ -21,10 +19,8 @@ If you want to [connect using OAuth](#connect-your-buildkite-account-to-github-u
 
 Connecting Buildkite and GitHub using the GitHub App lets your GitHub organization admins see permissions and manage access on a per-repository basis.
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">Required permissions for adding a provider</h3>
-<p>The user adding the provider needs to be a Buildkite user connected to a GitHub user who has administrative privileges on both Buildkite and the GitHub organizations.</p>
-</div>
+>📘 Required permissions for adding a provider
+> The user adding the provider needs to be a Buildkite user connected to a GitHub user who has administrative privileges on both Buildkite and the GitHub organizations.
 
 1. Open your Buildkite organization's _Settings_.
 1. Select _[Repository Providers](https://buildkite.com/organizations/~/repository-providers)_ > _GitHub_.

--- a/pages/integrations/github_enterprise.md.erb
+++ b/pages/integrations/github_enterprise.md.erb
@@ -6,10 +6,9 @@ GitHub Enterprise Server is available to Buildkite customers on Business and Ent
 
 {:toc}
 
-<div class="Docs__note">
-<p>This guide was written using GitHub Enterprise version 2.16.3. Earlier or later versions may have different menus and headings for the OAuth app registration. All of the Buildkite settings will remain the same.</p>
-<p>This guide describes the setup for self-hosted GitHub Enterprise Server. GitHub Enterprise Cloud users should refer to <a href="https://buildkite.com/docs/integrations/github" rel="nofollow">GitHub</a>.</p>
-</div>
+>📘 This guide was written using GitHub Enterprise version 2.16.3.
+> Earlier or later versions may have different menus and headings for the OAuth app registration. All of the Buildkite settings will remain the same.
+> This guide describes the setup for self-hosted GitHub Enterprise Server. GitHub Enterprise Cloud users should refer to <a href="https://buildkite.com/docs/integrations/github" rel="nofollow">GitHub</a>.
 
 ## Step 1: Register Buildkite as an OAuth app
 

--- a/pages/integrations/gitlab.md.erb
+++ b/pages/integrations/gitlab.md.erb
@@ -10,9 +10,8 @@ If you host your repositories on [gitlab.com](https://gitlab.com/) enter your gi
 
 ## GitLab Community/Enterprise Edition
 
-<section class="Docs__note">
-  <p>The earliest supported version of GitLab is <a href=https://about.gitlab.com/2014/10/22/gitlab-7-4-released/>7.4</a>.</p>
-</section>
+>📘
+> The earliest supported version of GitLab is <a href=https://about.gitlab.com/2014/10/22/gitlab-7-4-released/>7.4</a>.
 
 1. Open your Buildkite _Organization Settings_ and choose [Repository Providers](https://buildkite.com/organizations/-/repository-providers)
 2. Select _GitLab_.

--- a/pages/integrations/phabricator.md.erb
+++ b/pages/integrations/phabricator.md.erb
@@ -11,9 +11,8 @@ Phabricator and Buildkite integrate using webhooks. Phabricator triggers builds 
 Check that your repository is activated in your Phabricator instance and
 Harbormaster is installed. Configure a pipeline for that repository in Buildkite. You'll also need to create a Buildkite API Access Token.
 
-<div class="Docs__note">
-	<p>Admin access in both Phabricator and your Buildkite organization will be required.</p>
-</div>
+>📘
+> Admin access in both Phabricator and your Buildkite organization will be required.
 
 ## Step 1: New Phabricator build step
 

--- a/pages/integrations/sso.md.erb
+++ b/pages/integrations/sso.md.erb
@@ -49,9 +49,8 @@ If you are the administrator of an organization within Buildkite with an existin
 1. [Add](/docs/integrations/sso#adding-sso) a new SSO provider, verify it, and allow login from both SSO providers. The users in your organization can continue to sign in and use the same user accounts within Buildkite as long as the emails stay the same.
 2. [Disable and remove](/docs/integrations/sso#disabling-and-removing-sso) the SSO provider you no longer need. If the user credentials (email) stay the same, this is all you need to migrate from one SSO provider to another.
 
-<div class="Docs__note">
-  <p>If you are also changing the email provider, make sure that Buildkite users in your organization sign in to their existing accounts when performing single sign-on through the new provider to prevent your organization being billed twice for the same users.</p>
-</div>
+>📘
+> If you are also changing the email provider, make sure that Buildkite users in your organization sign in to their existing accounts when performing single sign-on through the new provider to prevent your organization being billed twice for the same users.
 
 If you'd like to have some help with the migration, contact support@buildkite.com.
 

--- a/pages/integrations/sso/adfs.md.erb
+++ b/pages/integrations/sso/adfs.md.erb
@@ -4,9 +4,8 @@ You can use Active Directory Federation Services (ADFS) for your Buildkite organ
 
 ADFS SSO is available to customers on the Buildkite customers on the [Enterprise](https://buildkite.com/pricing) plan.
 
-<div class="Docs__note">
-  <p>You can also set up SSO providers manually with GraphQL. See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.</p>
-</div>
+>📘 You can also set up SSO providers manually with GraphQL.
+> See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.
 
 {:toc}
 
@@ -29,12 +28,9 @@ The instructions below guide you through using a series of wizards to:
 
 With these wizards, you'll set up your domain for SSO and retrieve the information the Buildkite team requires to complete the setup process.
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">This guide was written for, and tested using, Windows Server 2016</h3>
-<p>Some of the wizard pages and dialog tab names have changed across versions of Windows Server.</p>
-
-<p>For a guide written for Windows Server 2012, the <a href="https://www.pagerduty.com/docs/guides/adfs-sso-guide/">PagerDuty SSO integration guide</a> is very similar to Buildkite. Follow the PagerDuty instructions, and substitute in the Buildkite values from the instructions below.</p>
-</div>
+>📘 This guide was written for, and tested using, Windows Server 2016
+> Some of the wizard pages and dialog tab names have changed across versions of Windows Server.
+> For a guide written for Windows Server 2012, the <a href="https://www.pagerduty.com/docs/guides/adfs-sso-guide/">PagerDuty SSO integration guide</a> is very similar to Buildkite. Follow the PagerDuty instructions, and substitute in the Buildkite values from the instructions below.
 
 ### Step 2.1 Add a relying party trust
 

--- a/pages/integrations/sso/azure_ad.md.erb
+++ b/pages/integrations/sso/azure_ad.md.erb
@@ -55,9 +55,8 @@ Then, on your [Buildkite Organization Settings](https://buildkite.com/organizati
 
 Once you've [performed a test login](#step-4-perform-a-test-login) you can enable your SSO provider using the _Enable_ button. Enabling the SSO provider will not force a log out of any signed in users, but will cause all new or expired sessions to authorize through Azure AD before accessing any organization data.
 
-<div class="Docs__troubleshooting-note">
-  <p>If you need to edit or update your Azure Active Directory provider settings, you will need to <a href="/docs/integrations/sso#disabling-and-removing-sso">disable the SSO provider</a> first.</p>
-</div>
+>🚧
+>If you need to edit or update your Azure Active Directory provider settings, you will need to <a href="/docs/integrations/sso#disabling-and-removing-sso">disable the SSO provider</a> first.
 
 ## Using SCIM to provision and manage users
 

--- a/pages/integrations/sso/azure_ad.md.erb
+++ b/pages/integrations/sso/azure_ad.md.erb
@@ -2,9 +2,8 @@
 
 You can use [Azure Active Directory](https://azure.microsoft.com/en-us/services/active-directory/#overview) as an SSO provider for your Buildkite organization. To complete this tutorial, you need admin privileges for both Azure and Buildkite.
 
-<div class="Docs__note">
-  <p>You can also set up SSO providers manually with GraphQL. See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.</p>
-</div>
+>📘 You can also set up SSO providers manually with GraphQL.
+> See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.
 
 {:toc}
 
@@ -67,17 +66,15 @@ Enterprise customers can automatically add and remove user accounts from their B
 * Create users
 * Deactivate users (deprovisioning)
 
-<div class="Docs__note">
-  <p>Buildkite does not bill you for users that you add to Azure AD until they sign in to your Buildkite organization.</p>
-</div>
+>📘
+> Buildkite does not bill you for users that you add to Azure AD until they sign in to your Buildkite organization.
 
 ### Configuration instructions
 
 Adding and removing users accounts in Azure AD is called provisioning. You need an enabled Azure AD SSO Provider for your Buildkite Organization before you can set up SCIM provisioning.
 
-<div class="Docs__note">
-  <p>User deprovisioning is an Enterprise only feature that needs to be enabled. Please contact support at support@buildkite.com to have this enabled.</p>
-</div>
+>📘
+> User deprovisioning is an Enterprise only feature that needs to be enabled. Please contact support at support@buildkite.com to have this enabled.
 
 After enabling your Azure AD SSO provider in Buildkite, get the _Base URL_ and _API Token_ from your Azure AD SSO provider settings:
 

--- a/pages/integrations/sso/custom_saml.md.erb
+++ b/pages/integrations/sso/custom_saml.md.erb
@@ -8,9 +8,7 @@ SAML customization is available to customers on the Buildkite [Enterprise](https
 
 There are two workflows for setting up a new SAML provider, depending on your IdP's setup process: if you require an ACS URL from Buildkite to complete your IdP's setup, or if you can complete the setup without anything from Buildkite.
 
-<div class="Docs__note">
-  <p>You can also set up SSO providers manually with GraphQL. See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.</p>
-</div>
+>📘 You can also set up SSO providers manually with GraphQL. See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.
 
 ## Set up with an ACS URL
 

--- a/pages/integrations/sso/google_workspace.md.erb
+++ b/pages/integrations/sso/google_workspace.md.erb
@@ -10,9 +10,8 @@ In your Buildkite Organization Settings' _Single Sign On_ menu item, choose the 
 
 <%= image "sso-settings.png", width: 1716/2, height: 884/2, alt: "Screenshot of the Buildkite SSO Settings Page" %>
 
-<div class="Docs__note">
-  <p>You can also set up SSO providers manually with GraphQL. See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.</p>
-</div>
+>📘 You can also set up SSO providers manually with GraphQL.
+> See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.
 
 ## Step 2. Perform a test login
 

--- a/pages/integrations/sso/google_workspace_saml.md.erb
+++ b/pages/integrations/sso/google_workspace_saml.md.erb
@@ -68,9 +68,8 @@ Save your settings. Your provider page opens.
 
 Follow the instructions on the provider page to perform a test login. Performing a test login verifies that SSO is working correctly before you activate it for your organization members.
 
-<div class="Docs__troubleshooting-note">
-  <p>According to Google, "Changes may take up to 24 hours to propagate to all user". Some changes may take at least several hours, so if the test login fails, it is worth waiting and trying again.</p>
-</div>
+>🚧
+> According to Google, "Changes may take up to 24 hours to propagate to all user". Some changes may take at least several hours, so if the test login fails, it is worth waiting and trying again.
 
 ## Step 4. Enable the new SSO provider
 

--- a/pages/integrations/sso/google_workspace_saml.md.erb
+++ b/pages/integrations/sso/google_workspace_saml.md.erb
@@ -4,9 +4,8 @@ As an alternative to [Google Workspace SSO using OpenID](/docs/integrations/sso/
 
 To complete this tutorial, you need admin privileges for both Google Workspace and Buildkite.
 
-<div class="Docs__note">
-  <p>You can also set up SSO providers manually with GraphQL. See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.</p>
-</div>
+>📘 You can also set up SSO providers manually with GraphQL.
+> See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.
 
 After following these steps, your Google Workspace users can sign in to Buildkite using their Google account.  
 

--- a/pages/integrations/sso/okta.md.erb
+++ b/pages/integrations/sso/okta.md.erb
@@ -17,17 +17,15 @@ Customers on the Buildkite [Enterprise](https://buildkite.com/pricing) plan can 
 * Create users
 * Deactivate users (deprovisioning)
 
-<div class="Docs__note">
-  <p>Buildkite does not bill you for users that you add to your Okta Buildkite app until they sign in to your Buildkite organization.</p>
-</div>
+>📘
+> Buildkite does not bill you for users that you add to your Okta Buildkite app until they sign in to your Buildkite organization.
 
 ### Configuration instructions
 
 Using the SCIM provisioning settings in Okta, Buildkite customers on the [Enterprise](https://buildkite.com/pricing) plan can automatically remove user accounts from your Buildkite organization. In Okta this feature is called 'Deactivating' a user. You need an enabled Okta SSO Provider before you can set up SCIM.
 
-<div class="Docs__note">
-  <p>User deprovisioning is an Enterprise only feature that needs to be enabled. Please contact support at support@buildkite.com to have this enabled.</p>
-</div>
+>📘
+> User deprovisioning is an Enterprise only feature that needs to be enabled. Please contact support at support@buildkite.com to have this enabled.
 
 After creating your SSO Provider in Buildkite, you will need the  _Base URL_ and _API Token_ from your Okta SSO Provider Settings:
 

--- a/pages/integrations/sso/onelogin.md.erb
+++ b/pages/integrations/sso/onelogin.md.erb
@@ -44,9 +44,8 @@ On the following screen in the setup form, enter your IdP data. The following th
     </tr>
 </table>
 
-<div class="Docs__note">
-  <p>You can also set up SSO providers manually with GraphQL. See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.</p>
-</div>
+>📘 You can also set up SSO providers manually with GraphQL.
+> See the <a href="/docs/integrations/sso/sso-setup-with-graphql">SSO Setup with GraphQL Guide</a> for detailed instructions and code samples.
 
 ## Step 3. Perform a test login
 

--- a/pages/integrations/sso/sso_setup_with_graphql.md.erb
+++ b/pages/integrations/sso/sso_setup_with_graphql.md.erb
@@ -72,9 +72,8 @@ mutation EnableProvider {
 
 You should now see that the provider's state is enabled.
 
-<section class="Docs__troubleshooting-note">
-  <p>See the <code>SSOProviderUpdatePayload</code> documentation for other properties that can be configured on your SSO provider, such as <code>sessionDurationInHours</code> and <code>note</code>.</p>
-</section>
+>🚧
+> See the <code>SSOProviderUpdatePayload</code> documentation for other properties that can be configured on your SSO provider, such as <code>sessionDurationInHours</code> and <code>note</code>.
 
 ## Setting up SAML (Google Cloud Identity, Okta, OneLogin, ADFS and others)
 
@@ -195,9 +194,8 @@ mutation EnableProvider {
 
 You should now see that the provider's state is enabled.
 
-<section class="Docs__troubleshooting-note">
-  <p>See the <code>SSOProviderUpdatePayload</code> documentation for other properties that can be configured on your SSO provider, such as <code>sessionDurationInHours</code> and <code>note</code>.</p>
-</section>
+>🚧
+> See the <code>SSOProviderUpdatePayload</code> documentation for other properties that can be configured on your SSO provider, such as <code>sessionDurationInHours</code> and <code>note</code>.
 
 ## Finding an SSO provider's details
 

--- a/pages/integrations/sso/sso_setup_with_graphql.md.erb
+++ b/pages/integrations/sso/sso_setup_with_graphql.md.erb
@@ -2,9 +2,8 @@
 
 Buildkite's Single Sign-On (SSO) can be set up by emailing support, or you can set it up manually using our [GraphQL APIs](/docs/apis/graphql-api). This tutorial covers how to set up SSO manually using GraphQL.
 
-<section class="Docs__note">
-  <p>For details on every available option available in the GraphQL APIs, please use the documentation sidebar built into the <a href="/docs/graphql-api#getting-started">GraphQL Explorer</a>.</p>
-</section>
+>📘
+> For details on every available option available in the GraphQL APIs, please use the documentation sidebar built into the <a href="/docs/graphql-api#getting-started">GraphQL Explorer</a>.
 
 {:toc}
 

--- a/pages/pipelines.md.erb
+++ b/pages/pipelines.md.erb
@@ -94,7 +94,5 @@ Job exit status may include the exit signal reason, which indicates whether the 
 
 <%= image "exit-status.png", width: 2048/2, height: 880/2, alt: "Exit status of a job" %>
 
-<section class="Docs__troubleshooting-note">
-  <p>Exit status information available in the <a href="/docs/apis/graphql-api">GraphQL API</a> but not the <a href="/docs/apis/rest-api">REST API</a>.</p>
-</section>
-
+>🚧
+> Exit status information available in the <a href="/docs/apis/graphql-api">GraphQL API</a> but not the <a href="/docs/apis/rest-api">REST API</a>.

--- a/pages/pipelines/_build_states.md.erb
+++ b/pages/pipelines/_build_states.md.erb
@@ -1,9 +1,8 @@
 Build state can be one of `creating`, `scheduled`, `running`, `passed`, `failing`, `failed`, `blocked`, `canceling`, `canceled`, `skipped`, `not_run`.
 You can query for `finished` builds to return builds in any of the following states: `passed`, `failed`, `blocked`, or `canceled`.
 
-<section class="Docs__troubleshooting-note">
-<p>When a <a href="/docs/pipelines/trigger-step">triggered build</a> fails, the step that triggered it will be stuck in the <code>running</code> state forever.</p>
-</section>
+>🚧
+> When a <a href="/docs/pipelines/trigger-step">triggered build</a> fails, the step that triggered it will be stuck in the <code>running</code> state forever.
 
 <section class="Docs__note">
 <p>When all the steps in a build are skipped (either by using skip attribute or by using `if` condition), the build state will be marked as `not_run`.</p>

--- a/pages/pipelines/_build_states.md.erb
+++ b/pages/pipelines/_build_states.md.erb
@@ -4,6 +4,5 @@ You can query for `finished` builds to return builds in any of the following sta
 >🚧
 > When a <a href="/docs/pipelines/trigger-step">triggered build</a> fails, the step that triggered it will be stuck in the <code>running</code> state forever.
 
-<section class="Docs__note">
-<p>When all the steps in a build are skipped (either by using skip attribute or by using `if` condition), the build state will be marked as `not_run`.</p>
-</section>
+>📘
+> When all the steps in a build are skipped (either by using skip attribute or by using `if` condition), the build state will be marked as `not_run`.

--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -339,9 +339,8 @@ You can access the stored meta-data after the block step has passed. Use the `bu
 buildkite-agent meta-data get "release-name"
 ```
 
-<div class="Docs__troubleshooting-note">
-  <p>Meta-data cannot be interpolated directly from the <code>pipeline.yml</code> at runtime. The meta-data store can only be accessed from within a command step.</p>
-</div>
+>🚧
+> Meta-data cannot be interpolated directly from the <code>pipeline.yml</code> at runtime. The meta-data store can only be accessed from within a command step.
 
 In the below example, the script uses the `buildkite-agent` meta-data command to retrieve the meta-data and print it to the log:
 

--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -120,10 +120,8 @@ steps:
 
 ## Text input attributes
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">Line endings</h3>
-<p>A text field normalizes line endings to Unix format (<code>\n</code>).</p>
-</div>
+>📘 Line endings
+> A text field normalizes line endings to Unix format (<code>\n</code>).
 
 _Required attributes:_
 

--- a/pages/pipelines/branch_configuration.md.erb
+++ b/pages/pipelines/branch_configuration.md.erb
@@ -51,9 +51,8 @@ steps:
 
 The `branches` attribute cannot be used at the same time as the `if` attribute. See more in [Conditionals in steps](/docs/pipelines/conditionals#conditionals-in-steps).
 
-<section class="Docs__note">
-  <p>Step-level branch filters will only affect the step that they are added to. Subsequent steps without branch filters will still be added to the pipeline.</p>
-</section>
+>📘
+> Step-level branch filters will only affect the step that they are added to. Subsequent steps without branch filters will still be added to the pipeline.
 
 ## Branch pattern examples
 

--- a/pages/pipelines/build_matrix.md.erb
+++ b/pages/pipelines/build_matrix.md.erb
@@ -43,9 +43,8 @@ steps:
 
 All jobs created by a build matrix are marked with the _Matrix_ badge in the Buildkite interface.
 
-<div class="Docs__note">
-<p class="Docs__note__heading">Matrix and Parallel steps</h3>
-<p>Matrix builds are not compatible with explicit <a href="/docs/tutorials/parallel-builds#parallel-jobs">parallelism in steps</a>. You can use a <code>matrix</code> and <code>parellism</code> in the same build, as long as they are on separate steps.</p></div>
+>📘 Matrix and Parallel steps
+> Matrix builds are not compatible with explicit <a href="/docs/tutorials/parallel-builds#parallel-jobs">parallelism in steps</a>. You can use a <code>matrix</code> and <code>parellism</code> in the same build, as long as they are on separate steps.
 
 For more complex builds, add multiple dimensions to `matrix.setup` instead of the `matrix` array:
 

--- a/pages/pipelines/build_meta_data.md.erb
+++ b/pages/pipelines/build_meta_data.md.erb
@@ -32,10 +32,8 @@ buildkite-agent meta-data get "release-version"
 
 Assuming that the "release-version" key was set with the value from the Setting Data example, this command will return "1.1". If there are no keys matching the name "release-version", it will return an error.
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">Default values</h3>
-<p>The `get` command has a `default` flag. You can use this to return a value in the case that the key has not been set.</p>
-</div>
+>📘 Default values
+> The `get` command has a `default` flag. You can use this to return a value in the case that the key has not been set.
 
 ## Using meta-data on the dashboard
 

--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -40,10 +40,8 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-<div class="Docs__note">
-  <h3 class="Docs__note__heading">Pipelines without command steps</h3>
-  <p>Although the <code>command</code> attribute is required for a command step, some <a href="/docs/plugins/using#adding-a-plugin-to-your-pipeline">plugins</a> work without a command step, so it isn't strictly necessary for your pipeline to have an explicit command step.</p>
-</div>
+>📘 Pipelines without command steps
+> Although the <code>command</code> attribute is required for a command step, some <a href="/docs/plugins/using#adding-a-plugin-to-your-pipeline">plugins</a> work without a command step, so it isn't strictly necessary for your pipeline to have an explicit command step.
 
 _Optional attributes:_
 
@@ -317,10 +315,8 @@ _Optional Attributes_
   </tr>
 </table>
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">-1 exit status</h3>
-<p>A job will fail with an exit status of -1 if communication with the agent has been lost (for example, the agent has been forcefully terminated, or the agent machine was shut down without allowing the agent to disconnect). See the section on <a href="/docs/agent/v3#exit-codes">Exit Codes</a> for information on other exit codes.</p>
-</div>
+>📘 -1 exit status
+> A job will fail with an exit status of -1 if communication with the agent has been lost (for example, the agent has been forcefully terminated, or the agent machine was shut down without allowing the agent to disconnect). See the section on <a href="/docs/agent/v3#exit-codes">Exit Codes</a> for information on other exit codes.
 
 ```yml
 steps:

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -155,41 +155,37 @@ The following expressions are supported by the `if` attribute.
  	</tbody>
  </table>
 
-<div class="Docs__troubleshooting-note">
-  <h3>Formatting regular expressions</h3>
-  <p>When using regular expressions in conditionals, the regular expression must be on the right hand side, and the use of the <code>$</code> anchor symbol must be escaped to avoid <a href="/docs/agent/v3/cli-pipeline#environment-variable-substitution">environment variable substitution</a>. For example, to match branches ending in <code>"/feature"</code> the conditional statement would be <code>build.branch =~ /\/feature$$/</code>.
-</div>
+>🚧 Formatting regular expressions
+> When using regular expressions in conditionals, the regular expression must be on the right hand side, and the use of the <code>$</code> anchor symbol must be escaped to avoid <a href="/docs/agent/v3/cli-pipeline#environment-variable-substitution">environment variable substitution</a>. For example, to match branches ending in <code>"/feature"</code> the conditional statement would be <code>build.branch =~ /\/feature$$/</code>.
 
 ### Variables
 
 The following variables are supported by the `if` attribute. Note that you cannot use [Build Meta-data](/docs/pipelines/build-meta-data) in conditional expressions.
 
-<div class="Docs__troubleshooting-note">
-  <h3 id="unverified">Unverified commits</h3>
-	<p>Note that GitHub accepts <a href="https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification">unsigned commits</a>, including information about the commit author and passes them along to webhooks, so you should not rely on these for authentication unless you are confident that all of your commits are trusted.</p>
-</div>
+>🚧 Unverified commits
+> Note that GitHub accepts <a href="https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification">unsigned commits</a>, including information about the commit author and passes them along to webhooks, so you should not rely on these for authentication unless you are confident that all of your commits are trusted.
 
 <table>
 <tbody>
 	<tr>
 		<td><code>build.author.email</code></td>
 		<td><code>String</code></td>
-		<td>The <strong><a href="#unverified">unverified</a></strong> email address of the user who authored the build's commit</td>
+		<td>The <strong><a href="#unverified-commits">unverified</a></strong> email address of the user who authored the build's commit</td>
 	</tr>
 	<tr>
 		<td><code>build.author.id</code></td>
 		<td><code>String</code></td>
-		<td>The <strong><a href="#unverified">unverified</a></strong> ID of the user who authored the build's commit</td>
+		<td>The <strong><a href="#unverified-commits">unverified</a></strong> ID of the user who authored the build's commit</td>
 	</tr>
 	<tr>
 		<td><code>build.author.name</code></td>
 		<td><code>String</code></td>
-		<td>The <strong><a href="#unverified">unverified</a></strong> name of the user who authored the build's commit</td>
+		<td>The <strong><a href="#unverified-commits">unverified</a></strong> name of the user who authored the build's commit</td>
 	</tr>
 	<tr>
 		<td><code>build.author.teams</code></td>
 		<td><code>Array</code></td>
-		<td>An <strong><a href="#unverified">unverified</a></strong> array of the team/s which the user who authored the build's commit is a member of</td>
+		<td>An <strong><a href="#unverified-commits">unverified</a></strong> array of the team/s which the user who authored the build's commit is a member of</td>
 	</tr>
 	<tr>
 		<td><code>build.branch</code></td>
@@ -204,22 +200,22 @@ The following variables are supported by the `if` attribute. Note that you canno
 	<tr>
 		<td><code>build.creator.email</code></td>
 		<td><code>String</code></td>
-		<td>The <strong><a href="#unverified">unverified</a></strong> email of the user who created the build. </td>
+		<td>The <strong><a href="#unverified-commits">unverified</a></strong> email of the user who created the build. </td>
 	</tr>
 	<tr>
 		<td><code>build.creator.id</code></td>
 		<td><code>String</code></td>
-		<td>The <strong><a href="#unverified">unverified</a></strong> ID of the user who created the build</td>
+		<td>The <strong><a href="#unverified-commits">unverified</a></strong> ID of the user who created the build</td>
 	</tr>
 	<tr>
 		<td><code>build.creator.name</code></td>
 		<td><code>String</code></td>
-		<td>The <strong><a href="#unverified">unverified</a></strong> name of the user who created the build</td>
+		<td>The <strong><a href="#unverified-commits">unverified</a></strong> name of the user who created the build</td>
 	</tr>
 	<tr>
 		<td><code>build.creator.teams</code></td>
 		<td><code>Array</code></td>
-		<td>An <strong><a href="#unverified">unverified</a></strong> array of the team/s which the user who created the build is a member of</td>
+		<td>An <strong><a href="#unverified-commits">unverified</a></strong> array of the team/s which the user who created the build is a member of</td>
 	</tr>
 	<tr>
 		<td><code>build.env()</code></td>
@@ -342,10 +338,9 @@ The following variables are supported by the `if` attribute. Note that you canno
 </tbody>
 </table>
 
-<div class="Docs__troubleshooting-note">
-<h3>Using <code>build.env()</code> with custom environment variables</h3>
-<p>To access custom environment variables with the <code>build.env()</code> function, ensure that the <a href="https://buildkite.com/changelog/32-defining-pipeline-build-steps-with-yaml">YAML pipeline steps editor</a> has been enabled in the Pipeline Settings menu.</p>
-</div>
+>🚧 Using <code>build.env()</code> with custom environment variables
+> To access custom environment variables with the <code>build.env()</code> function, ensure that the <a href="https://buildkite.com/changelog/32-defining-pipeline-build-steps-with-yaml">YAML pipeline steps editor</a> has been enabled in the Pipeline Settings menu.
+
 
 ## Example expressions
 
@@ -407,7 +402,7 @@ To run when the value of `CUSTOM_ENVIRONMENT_VARIABLE` is `value`:
 build.env("CUSTOM_ENVIRONMENT_VARIABLE") == "value"
 ```
 
-To run when the **[unverified](#unverified)** build creator is in the `deploy` team:
+To run when the **[unverified](#unverified-commits)** build creator is in the `deploy` team:
 
 ```js
 build.creator.teams includes "deploy"

--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -18,10 +18,8 @@ Pipeline-level build conditionals are evaluated before any other build trigger s
 
 Conditionals are supported in [Bitbucket](/docs/integrations/bitbucket), [Bitbucket Server](/docs/integrations/bitbucket-server), [GitHub](/docs/integrations/github), [GitHub Enterprise](/docs/integrations/github-enterprise), and [GitLab](/docs/integrations/gitlab) (including GitLab Community and GitLab Enterprise). You can add a conditional on your _Pipeline Settings page_ in the Buildkite UI or using the REST API.
 
-<div class="Docs__note">
-  <h3>Evaluating conditionals</h3>
-  <p>Conditional expressions are evaluated at pipeline upload, not at step runtime.</p>
-</div>
+>📘 Evaluating conditionals
+> Conditional expressions are evaluated at pipeline upload, not at step runtime.
 
 ## Conditionals in steps
 

--- a/pages/pipelines/controlling_concurrency.md.erb
+++ b/pages/pipelines/controlling_concurrency.md.erb
@@ -14,10 +14,8 @@ Setting a concurrency limit of `1` on a step in your pipeline will ensure that n
 
 You can add concurrency limits to steps either through Buildkite, or your `pipeline.yml` file. When adding a concurrency limit, you'll also need the `concurrency_group` attribute so that steps in other pipelines can use it as well.
 
-<section class="Docs__troubleshooting-note">
-    <h3>I'm seeing an error about a missing `concurrency_group_id` when I run my pipeline upload</h3>
-    <p>This error is caused by a missing `concurrency_group` attribute. Add this attribute to the same step where you defined the `concurrency` attribute.</p>
-</section>
+>🚧 I'm seeing an error about a missing `concurrency_group_id` when I run my pipeline upload 
+> This error is caused by a missing `concurrency_group` attribute. Add this attribute to the same step where you defined the `concurrency` attribute.
 
 ## Concurrency groups
 

--- a/pages/pipelines/controlling_concurrency.md.erb
+++ b/pages/pipelines/controlling_concurrency.md.erb
@@ -14,7 +14,7 @@ Setting a concurrency limit of `1` on a step in your pipeline will ensure that n
 
 You can add concurrency limits to steps either through Buildkite, or your `pipeline.yml` file. When adding a concurrency limit, you'll also need the `concurrency_group` attribute so that steps in other pipelines can use it as well.
 
->🚧 I'm seeing an error about a missing `concurrency_group_id` when I run my pipeline upload 
+>🚧 I'm seeing an error about a missing `concurrency_group_id` when I run my pipeline upload
 > This error is caused by a missing `concurrency_group` attribute. Add this attribute to the same step where you defined the `concurrency` attribute.
 
 ## Concurrency groups

--- a/pages/pipelines/defining_steps.md.erb
+++ b/pages/pipelines/defining_steps.md.erb
@@ -70,13 +70,10 @@ steps:
 
 When you eventually run a build from this pipeline, this step will look for a directory called `.buildkite` containing a file named `pipeline.yml`. Any steps it finds inside that file will be uploaded to Buildkite and will appear during the build.
 
-<div class="Docs__note">
-
-<p>When using WSL2 or PowerShell Core, you cannot add a <code>buildkite-agent pipeline upload</code> command step directly in the YAML steps editor. To work around this, there are two options:
-<ul>
- <li>Use the YAML steps editor alone</li>
- <li>Place the <code>buildkite-agent pipeline upload</code> command in a script file. In the YAML steps editor, add a command to run that script file. It will upload your pipeline.</li></ul>  </p>
-</div>
+>📘
+> When using WSL2 or PowerShell Core, you cannot add a <code>buildkite-agent pipeline upload</code> command step directly in the YAML steps editor. To work around this, there are two options:
+- Use the YAML steps editor alone
+- Place the <code>buildkite-agent pipeline upload</code> command in a script file. In the YAML steps editor, add a command to run that script file. It will upload your pipeline.
 
 Create your `pipeline.yml` file in a `.buildkite` directory in your repo.
 
@@ -144,9 +141,8 @@ Differentiating between `broken`, `skipped` and `canceled` states:
 * This is distinct from `skipped` jobs, which might happen if a newer build is started and [build skipping](/docs/apis/rest-api/pipelines#create-a-yaml-pipeline) is enabled. Broadly, jobs break because of something inside the build, and are skipped by something outside the build.
 * Jobs can be `canceled` intentionally, either using the Buildkite UI or one of the APIs.
 
-<section class="Docs__note">
-  <p>The <a href="/docs/apis/rest-api/builds">REST API</a> does not return <code>finished</code>, but returns <code>passed</code> or <code>failed</code> according to the exit status of the job. It also lists <code>limiting</code> and <code>limited</code> as <code>scheduled</code> for legacy compatibility.</p>
-</section>
+>📘
+> The <a href="/docs/apis/rest-api/builds">REST API</a> does not return <code>finished</code>, but returns <code>passed</code> or <code>failed</code> according to the exit status of the job. It also lists <code>limiting</code> and <code>limited</code> as <code>scheduled</code> for legacy compatibility.
 
 <%= render_markdown partial: 'pipelines/job_states' %>
 

--- a/pages/pipelines/defining_steps.md.erb
+++ b/pages/pipelines/defining_steps.md.erb
@@ -72,8 +72,8 @@ When you eventually run a build from this pipeline, this step will look for a di
 
 >📘
 > When using WSL2 or PowerShell Core, you cannot add a <code>buildkite-agent pipeline upload</code> command step directly in the YAML steps editor. To work around this, there are two options:
-- Use the YAML steps editor alone
-- Place the <code>buildkite-agent pipeline upload</code> command in a script file. In the YAML steps editor, add a command to run that script file. It will upload your pipeline.
+* Use the YAML steps editor alone
+* Place the <code>buildkite-agent pipeline upload</code> command in a script file. In the YAML steps editor, add a command to run that script file. It will upload your pipeline.
 
 Create your `pipeline.yml` file in a `.buildkite` directory in your repo.
 

--- a/pages/pipelines/defining_steps.md.erb
+++ b/pages/pipelines/defining_steps.md.erb
@@ -105,10 +105,8 @@ For more example steps and detailed configuration options, see the example `pipe
 
 If your pipeline has more than one step and you have multiple agents available to run them, they will automatically run at the same time. If your steps rely on running in sequence, you can separate them with [wait steps](/docs/pipelines/wait-step). This will ensure that any steps before the 'wait' are completed before steps after the 'wait' are run.
 
-<div class="Docs__troubleshooting-note">
-  <h3>Explicit dependencies in uploaded steps </h3>
-  <p>If a step <a href="/docs/pipelines/dependencies">depends</a> on an upload step, then all steps uploaded by that step become dependencies of the original step. For example, if step B depends on step A, and step A uploads step C, then step B will also depend on step C.</p>
-</div>
+>🚧 Explicit dependencies in uploaded steps
+> If a step <a href="/docs/pipelines/dependencies">depends</a> on an upload step, then all steps uploaded by that step become dependencies of the original step. For example, if step B depends on step A, and step A uploads step C, then step B will also depend on step C.
 
 When a step is run by an agent, it will be run with a clean checkout of the pipeline's repository. If your commands or scripts rely on the output from previous steps, you will need to either combine them into a single script or use [artifacts](/docs/pipelines/artifacts) to pass data between steps. This enables any step to be picked up by any agent and run steps in parallel to speed up your build.
 
@@ -154,9 +152,9 @@ Differentiating between `broken`, `skipped` and `canceled` states:
 
 Each job in a build also has a footer that displays exit status information. It may include exit signal reason, which indicates whether the Buildkite agent stopped or the job was cancelled.
 
-<section class="Docs__troubleshooting-note">
-  <p>Exit status information available in the <a href="/docs/apis/graphql-api">GraphQL API</a> but not the <a href="/docs/apis/rest-api">REST API</a>.</p>
-</section>
+>🚧
+> Exit status information available in the <a href="/docs/apis/graphql-api">GraphQL API</a> but not the <a href="/docs/apis/rest-api">REST API</a>.
+
 
 ## Example pipeline
 

--- a/pages/pipelines/dependencies.md.erb
+++ b/pages/pipelines/dependencies.md.erb
@@ -59,10 +59,8 @@ steps:
 
 In the above example, the second command step (build) will not run until the first command step (tests) has completed. Without the `depends_on` attribute, and given enough agents, these steps would run in parallel.
 
-<div class="Docs__troubleshooting-note">
-  <h3><code>depends_on</code> and <code>block</code>/<code>wait</code></h3>
-  <p>Note that a step with an explicit dependency specified with the <code>depends_on</code> attribute will run immediately after the dependency step has completed, without waiting for <code>block</code> or <code>wait</code> steps unless those are also explicit dependencies.</p>
-</div>
+>🚧 <code>depends_on</code> and <code>block</code>/<code>wait</code>
+> Note that a step with an explicit dependency specified with the <code>depends_on</code> attribute will run immediately after the dependency step has completed, without waiting for <code>block</code> or <code>wait</code> steps unless those are also explicit dependencies.
 
 Dependencies can also be added as a list of strings, or a list of steps. Both formats use the the step `key` to refer to the step.
 
@@ -84,10 +82,8 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-<div class="Docs__troubleshooting-note">
-  <h3>Explicit dependencies in uploaded steps </h3>
-  <p>If a step depends on an upload step, then all steps uploaded by that step become dependencies of the original step. For example, if step B depends on step A, and step A uploads step C, then step B will also depend on step C.</p>
-</div>
+>🚧 Explicit dependencies in uploaded steps
+> If a step depends on an upload step, then all steps uploaded by that step become dependencies of the original step. For example, if step B depends on step A, and step A uploads step C, then step B will also depend on step C.
 
 To ensure that a step is not dependent on any other step, add an explicit empty dependency with the `~` character (YAML) or `null` (JSON). This also ensures that the step will run immediately at the start of the build:
 

--- a/pages/pipelines/emojis.md.erb
+++ b/pages/pipelines/emojis.md.erb
@@ -41,7 +41,5 @@ A few common emojis are listed below, but you can see the [full list of availabl
 
 Add your own emoji by opening a [pull request](https://github.com/buildkite/emojis#contributing-new-emoji) containing a 64x64 PNG image and a name to the emoji repository.
 
-<section class="Docs__troubleshooting-note">
-  <h3>Buildkite emojis in other tools</h3>
-  <p>Buildkite loads custom emojis as <a href="https://github.com/buildkite/emojis">images</a>. Other tools, such as GitHub, might not display the images correctly, and will only show the <code>:text-form:</code>.</p>
-</section>
+>🚧 Buildkite emojis in other tools
+> Buildkite loads custom emojis as <a href="https://github.com/buildkite/emojis">images</a>. Other tools, such as GitHub, might not display the images correctly, and will only show the <code>:text-form:</code>.

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -163,10 +163,9 @@ There are many different levels at which environment variables are merged togeth
 
 When a job runs on an agent, the first combination of environment variables happens in the job environment itself. This is the environment you can see in a job's Environment tab in the Buildkite dashboard, and the one returned by the REST and GraphQL APIs.
 
-<div class="Docs__note">
-  <p>If you are not using YAML Steps, the precedence of environment variables is different from the list below.</p>
-  <p>Please <a href="/docs/tutorials/pipeline-upgrade">migrate your pipelines</a> to use YAML steps.</p>
-</div>
+>📘
+> If you are not using YAML Steps, the precedence of environment variables is different from the list below.
+> Please <a href="/docs/tutorials/pipeline-upgrade">migrate your pipelines</a> to use YAML steps.
 
 The job environment is made by merging the following sets of values, where values in each successive set take precedence:
 
@@ -221,9 +220,8 @@ There are two places in a pipeline.yml file that you can set environment variabl
 
 Defining an environment variable at the top of your yaml file will set that variable on each of the command steps in the pipeline, and is equivalent to setting the `env` attribute on every step. This includes further pipeline uploads through `buildkite-agent pipeline upload`.
 
-<div class="Docs__note">
-  <p>Top level pipeline environment variables will override what is set in the <code>env</code> attribute of an individual step.</p>
-</div>
+>📘
+> Top level pipeline environment variables will override what is set in the <code>env</code> attribute of an individual step.
 
 #### Setting variables in a Trigger step
 
@@ -243,9 +241,8 @@ For a list of variables and configuration flags, you can set on your agent, see 
 
 Once the job is accepted by an agent, more environment merging happens. Starting with the environment that we put together in the [Job Environment section](#environment-variable-precedence-job-environment), we merge in some of the variables from the agent environment.
 
-<div class="Docs__note">
-  <p>Not all variables from the agent are available in the job runtime. For example, we remove the agent's registration token and replace it with a build session token that has limited permissions. This new session token is used when you run the <code>artifact</code>, <code>meta-data</code> and <code>pipeline</code> commands inside the job.</p>
-</div>
+>📘
+> Not all variables from the agent are available in the job runtime. For example, we remove the agent's registration token and replace it with a build session token that has limited permissions. This new session token is used when you run the <code>artifact</code>, <code>meta-data</code> and <code>pipeline</code> commands inside the job.
 
 After the agent variables have been merged, the bootstrap script is run.
 

--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -12,10 +12,8 @@ For best practices and recommendations about using secrets in your environment v
 
 The following environment variables may be visible in your commands, plugins, and hooks.
 
-<div class="Docs__troubleshooting-note">
-  <h3 id="unverified">Unverified commits</h3>
-	<p>Note that GitHub accepts <a href="https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification">unsigned commits</a>, including information about the commit author and passes them along to webhooks, so you should not rely on these for authentication unless you are confident that all of your commits are trusted.</p>
-</div>
+>🚧 Unverified commits
+> Note that GitHub accepts <a href="https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification">unsigned commits</a>, including information about the commit author and passes them along to webhooks, so you should not rely on these for authentication unless you are confident that all of your commits are trusted.
 
 <table class="Docs__attribute__table">
   <colgroup>
@@ -117,10 +115,8 @@ You can define environment variables in your jobs in a few ways, depending on th
 * [Build pipeline configuration](/docs/pipelines/command-step) — for values that are *not secret*.
 * An `environment` or `pre-command` [agent hook](/docs/agent/v3/hooks) — for values that are secret or agent-specific.
 
-<section class="Docs__troubleshooting-note">
-  <h3>Secrets in environment variables</h3>
-  <p>Do not print or export secrets in your pipelines. See the <a href="/docs/pipelines/secrets">Secrets</a> documentation for further information and best practices.</p>
-</section>
+>🚧 Secrets in environment variables
+> Do not print or export secrets in your pipelines. See the <a href="/docs/pipelines/secrets">Secrets</a> documentation for further information and best practices.
 
 ## Variable interpolation
 
@@ -258,10 +254,8 @@ The bootstrap runs any hooks that have been defined by your
 Variables that are set in these hooks will be merged into the runtime
 environment, and will override any previous values that are set.
 
-<div class="Docs__troubleshooting-note">
-  <h3>Take care with environment variables in hooks</h3>
-  <p>Variables that are defined in hooks can override anything that exists in the environment.</p>
-</div>
+>🚧 Take care with environment variables in hooks
+> Variables that are defined in hooks can override anything that exists in the environment.
 
 This is the environment your command runs in 🎉
 

--- a/pages/pipelines/group_step.md.erb
+++ b/pages/pipelines/group_step.md.erb
@@ -164,10 +164,8 @@ Group merging is only possible when a group in the uploaded pipeline matches the
 
 Note that inside a single pipeline, groups with the same `group` or `label` will not be merged in the Buildkite UI.
 
-<section class="Docs__note">
-  <h3>You can't define the same key twice</h3>
-  <p>Trying to create different groups with the same `key` attribute will result in an error.</p>
-</section>
+>📘 You can't define the same key twice
+> Trying to create different groups with the same `key` attribute will result in an error.
 
 For example, you have a YAML file:
 

--- a/pages/pipelines/input_step.md.erb
+++ b/pages/pipelines/input_step.md.erb
@@ -105,10 +105,8 @@ steps:
 
 ## Text input attributes
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">Line endings</h3>
-<p>A text field normalizes line endings to Unix format (<code>\n</code>).</p>
-</div>
+>📘 Line endings
+> A text field normalizes line endings to Unix format (<code>\n</code>).
 
 _Required attributes:_
 

--- a/pages/pipelines/links_and_images_in_log_output.md.erb
+++ b/pages/pipelines/links_and_images_in_log_output.md.erb
@@ -84,9 +84,8 @@ Be careful to ensure the part of the URL after `artifact://` exactly matches the
 
 The image artifact does not have to be uploaded at the time it's written to the build log. If the artifact has not been uploaded you'll see a loading placeholder, and as soon as it's ready the image will automatically appear.
 
-<section class="Docs__note">
-  <p>If you are using private artifacts, your images need to be <a href="#images-base64-encoded-images">base64-encoded</a> so that Buildkite can access and inline them.</p>
-</section>
+>📘
+> If you are using private artifacts, your images need to be <a href="#images-base64-encoded-images">base64-encoded</a> so that Buildkite can access and inline them.
 
 ### Base64-encoded images
 

--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -139,18 +139,15 @@ The default environment variable name patterns are `*_PASSWORD`, `*_SECRET` and 
 
 For example, if you have environment variable `MY_SECRET="topsecret"`and you run a command that outputs `This is topsecret info`, the log output will actually be `This is [REDACTED] info`.
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">Setting environment variables</h3>
-<p>Note that if you <emphasis>set</emphasis> or <emphasis>interpolate</emphasis> a secret environment variable in your <code>pipeline.yml</code> it is not redacted, but doing that is <a href="/docs/pipelines/secrets#anti-pattern-storing-secrets-in-your-pipeline-dot-yml">not recommended</a>.</p>
-</div>
+>📘 Setting environment variables
+> Note that if you <emphasis>set</emphasis> or <emphasis>interpolate</emphasis> a secret environment variable in your <code>pipeline.yml</code> it is not redacted, but doing that is <a href="/docs/pipelines/secrets#anti-pattern-storing-secrets-in-your-pipeline-dot-yml">not recommended</a>.
 
 ## Private build log archive storage
 
 By default, build logs are stored in encrypted form in Buildkite's Amazon S3 buckets, but you can also store the archived build logs in your private AWS S3 bucket.
 
-<div class="Docs__note">
-<p>This feature is only available to customers on the Buildkite <a href="https://buildkite.com/pricing">Enterprise</a> plan.</p>
-</div>
+>📘
+> This feature is only available to customers on the Buildkite <a href="https://buildkite.com/pricing">Enterprise</a> plan.
 
 To set up a private build log archive storage:
 

--- a/pages/pipelines/my_builds.md.erb
+++ b/pages/pipelines/my_builds.md.erb
@@ -29,7 +29,5 @@ The My Builds page lists all of your past builds in reverse chronological order,
 
 <%= image "builds-page.png", width: 1940/2, height: 974/2, alt: "Screenshot of the My Builds page" %>
 
-<section class="Docs__troubleshooting-note">
-  <h3>The build I just created is running, but isn't showing up in My Builds</h3>
-  <p>The most common reason for a build to not be included in My Builds is that the email address associated with your commit isn't linked to your account. Make sure that the email in your git config is <a href="/user/emails">linked to your Buildkite account</a>. Without this link, we won't know which builds are yours!</p>
-</section>
+>🚧 The build I just created is running, but isn't showing up in My Builds
+> The most common reason for a build to not be included in My Builds is that the email address associated with your commit isn't linked to your account. Make sure that the email in your git config is <a href="/user/emails">linked to your Buildkite account</a>. Without this link, we won't know which builds are yours!

--- a/pages/pipelines/my_builds.md.erb
+++ b/pages/pipelines/my_builds.md.erb
@@ -29,5 +29,5 @@ The My Builds page lists all of your past builds in reverse chronological order,
 
 <%= image "builds-page.png", width: 1940/2, height: 974/2, alt: "Screenshot of the My Builds page" %>
 
->🚧 The build I just created is running, but isn't showing up in My Builds
+>🚧 The build I created recently is running, but isn't showing up in My Builds
 > The most common reason for a build to not be included in My Builds is that the email address associated with your commit isn't linked to your account. Make sure that the email in your git config is <a href="/user/emails">linked to your Buildkite account</a>. Without this link, we won't know which builds are yours!

--- a/pages/pipelines/notifications.md.erb
+++ b/pages/pipelines/notifications.md.erb
@@ -43,9 +43,8 @@ notify:
 
 See [Supported Variables](/docs/pipelines/conditionals#variable-and-syntax-reference-variables) for more conditional variables that can be used in the `if` attribute.
 
-<section class="Docs__troubleshooting-note">
-  <p>To trigger conditional notifications to a Slack channel, you will first need to configure <a href="/docs/integrations/slack#conditional-notifications">Conditional notifications for Slack</a>.
-</section>
+>🚧
+> To trigger conditional notifications to a Slack channel, you will first need to configure <a href="/docs/integrations/slack#conditional-notifications">Conditional notifications for Slack</a>.
 
 ## Email
 
@@ -77,9 +76,8 @@ notify:
 
 To send notifications to a Basecamp Campfire, you'll need to set up a chatbot in Basecamp as well as adding the notification to your `pipeline.yml` file. Basecamp admin permission is required to setup your chatbot.
 
-<section class="Docs__troubleshooting-note">
-  <p>Campfire messages can only be sent using Basecamp 3.</p>
-</section>
+>🚧
+> Campfire messages can only be sent using Basecamp 3.</p>
 
 1. Add a [chatbot](https://m.signalvnoise.com/new-in-basecamp-3-chatbots/) to the Basecamp project or team that you'll be sending notifications to.
 1. Set up your chatbot with a name and an optional URL. If you'd like to include an image, you can find the Buildkite logo in our [Brand Assets](https://buildkite.com/brand-assets).
@@ -116,9 +114,8 @@ Before adding a `notify` attribute to your `pipeline.yml`, ensure an organizatio
 
 Once a Slack channel has been configured in your organization, add a Slack notification to your pipeline using the `slack` attribute of the `notify` YAML block. Remember that if you rename or modify the Slack channel for which the integration was set up, for example if you change it from public to private, you need to set up a new integration.
 
-<section class="Docs__troubleshooting-note">
-  <p>When using just a channel name, you must specify it in quotes, as otherwise the <code>#</code> will cause the channel name to be treated as a comment.</p>
-</section>
+>🚧
+> When using just a channel name, you must specify it in quotes, as otherwise the <code>#</code> will cause the channel name to be treated as a comment.</p>
 
 For example, to deliver build-level notifications to the `#general` channel of all configured workspaces:
 

--- a/pages/pipelines/notifications.md.erb
+++ b/pages/pipelines/notifications.md.erb
@@ -115,7 +115,7 @@ Before adding a `notify` attribute to your `pipeline.yml`, ensure an organizatio
 Once a Slack channel has been configured in your organization, add a Slack notification to your pipeline using the `slack` attribute of the `notify` YAML block. Remember that if you rename or modify the Slack channel for which the integration was set up, for example if you change it from public to private, you need to set up a new integration.
 
 >🚧
-> When using just a channel name, you must specify it in quotes, as otherwise the <code>#</code> will cause the channel name to be treated as a comment.</p>
+> When using only a channel name, you must specify it in quotes, as otherwise the <code>#</code> will cause the channel name to be treated as a comment.</p>
 
 For example, to deliver build-level notifications to the `#general` channel of all configured workspaces:
 

--- a/pages/pipelines/permissions.md.erb
+++ b/pages/pipelines/permissions.md.erb
@@ -177,10 +177,8 @@ Removing a compromised user from your organization immediately protects all the 
 
 In case of a non-responsive or rogue user, or if multiple accounts are compromised, you can send a list of impacted user IDs to [support@buildkite.com](mailto:support@buildkite.com) and ask the Buildkite support to log out the specific user or all the users out of all sessions.
 
-<section class="Docs__note">
-  <h3>Enterprise plan</h3>
-  <p>As a part of the Buildkite SLA, customers on the Enterprise plan have an emergency email available for operational and security incidents. Contact your Customer Success Manager for more information.</p>
-</section>
+>📘 Enterprise plan
+> As a part of the Buildkite SLA, customers on the Enterprise plan have an emergency email available for operational and security incidents. Contact your Customer Success Manager for more information.
 
 If you suspect or have already detected a security breach, and the affected user is cooperative, they can also log out and [reset](https://buildkite.com/forgot-password) their password, which will automatically reset all of their active sessions. Then you can work with the affected user to ensure their account is safe and re-add them to your Buildkite organization.
 

--- a/pages/pipelines/permissions.md.erb
+++ b/pages/pipelines/permissions.md.erb
@@ -42,10 +42,8 @@ If you're creating pipelines programmatically using the REST API, you can add th
 
 You can also restrict agents to specific teams with the `BUILDKITE_BUILD_CREATOR_TEAMS` environment variable. Using agent hooks, you can allow or disallow builds based on the creator's team memberships.
 
-<div class="Docs__troubleshooting-note">
-  <h3 id="unverified">Unverified commits</h3>
-	<p>Note that GitHub accepts <a href="https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification">unsigned commits</a>, including information about the commit author and passes them along to webhooks, so you should not rely on these for authentication unless you are confident that all of your commits are trusted.</p>
-</div>
+>🚧 Unverified commits
+> Note that GitHub accepts <a href="https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification">unsigned commits</a>, including information about the commit author and passes them along to webhooks, so you should not rely on these for authentication unless you are confident that all of your commits are trusted.
 
 For example, the following [`environment` hook](/docs/agent/v3/hooks#job-lifecycle-hooks)
 prevents anyone from outside of the ops team from running a build on the agent:
@@ -198,9 +196,8 @@ If the attacker has control of the SSO, the scope of the security incident is be
 
 The other control you have is the organization membership's SSO mode. If the membership requires SSO, the user will only have access to your organization in the particular sessions authenticated through your SSO provider.
 
-<section class="Docs__troubleshooting-note">
-  <p>Before you proceed, make sure that you have at least one user with SSO as an optional log in requirement in your organization to make it possible for someone to log back in!</p>
-</section>
+>🚧
+> Before you proceed, make sure that you have at least one user with SSO as an optional log in requirement in your organization to make it possible for someone to log back in!
 
 Admins of your Buildkite organization can disable and then re-enable the SSO, which will force all users in your organization to re-authorize with SSO. When you disable an SSO provider, it rescinds all active SSO authorizations for all users _including the admin who disables the SSO_! The admin will need to log back into the organization by using a non-SSO method.
 

--- a/pages/pipelines/secrets.md.erb
+++ b/pages/pipelines/secrets.md.erb
@@ -95,9 +95,7 @@ See the [Elastic CI Stack for AWS](https://github.com/buildkite/elastic-ci-stack
 
 You should never store secrets on your Buildkite Pipeline Settings page. Not only does this expose the secret value to Buildkite, but pipeline settings are often returned in REST and GraphQL API payloads.
 
-<section class="Docs__note">
-  <p>Never store secret values in your Buildkite pipeline settings.</p>
-</section>
+>📘Never store secret values in your Buildkite pipeline settings.
 
 ## Anti-pattern: Storing secrets in your pipeline.yml
 
@@ -114,9 +112,7 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-<section class="Docs__note">
-  <p>Never store secrets in the <code>env</code> section of your pipeline.</p>
-</section>
+>📘 Never store secrets in the <code>env</code> section of your pipeline.
 
 ## Anti-pattern: Referencing secrets in your pipeline YAML
 
@@ -147,9 +143,8 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-<section class="Docs__note">
-  <p>Use <a href="/docs/pipelines/writing-build-scripts">build scripts</a> instead of <code>command</code> blocks for steps that use secrets.</p>
-</section>
+>📘
+> Use <a href="/docs/pipelines/writing-build-scripts">build scripts</a> instead of <code>command</code> blocks for steps that use secrets.
 
 If you must define your script in your steps, you can prevent interpolation by using the `$$` syntax:
 

--- a/pages/pipelines/skipping.md.erb
+++ b/pages/pipelines/skipping.md.erb
@@ -66,10 +66,8 @@ Fix readme typos
 
 For more advanced build filtering and commit skipping, see the [Using conditionals](/docs/pipelines/conditionals) guide.
 
-<div class="Docs__troubleshooting-note">
-  <h3>Skipping commits with Bitbucket Server</h3>
-  <p>Not all webhooks from Bitbucket Server contain the commit message. When a commit message is not included in a webhook, the build will run.</p>
-</div>
+>🚧 Skipping commits with Bitbucket Server
+> Not all webhooks from Bitbucket Server contain the commit message. When a commit message is not included in a webhook, the build will run.
 
 ## Ignore branches
 

--- a/pages/pipelines/trigger_step.md.erb
+++ b/pages/pipelines/trigger_step.md.erb
@@ -44,9 +44,8 @@ _Required attributes:_
   </tr>
 </table>
 
-<div class="Docs__troubleshooting-note">
-<p>When a <a href="/docs/pipelines/trigger-step">triggered build</a> fails, the step that triggered it will be stuck in the <code>running</code> state forever.</p>
-</div>
+>🚧
+> When a <a href="/docs/pipelines/trigger-step">triggered build</a> fails, the step that triggered it will be stuck in the <code>running</code> state forever.
 
 _Optional attributes:_
 

--- a/pages/pipelines/writing_build_scripts.md.erb
+++ b/pages/pipelines/writing_build_scripts.md.erb
@@ -47,10 +47,8 @@ run_tests
 
 For a full list of options, see the [Bash Reference Manual](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html).
 
-<section class="Docs__troubleshooting-note">
-  <h3>Unbound variable errors</h3>
-  <p>Note that while enabling the <code>u</code> option is generally a good default to use for all build scripts, it can cause some tools like <a href="https://rvm.io">rvm</a> to fail with “unbound variable” errors. If you encounter errors, you can either remove <code>u</code> from the list of options, or run the tool causing the error wrapped in <code>set +u</code> and <code>set -u</code> to remove the option just for that command. For example: <code>set +u; rvm xxx; set -u</code>.</p>
-</section>
+>🚧 Unbound variable errors
+> Note that while enabling the <code>u</code> option is generally a good default to use for all build scripts, it can cause some tools like <a href="https://rvm.io">rvm</a> to fail with “unbound variable” errors. If you encounter errors, you can either remove <code>u</code> from the list of options, or run the tool causing the error wrapped in <code>set +u</code> and <code>set -u</code> to remove the option just for that command. For example: <code>set +u; rvm xxx; set -u</code>.
 
 ## Capturing exit status
 
@@ -116,10 +114,8 @@ some_command
 
 If you require more environment information, you can execute `env` to print out all the environment variable names and their values. If you use `env` you should filter the output using a tool such as `grep` or `egrep`, to ensure you don't leak private keys or other information.
 
-<section class="Docs__troubleshooting-note">
-  <h3>Security recommendation</h3>
-  <p>If you use environment variables to define sensitive data such as API keys or Secret Access Keys, you should always filter the output of <code>env</code> to ensure you're not exposing any secrets in your build log.</p>
-</section>
+>🚧 Security recommendation
+> If you use environment variables to define sensitive data such as API keys or Secret Access Keys, you should always filter the output of <code>env</code> to ensure you're not exposing any secrets in your build log.
 
 For example, the following prints all environment variable names and values containing the words "git" or "node", using a case-insensitive search:
 

--- a/pages/pipelines/writing_build_scripts.md.erb
+++ b/pages/pipelines/writing_build_scripts.md.erb
@@ -48,7 +48,7 @@ run_tests
 For a full list of options, see the [Bash Reference Manual](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html).
 
 >🚧 Unbound variable errors
-> Note that while enabling the <code>u</code> option is generally a good default to use for all build scripts, it can cause some tools like <a href="https://rvm.io">rvm</a> to fail with “unbound variable” errors. If you encounter errors, you can either remove <code>u</code> from the list of options, or run the tool causing the error wrapped in <code>set +u</code> and <code>set -u</code> to remove the option just for that command. For example: <code>set +u; rvm xxx; set -u</code>.
+> Note that while enabling the <code>u</code> option is generally a good default to use for all build scripts, it can cause some tools like <a href="https://rvm.io">rvm</a> to fail with “unbound variable” errors. If you encounter errors, you can either remove <code>u</code> from the list of options, or run the tool causing the error wrapped in <code>set +u</code> and <code>set -u</code> to remove the option for only that command. For example: <code>set +u; rvm xxx; set -u</code>.
 
 ## Capturing exit status
 

--- a/pages/plugins/directory.md.erb
+++ b/pages/plugins/directory.md.erb
@@ -25,6 +25,5 @@ Once completed, your plugin will display in the directory as pictured below:
 
 <%= image "ecr-plugin-directory-item.png", width: 1014/2, height: 500/2, alt: "Screenshot of ECR plugin in the Buildkite plugins directory" %>
 
-<section class="Docs__troubleshooting-note">
-	<p>If you've completed the above steps and your plugin doesn't appear, send an email to <a href="mailto:support@buildkite.com">support@buildkite.com</a> and we'll investigate it for you.</p>
-</section>
+>🚧
+> If you've completed the above steps and your plugin doesn't appear, send an email to <a href="mailto:support@buildkite.com">support@buildkite.com</a> and we'll investigate it for you.

--- a/pages/plugins/using.md.erb
+++ b/pages/plugins/using.md.erb
@@ -21,9 +21,8 @@ steps:
           workdir: /app
 ```
 
-<div class="Docs__note">
-<p>Always specify a tag or commit (for example, <code>v1.2.3</code>) to prevent the plugin changing unexpectedly, and to prevent stale checkouts of plugins on your agent machines.</p>
-</div>
+>📘
+> Always specify a tag or commit (for example, <code>v1.2.3</code>) to prevent the plugin changing unexpectedly, and to prevent stale checkouts of plugins on your agent machines.
 
 Not all plugins require a `command` attribute, for example:
 

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -48,12 +48,8 @@ The `configuration` property defines the validation rules for the plugin configu
 
 Configuration properties are available to the hook script as environment variables with the naming pattern `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>` where `<PLUGIN_NAME>` is the GitHub repository slug, not the name defined in `plugin.yml`. In this case, the configured value of `pattern` will be available as `BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN`.
 
-<div class="Docs__troubleshooting-note">
-  <h3>Plugin properties and git</h3>
-  <p>
-    Note that if you <a href="/docs/plugins/using#plugin-sources">reference a plugin</a> using a full URL and <code>.git</code> extension, you need to use a slightly different syntax to get access to the configuration properties. For example, to get the value of <code>pattern</code> in <code>https://github.com/my-org/my-plugin.git#v1.0.0</code> use  <code>BUILDKITE_PLUGIN_MY_PLUGIN_GIT_PATTERN</code>.
-  </p>
-</div>
+>🚧 Plugin properties and git
+> Note that if you <a href="/docs/plugins/using#plugin-sources">reference a plugin</a> using a full URL and <code>.git</code> extension, you need to use a slightly different syntax to get access to the configuration properties. For example, to get the value of <code>pattern</code> in <code>https://github.com/my-org/my-plugin.git#v1.0.0</code> use  <code>BUILDKITE_PLUGIN_MY_PLUGIN_GIT_PATTERN</code>.
 
 ### Valid plugin.yml properties
 

--- a/pages/test_analytics/monitors.md.erb
+++ b/pages/test_analytics/monitors.md.erb
@@ -6,10 +6,8 @@ Monitors track what matters to you. They trigger alerts under conditions that yo
 
 ## Monitors
 
-<div class="Docs__troubleshooting-note">
-  <h3>Feature temporarily unavailable</h3>
-    <p>Monitors and alerts for Test Analytics are unavailable as of September 05, 2022. We expect them to be back soon in the capacity outlined on this page.</p>
-</div>
+>🚧 Feature temporarily unavailable
+> Monitors and alerts for Test Analytics are unavailable as of September 05, 2022. We expect them to be back soon in the capacity outlined on this page.
 
 There are three different types of monitors in Test Analytics:
 

--- a/pages/tutorials/docker_containerized_builds.md.erb
+++ b/pages/tutorials/docker_containerized_builds.md.erb
@@ -90,10 +90,8 @@ steps:
 
 There are many configuration options available for the Docker plugin. For the complete list, see the readme for the [Docker Buildkite Plugin on GitHub](https://github.com/buildkite-plugins/docker-buildkite-plugin).
 
-<div class="Docs__note">
-<h3 class="Docs__note__heading">Pinning plugin versions</h3>
-<p>Specifying the version of your plugin using the <code>plugin-name#vx.x.x</code> format is recommended, to ensure that no changes are introduced without your knowledge.</p>
-</div>
+>📘 Pinning plugin versions
+> Specifying the version of your plugin using the <code>plugin-name#vx.x.x</code> format is recommended, to ensure that no changes are introduced without your knowledge.
 
 ## Creating your own Docker infrastructure
 

--- a/pages/tutorials/getting_started.md.erb
+++ b/pages/tutorials/getting_started.md.erb
@@ -41,9 +41,10 @@ Choose a sample pipeline to use as your first pipeline:
       - label: "Pipeline upload"
         command: buildkite-agent pipeline upload
     ```
-    <div class="Docs__note">
-    <p>If you do not see the <i>Steps</i> screen, or if the previous screen included a <i>Steps</i> section, you are still using the old web-based editor. This will be deprecated at some point. Please make sure to opt in to the YAML steps editor. Refer to <a href="https://buildkite.com/docs/tutorials/pipeline-upgrade#using-yaml-steps-for-new-pipelines">Pipeline Upgrade - Using YAML Steps for new pipelines</a> for more information.</p>
-    </div>
+
+    >📘
+    > If you do not see the <i>Steps</i> screen, or if the previous screen included a <i>Steps</i> section, you are still using the old web-based editor. This will be deprecated at some point. Please make sure to opt in to the YAML steps editor. Refer to <a href="https://buildkite.com/docs/tutorials/pipeline-upgrade#using-yaml-steps-for-new-pipelines">Pipeline Upgrade - Using YAML Steps for new pipelines</a> for more information.
+
 4. Select *Save and Build*. Buildkite opens the *New Build* modal.
 5. You can usually accept the defaults here. If your repository uses 'main' rather than 'master' branch, edit the *Branch* option. Select *Create build*. Buildkite takes you to the pipeline build.
 

--- a/pages/tutorials/pipeline_upgrade.md.erb
+++ b/pages/tutorials/pipeline_upgrade.md.erb
@@ -73,10 +73,8 @@ If you expect to have compatibility issues with your environment variables, indi
 
 You can migrate all of the pipelines in your organization at the same time using the "Replace web steps for all pipelines with YAML" button on the migration page. The new YAML steps version of your pipeline will be auto-saved during migration, and will replace the web-based steps.
 
-<section class="Docs__note">
-<p>If you expect to have <a href="#what-is-the-yaml-steps-editor-compatibility-issues">compatibility issues</a> with your environment variables, migrate your pipelines <a href="#migrating-existing-pipelines-individual-migration">individually</a>.
-</p>
-</section>
+>📘
+> If you expect to have <a href="#what-is-the-yaml-steps-editor-compatibility-issues">compatibility issues</a> with your environment variables, migrate your pipelines <a href="#migrating-existing-pipelines-individual-migration">individually</a>.
 
 <%= image "bulk-migration.png", width: 1744/2, height: 446/2, alt: "Screenshot of the bulk pipeline migration panel and button" %>
 

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -168,6 +168,24 @@ RSpec.describe Page::Renderer do
     expect(Page::Renderer.render(md).strip).to eql(html.strip)
   end
 
+  it 'supports custom Callouts' do
+    md = <<~MD
+      > 🚧 Troubleshooting: `launchctl` fails with "error"
+      > Ensure **strong emphasis** works
+      > Second paragraph has _emphasis_
+    MD
+
+    html = <<~HTML
+      <section class="Docs__note Docs__troubleshooting-note">
+        <p class="note-title" id="troubleshooting-launchctl-fails-with-error">🚧 Troubleshooting: <code>launchctl</code> fails with "error"</p>
+        <p>Ensure <strong>strong emphasis</strong> works</p>
+      <p>Second paragraph has <em>emphasis</em></p>
+      </section>
+    HTML
+
+    expect(Page::Renderer.render(md).strip).to eql(html.strip)
+  end
+
   it "supports {: id=\"some-id\"} for manually specifying an id of the previous bit of content" do
     md = <<~MD
       ## This is a section

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -176,8 +176,8 @@ RSpec.describe Page::Renderer do
     MD
 
     html = <<~HTML
-      <section class="Docs__note Docs__troubleshooting-note">
-        <p class="note-title" id="troubleshooting-launchctl-fails-with-error">🚧 Troubleshooting: <code>launchctl</code> fails with "error"</p>
+      <section class="callout callout--troubleshooting">
+        <p class="callout__title" id="troubleshooting-launchctl-fails-with-error">🚧 Troubleshooting: <code>launchctl</code> fails with "error"</p>
         <p>Ensure <strong>strong emphasis</strong> works</p>
       <p>Second paragraph has <em>emphasis</em></p>
       </section>

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -176,8 +176,10 @@ RSpec.describe Page::Renderer do
     MD
 
     html = <<~HTML
-      <section class="callout callout--troubleshooting">
-        <p class="callout__title" id="troubleshooting-launchctl-fails-with-error">🚧 Troubleshooting: <code>launchctl</code> fails with "error"</p>
+      <section class="callout callout--troubleshooting" id="troubleshooting-launchctl-fails-with-error">
+        <p class="callout__title">
+          <a class="callout__anchor" href="#troubleshooting-launchctl-fails-with-error">🚧 Troubleshooting: <code>launchctl</code> fails with "error"</a>
+        </p>
         <p>Ensure <strong>strong emphasis</strong> works</p>
       <p>Second paragraph has <em>emphasis</em></p>
       </section>

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -176,9 +176,29 @@ RSpec.describe Page::Renderer do
     MD
 
     html = <<~HTML
-      <section class="callout callout--troubleshooting" id="troubleshooting-launchctl-fails-with-error">
+      <section class="callout callout--troubleshooting">
         <p class="callout__title">
-          <a class="callout__anchor" href="#troubleshooting-launchctl-fails-with-error">🚧 Troubleshooting: <code>launchctl</code> fails with "error"</a>
+          <a class="callout__anchor" href="#troubleshooting-launchctl-fails-with-error" id="troubleshooting-launchctl-fails-with-error">🚧 Troubleshooting: <code>launchctl</code> fails with "error"</a>
+        </p>
+        <p>Ensure <strong>strong emphasis</strong> works</p>
+      <p>Second paragraph has <em>emphasis</em></p>
+      </section>
+    HTML
+
+    expect(Page::Renderer.render(md).strip).to eql(html.strip)
+  end
+
+  it 'supports custom Callouts without a title' do
+    md = <<~MD
+      > 🚧
+      > Ensure **strong emphasis** works
+      > Second paragraph has _emphasis_
+    MD
+
+    html = <<~HTML
+      <section class="callout callout--troubleshooting">
+        <p class="callout__title">
+          🚧
         </p>
         <p>Ensure <strong>strong emphasis</strong> works</p>
       <p>Second paragraph has <em>emphasis</em></p>

--- a/styleguide/STYLE.md
+++ b/styleguide/STYLE.md
@@ -341,47 +341,46 @@ Typically `{:notoc}` is for pages where the text immediately following the \#-le
 
 A page must have either `{:toc}` or `{:notoc}`.
 
-#### Note blocks
-Currently, the following syntax is commonly used for adding note blocks to the documentation:
+#### Callouts
+Currently, the standard Markdown blockquote syntax is combined with particular
+emoji to create callouts for particular sections of text:
 
-Regular info ("green") note:
+Regular info callout ("purple"):
 
 ```
-<section class="Docs__note">
-  <h3>Setting agent defaults</h3>
-  <p>Use a top-level <code>agents</code> block to <a href="/docs/pipelines/defining-steps#step-defaults">set defaults</a> for all steps in a pipeline.</p>
+>📘 A Callout Title
+> Callout content can have <code>code</code> or _emphasis_ and other inline elements in it, <a href="#">including links</a>.
+> Every line break after the first becames a new paragraph inside the callout.
+```
+This will be rendered as the following HTML in the site:
+```
+<section class="callout callout--info">
+  <p class="callout__title" id="a-callout-title"📘 A Callout Title</p>
+  <p>Callout content can have <code>code</code> or <em>emphasis</em> and other inline elements in it, <a href="#">including links</a></p>
+  <p>Every line break after the first becames a new paragraph inside the callout.</p>
 </section>
 ```
-or
+
+Note that block-level Markdown elements like lists won't be converted into HTML.
+Callout headings avoid clashing with other content heading by simply being styled paragraphs. However, they do have IDs for easy fragment references.
+
+For troubleshooting callouts ("orange"), use the 🚧 emoji:
 
 ```
-<div class="Docs__note">
-  <h3>Line endings</h3>
-  <p>A text field normalizes line endings to Unix format (<code>\n</code>).</p>
-</div>
-```
-Note that 'note' blocks are written in HTML so markdown syntax will not work. Use HTML syntax for links and formatting within 'note' blocks.
-
-
-For troubleshooting note blocks ("orange" notes), use the following example syntax:
-
-```
-<section class="Docs__troubleshooting-note">
-  <p>When a <a href="/docs/pipelines/trigger-step">triggered build</a> fails, the step that triggered it will be stuck in the <code>running</code> state forever.</p>
-</section>
-```
-For troubleshooting note blocks ("orange" notes) with ⚠️ ("warnings"), use the following example syntax:
-
-```
-<div class="Docs__troubleshooting-note">
-  <h3>Fast transitions and webhooks</h3>
-    <p>Note that if a builds transitions between states very quickly, for example from blocked (<code>finished</code>) to unblocked (<code>running</code>), the webhook may be in a different state from the actual build. This is a known limitation of webhooks, in that they may represent a later version of the object than the one that triggered the event.</p>
-</div>
+>🚧 A Troubleshooting Callout
+> Callout content can have <code>code</code> or <em>emphasis</em> and other inline elements in it, <a href="#">including links</a>.
+> Every line break after the first becames a new paragraph inside the callout.
 ```
 
-Note that these note and troubleshooting note blocks are written in HTML so markdown syntax will not work. Use HTML syntax for links and formatting within 'troubleshooting note' blocks.
+For WIP or Experimental callouts ("orange"), use the 🛠 emoji:
 
-It is recommended to keep the headings in notes level-independent because a note within a H3-level section will require a H4-level heading and it's easy to forget about this, especially when moving a large section of documentation to a different page.
+```
+>🛠 This marks it as WIP
+> Callout content can have <code>code</code> or <em>emphasis</em> and other inline elements in it, <a href="#">including links</a>.
+> Every line break after the first becames a new paragraph inside the callout.
+```
+
+Any other emoji will render blockquotes as normal.
 
 #### Two-column tables
 To use a custom style for two-column tables that are rendered like the table in the [Job states](/docs/pipelines/defining-steps#job-states) section, use the following syntax:


### PR DESCRIPTION
This resolves ONB-59: https://linear.app/buildkite/issue/ONB-59/markdown-compatible-notes

This is definitely one to review [commit by commit](https://github.com/buildkite/docs/pull/1744/commits), otherwise it'll be overwhelming. Some of the refactors are pretty huge.

Our "notes" were done in HTML which led to inconsistency, poor readability and editing within the Markdown files, and styling issues. This PR refactors them into consistent readable Markdown patterns triggered by specific emoji, and greatly simplifies the styling and editing. 

The styles as they stand are not the most exciting (@olyism, I'd call them out for a quick pass by a designer at some point), but re-styling or even re-designing them will now be vastly easier.

A regular info callout ("purple") now looks like this in the Markdown:

```
>📘 A Callout Title
> Callout content can have <code>code</code> or _emphasis_ and other inline elements in it, <a href="#">including links</a>.
> Every line break after the first becames a new paragraph inside the callout.
```

This will be rendered as the following HTML in the site:

```
<section class="callout callout--info">
  <p class="callout__title">
    <a href="#a-callout-title" id="a-callout-title">📘 A Callout Title</a>
  </p>
  <p>Callout content can have <code>code</code> or <em>emphasis</em> and other inline elements in it, <a href="#">including links</a></p>
  <p>Every line break after the first becames a new paragraph inside the callout.</p>
</section>
```

If a callout has no title, it also won't have an anchor or link:

```
>📘
> Callout content can have <code>code</code> or _emphasis_ and other inline elements in it, <a href="#">including links</a>.
```

This will be rendered as the following HTML in the site:

```
<section class="callout callout--info">
  <p class="callout__title">📘</p>
  <p>Callout content can have <code>code</code> or <em>emphasis</em> and other inline elements in it, <a href="#">including links</a></p>
</section>
```

I'll include some screenshots below, but the easiest place to see multiple callouts in action is on https://bk-docs-pr-1744.onrender.com/docs/pipelines/conditionals

Callout types we use are:
    '📘': 'info',
    '🚧': 'troubleshooting',
    '🛠': 'wip'

Info has a purple border while Troubleshooting and WIP both have orange (I feel they should be distinct from one another.) I also find the purple text in the Info heading a bit off.

**Example of an Info Callout**
<img width="831" alt="Screen Shot 2022-10-17 at 22 52 06" src="https://user-images.githubusercontent.com/3682/196170215-e8fa9dc6-a2a7-4c1f-86fc-b48a10293954.png">

**Example of a Troubleshooting Callout**
<img width="845" alt="Screen Shot 2022-10-17 at 22 52 50" src="https://user-images.githubusercontent.com/3682/196170359-cb14cc5f-97c2-4b17-b23d-e229a825916a.png">

**Example of WIP Callout**
<img width="802" alt="Screen Shot 2022-10-17 at 23 00 17" src="https://user-images.githubusercontent.com/3682/196171857-b0dd558e-0108-4e87-9526-f9c999d1f599.png">

**Example of WIP Callout in a table**
<img width="828" alt="Screen Shot 2022-10-17 at 22 58 41" src="https://user-images.githubusercontent.com/3682/196171511-cd18b897-5df8-4560-92e8-6c8c0484b844.png">


Feedback very welcome! Especially on styles and choices of emoji, but also on the structure of these changes
