### PR TITLE
Set ENV VAR for Render PR Apps to `false`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ EXPOSE 3000
 # Let puma serve the static files
 ENV RAILS_SERVE_STATIC_FILES=true
 
-# test ENV VARs for Render and Production
+# Set Render PR App switch
 ENV RENDER_PR_APP=false
 
 CMD ["bundle", "exec", "puma", "-C", "./config/puma.rb"]

--- a/Dockerfile.render
+++ b/Dockerfile.render
@@ -18,9 +18,6 @@ COPY --from=builder --chown=1000:1000 /app /app/
 USER 1000:1000
 WORKDIR /app
 
-# test ENV VARs for Render and Production
-ENV RENDER_PR_APP=true
-
 # Source all /app/.profile.d/*.sh files before process start.
 # These are created by buildpacks.
 # https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts


### PR DESCRIPTION
Again with ONB-29.

Setting `RENDER_PR_APP` to `false`

    This sets the ENV VAR to `false` in every environment. In Render,
    the ENV VAR has been set to `true` via the Render UI. This inherits
    to all PR environments inside Render, but can be overridden on
    individual PRs via the PR-specific environment settings.

@elle I think this means you can set the tracking VARs appropriately for Render or not. It doesn't solve setting them for other environments like TEST or DEVELOPMENT etc