### PR TITLE
Update documented versions of buildkite-agent, docker, docker-compose

### DIFF
--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -194,7 +194,7 @@ CloudWatch Logs and EC2 instance log data are forwarded to CloudWatch Logs, but 
 <!-- vale off -->
 
 * [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/)
-* [Buildkite Agent v3.39.2](https://buildkite.com/docs/agent)
+* [Buildkite Agent v3.39.1](https://buildkite.com/docs/agent)
 * [Docker](https://www.docker.com) - 20.10.7 (Linux) and 20.10.0 (Windows)
 * [Docker Compose](https://docs.docker.com/compose/) - 1.29.2 (Linux) and 1.28.5 (Windows)
 * [AWS CLI](https://aws.amazon.com/cli/) - useful for performing any ops-related tasks

--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -194,9 +194,9 @@ CloudWatch Logs and EC2 instance log data are forwarded to CloudWatch Logs, but 
 <!-- vale off -->
 
 * [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/)
-* [Buildkite Agent v3.33.3](https://buildkite.com/docs/agent)
-* [Docker](https://www.docker.com) - 20.10.6 (Linux) and 20.10.0 (Windows)
-* [Docker Compose](https://docs.docker.com/compose/) - 1.28.6 (Linux) and 1.28.5 (Windows)
+* [Buildkite Agent v3.39.2](https://buildkite.com/docs/agent)
+* [Docker](https://www.docker.com) - 20.10.7 (Linux) and 20.10.0 (Windows)
+* [Docker Compose](https://docs.docker.com/compose/) - 1.29.2 (Linux) and 1.28.5 (Windows)
 * [AWS CLI](https://aws.amazon.com/cli/) - useful for performing any ops-related tasks
 * [jq](https://stedolan.github.io/jq/) - useful for manipulating JSON responses from CLI tools such as AWS CLI or the Buildkite API
 


### PR DESCRIPTION
This is what I get from the AMI
```
Starting session with SessionId: 1666063183331033225-000b3f9aa6e7623ec
sh-4.2$ buildkite-agent --version
buildkite-agent version 3.39.1, build 4608
sh-4.2$ docker --version
Docker version 20.10.17, build 100c701
sh-4.2$ docker-compose --version
docker-compose version 1.29.2, build 5becea4c
```