### PR TITLE
Set an env var on prod to flag this is not a review app

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         RAILS_ENV: production
+        RENDER_PR_APP: false
     ports:
       - '3000:3000'
     environment:


### PR DESCRIPTION
The goal is to be able to decide whether Segment script is included in the views.
So that Segment only captures activity in production only.

env var settings in the `Dockerfile` (or more accurately `docker-compose.yml`) override the env vars that are set in Render UI.
Therefore, we set `RENDER_PR_APP` in the Render UI to be true, and this value will propagate to all the review apps. We then set `RENDER_PR_APP` to be false in `docker-compose.yml`

This can be a bit confusing if someone only looks at the Render UI. So hopefully this commit message will help explain the idea. More details and explorations are available in the Linear issue.

Linear: https://linear.app/buildkite/issue/ONB-29/🔗-integrate-docs-with-segment