### PR TITLE
Add specs to confirm Emojicom rendering

### DIFF
--- a/spec/features/emojicom_rendering_spec.rb
+++ b/spec/features/emojicom_rendering_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.feature "Emojicom rendering" do
+  context "home page" do
+    scenario "does not display emojicom widget" do
+      visit "/docs"
+
+      expect(page).not_to have_css "#emojicom-widget-inline"
+    end
+  end
+
+  context "landing page" do
+    scenario "does not display emojicom widget" do
+      visit "/docs/test-analytics"
+
+      expect(page).not_to have_css "#emojicom-widget-inline"
+    end
+  end
+
+  context "standard docs page" do
+    scenario "displays emojicom widget" do
+      visit "/docs/tutorials/getting-started"
+
+      expect(page).to have_css "#emojicom-widget-inline"
+    end
+  end
+end


### PR DESCRIPTION
i.e. Emojicom should not be rendered on landing pages

Taken from https://github.com/buildkite/docs/pull/1609