### PR TITLE
Add BUILDKITE_PIPELINE_TEAMS to env docs

### DIFF
--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -290,6 +290,11 @@ variables:
     The pipeline slug on Buildkite as used in URLs.
   modifiable: false
   example: "my-project"
+- name: BUILDKITE_PIPELINE_TEAMS
+  desc: |
+    A colon separated list of the pipeline's non-private team slugs.
+  modifiable: false
+  example: "deploy:ops:production"
 - name: BUILDKITE_PLUGINS
   desc: |
     A JSON object containing a list plugins used in the step, and their configuration.


### PR DESCRIPTION
Add some docs for a new environment variables which lists teams for pipelines:

<img width="881" alt="image" src="https://user-images.githubusercontent.com/14028/196852900-23221668-3af3-42ad-aacb-c0db053facc9.png">
