### PR TITLE
update build.state available states table

### DIFF
--- a/pages/pipelines/conditionals.md.erb
+++ b/pages/pipelines/conditionals.md.erb
@@ -302,7 +302,7 @@ The following variables are supported by the `if` attribute. Note that you canno
 	<tr>
 		<td><code>build.state</code></td>
 		<td><code>String</code></td>
-		<td>The state the current build is in<br><em>Available states:</em>, <code>started</code>, <code>scheduled</code>, <code>running</code>, <code>passed</code>, <code>failed</code>, <code>soft_failed</code>, <code>blocked</code>, <code>canceling</code>, <code>canceled</code>, <code>skipped</code>, <code>not_run</code></td>
+		<td>The state the current build is in<br><em>Available states:</em>, <code>started</code>, <code>scheduled</code>, <code>running</code>, <code>passed</code>, <code>failed</code>, <code>failing</code>, <code>soft_failed</code>, <code>blocked</code>, <code>canceling</code>, <code>canceled</code>, <code>skipped</code>, <code>not_run</code></td>
 	</tr>
 	<tr>
 		<td><code>build.tag</code></td>


### PR DESCRIPTION
We are missing the `failing` state in a table on conditionals for `build.state`, this PR will fix that :)