### PR TITLE
DRY layout files

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,13 +2,15 @@ class PagesController < ApplicationController
   append_view_path "pages"
   layout :layout_by_path
 
+  def index
+    render :index, layout: "homepage"
+  end
+
   def show
     @page = Page.new(view_context, params[:path])
 
     # If the page doesn't exist, throw a 404
     raise ActionController::RoutingError.new("The documentation page `#{@page.basename}` does not exist") unless @page.exists?
-
-    # For the homepage, render with a custom layout that doesn't include the sidebar etc
 
     # If there's another more correct version of the URL (for example, we changed `_`
     # to `-`), then redirect them to where they should be.
@@ -32,9 +34,7 @@ class PagesController < ApplicationController
   helper_method :is_landing_page?
 
   def layout_by_path
-    if request.path == "/docs"
-      "homepage"
-    elsif request.path.starts_with? "/docs/apis/graphql"
+    if request.path.starts_with? "/docs/apis/graphql"
       "graphql"
     else
       "application"

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,16 +2,6 @@ class PagesController < ApplicationController
   append_view_path "pages"
   layout :layout_by_path
 
-  def layout_by_path
-    if request.path == "/docs"
-      "homepage"
-    elsif request.path.starts_with? "/docs/apis/graphql"
-      "graphql"
-    else
-      "application"
-    end
-  end
-
   def show
     @page = Page.new(view_context, params[:path])
 
@@ -41,4 +31,13 @@ class PagesController < ApplicationController
   end
   helper_method :is_landing_page?
 
+  def layout_by_path
+    if request.path == "/docs"
+      "homepage"
+    elsif request.path.starts_with? "/docs/apis/graphql"
+      "graphql"
+    else
+      "application"
+    end
+  end
 end

--- a/app/views/layouts/_algolia.html.erb
+++ b/app/views/layouts/_algolia.html.erb
@@ -1,0 +1,9 @@
+<%= javascript_tag nonce: true do %>
+  /* This api key is intentionally public */
+  docsearch({
+    apiKey: '<%= algolia_api_key %>',
+    indexName: '<%= algolia_index_name %>',
+    appId: '<%= algolia_app_id %>',
+    inputSelector: '#search'
+  });
+<% end %>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,0 +1,42 @@
+<meta charset='utf-8'>
+<%= tag :link, rel: "dns-prefetch", href: ENV["ASSET_HOST"] if ENV["ASSET_HOST"] %>
+<link rel="dns-prefetch" href="//www2.buildkiteassets.com" />
+<link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-book-39c5d1ed54e49102939d0280aeb20f01ef021bf5ffa74dc25fcafb43fce62ff3.woff2" crossorigin="anonymous" />
+<link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-bold-23e71bdfef13622d0d52b2b4b7ed3c1edb9e81f210692130dee9a521e97d062f.woff2" crossorigin="anonymous" />
+<link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-black-a8002849ea799a4dcf1be0b1abe0f010991cbae508f24f62e9ee0262590197eb.woff2" crossorigin="anonymous" >
+
+<title><%= [content_for(:page_title), "Buildkite Documentation"].compact.join(" | ") %></title>
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<%= stylesheet_link_tag "docsearch", "application", media: "all" %>
+
+<%= javascript_include_tag "docsearch", "application", nonce: true %>
+
+<%= csp_meta_tag %>
+
+<meta name="referrer" content="origin-when-cross-origin" />
+
+<%= tag :link, rel: "shortcut icon", href: image_path("favicon.png"), type: "image/x-icon" %>
+<%= tag :link, rel: "apple-touch-icon", href: image_path("appicon.png") %>
+<%= tag :link, rel: "mask-icon", href: image_path("logo-pinned.svg"), color: "#14CC80" %>
+
+<!-- Twitter Cards Metadata -->
+<%= tag :meta, property: "twitter:card", content: content_for(:page_twitter_card) || "summary_large_image" %>
+<meta name="twitter:site" content="@Buildkite">
+
+<!-- Open Graph Metadata -->
+<%= tag :meta, property: "og:type", content: content_for(:page_og_type) || "website" %>
+<%= tag :meta, property: "og:title", content: content_for(:page_og_title) || content_for(:page_title) || "Buildkite"%>
+<%= tag :meta, property: "og:description", content: content_for(:page_og_description) || content_for(:page_description) || "Automate your team’s software development processes, from testing through to delivery, no matter the language, environment or toolchain." %>
+<%= tag :meta, property: "og:image", content: content_for(:page_image) || image_url("opengraph_default.png").gsub(/^\/\//, 'https://') %>
+<% if page_image_alt = content_for(:page_image_alt) %>
+  <%= tag :meta, property: "og:image:alt", content: page_image_alt  %>
+<% end %>
+<meta property="og:site_name" content="Buildkite" />
+<meta property="og:locale" content="en_US" />
+
+<%= render 'layouts/analytics', application: 'docs', title: "Docs / #{content_for(:page_title)}", logged_in: probably_authenticated? %>
+
+<% if ENV.fetch("ROBOTS_NO_INDEX") { "false" } == "true" %>
+  <meta name="robots" content="noindex, nofollow">
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,48 +1,7 @@
 <!DOCTYPE html>
 <html lang='en'>
   <head>
-    <meta charset='utf-8'>
-    <%= tag :link, rel: "dns-prefetch", href: ENV["ASSET_HOST"] if ENV["ASSET_HOST"] %>
-    <link rel="dns-prefetch" href="//www2.buildkiteassets.com" />
-    <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-book-39c5d1ed54e49102939d0280aeb20f01ef021bf5ffa74dc25fcafb43fce62ff3.woff2" crossorigin="anonymous" />
-    <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-bold-23e71bdfef13622d0d52b2b4b7ed3c1edb9e81f210692130dee9a521e97d062f.woff2" crossorigin="anonymous" />
-    <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-black-a8002849ea799a4dcf1be0b1abe0f010991cbae508f24f62e9ee0262590197eb.woff2" crossorigin="anonymous" >
-
-    <title><%= [content_for(:page_title), "Buildkite Documentation"].compact.join(" | ") %></title>
-
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <%= stylesheet_link_tag "docsearch", "application", media: "all" %>
-
-    <%= javascript_include_tag "docsearch", "application", nonce: true %>
-
-    <%= csp_meta_tag %>
-
-    <meta name="referrer" content="origin-when-cross-origin" />
-
-    <%= tag :link, rel: "shortcut icon", href: image_path("favicon.png"), type: "image/x-icon" %>
-    <%= tag :link, rel: "apple-touch-icon", href: image_path("appicon.png") %>
-    <%= tag :link, rel: "mask-icon", href: image_path("logo-pinned.svg"), color: "#14CC80" %>
-
-    <!-- Twitter Cards Metadata -->
-    <%= tag :meta, property: "twitter:card", content: content_for(:page_twitter_card) || "summary_large_image" %>
-    <meta name="twitter:site" content="@Buildkite">
-
-    <!-- Open Graph Metadata -->
-    <%= tag :meta, property: "og:type", content: content_for(:page_og_type) || "website" %>
-    <%= tag :meta, property: "og:title", content: content_for(:page_og_title) || content_for(:page_title) || "Buildkite"%>
-    <%= tag :meta, property: "og:description", content: content_for(:page_og_description) || content_for(:page_description) || "Automate your team’s software development processes, from testing through to delivery, no matter the language, environment or toolchain." %>
-    <%= tag :meta, property: "og:image", content: content_for(:page_image) || image_url("opengraph_default.png").gsub(/^\/\//, 'https://') %>
-    <% if page_image_alt = content_for(:page_image_alt) %>
-      <%= tag :meta, property: "og:image:alt", content: page_image_alt  %>
-    <% end %>
-    <meta property="og:site_name" content="Buildkite" />
-    <meta property="og:locale" content="en_US" />
-
-    <%= render 'layouts/analytics', application: 'docs', title: "Docs / #{content_for(:page_title)}", logged_in: probably_authenticated? %>
-
-    <% if ENV.fetch("ROBOTS_NO_INDEX") { "false" } == "true" %>
-      <meta name="robots" content="noindex, nofollow">
-    <% end %>
+    <%= render "layouts/head" %>
   </head>
   <body <%= beta? ? 'class=beta' : ''-%>>
     <%= render "layouts/site_header" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,10 +38,6 @@
     <meta property="og:site_name" content="Buildkite" />
     <meta property="og:locale" content="en_US" />
 
-    <meta name="testing-render-env-var" content="<%= ENV['RENDER_PR_APP'] %>" />
-    <meta name="testing-docker-compose-env-var" content="<%= ENV['SEGMENT_ENV'] %>" />
-    <meta name="testing-rails-env-var" content="<%= ENV['RAILS_ENV'] %>" />
-
     <%= render 'layouts/analytics', application: 'docs', title: "Docs / #{content_for(:page_title)}", logged_in: probably_authenticated? %>
 
     <% if ENV.fetch("ROBOTS_NO_INDEX") { "false" } == "true" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
     <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-bold-23e71bdfef13622d0d52b2b4b7ed3c1edb9e81f210692130dee9a521e97d062f.woff2" crossorigin="anonymous" />
     <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-black-a8002849ea799a4dcf1be0b1abe0f010991cbae508f24f62e9ee0262590197eb.woff2" crossorigin="anonymous" >
 
-    <title><%= content_for(:page_title) %> | Buildkite Documentation</title>
+    <title><%= [content_for(:page_title), "Buildkite Documentation"].compact.join(" | ") %></title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= stylesheet_link_tag "docsearch", "application", media: "all" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,15 +21,7 @@
         </div>
       </div>
     </main>
-    <%= javascript_tag nonce: true do %>
-      /* This api key is intentionally public */
-      docsearch({
-        apiKey: '<%= algolia_api_key %>',
-        indexName: '<%= algolia_index_name %>',
-        appId: '<%= algolia_app_id %>',
-        inputSelector: '#search'
-      });
-    <% end %>
+    <%= render "layouts/algolia" %>
     <%= javascript_include_tag "nav", nonce: true %>
   </body>
 </html>

--- a/app/views/layouts/graphql.html.erb
+++ b/app/views/layouts/graphql.html.erb
@@ -21,15 +21,7 @@
         </div>
       </div>
     </main>
-    <%= javascript_tag nonce: true do %>
-      /* This api key is intentionally public */
-      docsearch({
-        apiKey: '<%= algolia_api_key %>',
-        indexName: '<%= algolia_index_name %>',
-        appId: '<%= algolia_app_id %>',
-        inputSelector: '#search'
-      });
-    <% end %>
+    <%= render "layouts/algolia" %>
     <%= javascript_include_tag "nav", nonce: true %>
   </body>
 </html>

--- a/app/views/layouts/graphql.html.erb
+++ b/app/views/layouts/graphql.html.erb
@@ -1,48 +1,7 @@
 <!DOCTYPE html>
 <html lang='en'>
   <head>
-    <meta charset='utf-8'>
-    <%= tag :link, rel: "dns-prefetch", href: ENV["ASSET_HOST"] if ENV["ASSET_HOST"] %>
-    <link rel="dns-prefetch" href="//www2.buildkiteassets.com" />
-    <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-book-39c5d1ed54e49102939d0280aeb20f01ef021bf5ffa74dc25fcafb43fce62ff3.woff2" crossorigin="anonymous" />
-    <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-bold-23e71bdfef13622d0d52b2b4b7ed3c1edb9e81f210692130dee9a521e97d062f.woff2" crossorigin="anonymous" />
-    <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-black-a8002849ea799a4dcf1be0b1abe0f010991cbae508f24f62e9ee0262590197eb.woff2" crossorigin="anonymous" >
-
-    <title><%= content_for(:page_title) %> | Buildkite Documentation</title>
-
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <%= stylesheet_link_tag "docsearch", "application", media: "all" %>
-
-    <%= javascript_include_tag "docsearch", "application", nonce: true %>
-
-    <%= csp_meta_tag %>
-
-    <meta name="referrer" content="origin-when-cross-origin" />
-
-    <%= tag :link, rel: "shortcut icon", href: image_path("favicon.png"), type: "image/x-icon" %>
-    <%= tag :link, rel: "apple-touch-icon", href: image_path("appicon.png") %>
-    <%= tag :link, rel: "mask-icon", href: image_path("logo-pinned.svg"), color: "#14CC80" %>
-
-    <!-- Twitter Cards Metadata -->
-    <%= tag :meta, property: "twitter:card", content: content_for(:page_twitter_card) || "summary_large_image" %>
-    <meta name="twitter:site" content="@Buildkite">
-
-    <!-- Open Graph Metadata -->
-    <%= tag :meta, property: "og:type", content: content_for(:page_og_type) || "website" %>
-    <%= tag :meta, property: "og:title", content: content_for(:page_og_title) || content_for(:page_title) || "Buildkite"%>
-    <%= tag :meta, property: "og:description", content: content_for(:page_og_description) || content_for(:page_description) || "Automate your team’s software development processes, from testing through to delivery, no matter the language, environment or toolchain." %>
-    <%= tag :meta, property: "og:image", content: content_for(:page_image) || image_url("opengraph_default.png").gsub(/^\/\//, 'https://') %>
-    <% if page_image_alt = content_for(:page_image_alt) %>
-      <%= tag :meta, property: "og:image:alt", content: page_image_alt  %>
-    <% end %>
-    <meta property="og:site_name" content="Buildkite" />
-    <meta property="og:locale" content="en_US" />
-
-    <%= render 'layouts/analytics', application: 'docs', title: "Docs / #{content_for(:page_title)}", logged_in: probably_authenticated? %>
-
-    <% if ENV.fetch("ROBOTS_NO_INDEX") { "false" } == "true" %>
-      <meta name="robots" content="noindex, nofollow">
-    <% end %>
+    <%= render "layouts/head" %>
   </head>
   <body <%= beta? ? 'class=beta' : ''-%>>
     <%= render "layouts/site_header", use_nav: "nav_graphql" %>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -1,50 +1,9 @@
 <!DOCTYPE html>
 <html lang='en'>
   <head>
-    <meta charset='utf-8'>
-    <%= tag :link, rel: "dns-prefetch", href: ENV["ASSET_HOST"] if ENV["ASSET_HOST"] %>
-    <link rel="dns-prefetch" href="//www2.buildkiteassets.com" />
-    <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-book-39c5d1ed54e49102939d0280aeb20f01ef021bf5ffa74dc25fcafb43fce62ff3.woff2" crossorigin="anonymous" />
-    <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-bold-23e71bdfef13622d0d52b2b4b7ed3c1edb9e81f210692130dee9a521e97d062f.woff2" crossorigin="anonymous" />
-    <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-black-a8002849ea799a4dcf1be0b1abe0f010991cbae508f24f62e9ee0262590197eb.woff2" crossorigin="anonymous" >
-
-    <title><%= [content_for(:page_title), "Buildkite Documentation"].compact.join(" | ") %></title>
-
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <%= stylesheet_link_tag "docsearch", "application", media: "all" %>
-
-    <%= javascript_include_tag "docsearch", "application", nonce: true %>
-
-    <%= csp_meta_tag %>
-
-    <meta name="referrer" content="origin-when-cross-origin" />
-
-    <%= tag :link, rel: "shortcut icon", href: image_path("favicon.png"), type: "image/x-icon" %>
-    <%= tag :link, rel: "apple-touch-icon", href: image_path("appicon.png") %>
-    <%= tag :link, rel: "mask-icon", href: image_path("logo-pinned.svg"), color: "#14CC80" %>
-
-    <!-- Twitter Cards Metadata -->
-    <%= tag :meta, property: "twitter:card", content: content_for(:page_twitter_card) || "summary_large_image" %>
-    <meta name="twitter:site" content="@Buildkite">
-
-    <!-- Open Graph Metadata -->
-    <%= tag :meta, property: "og:type", content: content_for(:page_og_type) || "website" %>
-    <%= tag :meta, property: "og:title", content: content_for(:page_og_title) || content_for(:page_title) || "Buildkite"%>
-    <%= tag :meta, property: "og:description", content: content_for(:page_og_description) || content_for(:page_description) || "Automate your team’s software development processes, from testing through to delivery, no matter the language, environment or toolchain." %>
-    <%= tag :meta, property: "og:image", content: content_for(:page_image) || image_url("opengraph_default.png").gsub(/^\/\//, 'https://') %>
-    <% if page_image_alt = content_for(:page_image_alt) %>
-      <%= tag :meta, property: "og:image:alt", content: page_image_alt  %>
-    <% end %>
-    <meta property="og:site_name" content="Buildkite" />
-    <meta property="og:locale" content="en_US" />
-
-    <%= render 'layouts/analytics', application: 'docs', title: "Docs / #{content_for(:page_title)}", logged_in: probably_authenticated? %>
-
-    <% if ENV.fetch("ROBOTS_NO_INDEX") { "false" } == "true" %>
-      <meta name="robots" content="noindex, nofollow">
-    <% end %>
+    <%= render "layouts/head" %>
   </head>
-  <body>
+  <body <%= beta? ? 'class=beta' : ''-%>>
     <header class="HomeHeader PageContainer">
       <%= link_to "https://buildkite.com/home", title: "Go to Buildkite homepage" do %>
         <img alt="Buildkite logo" class="HomeHeader__logo" src="<%= logo_image_url %>" />

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -8,13 +8,7 @@
     <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-bold-23e71bdfef13622d0d52b2b4b7ed3c1edb9e81f210692130dee9a521e97d062f.woff2" crossorigin="anonymous" />
     <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/lineto-circular/lineto-circular-black-a8002849ea799a4dcf1be0b1abe0f010991cbae508f24f62e9ee0262590197eb.woff2" crossorigin="anonymous" >
 
-    <title>
-      <% if content_for? :page_title %>
-        <%= yield :page_title  %>
-      <% else %>
-        Buildkite Documentation
-      <% end %>
-    </title>
+    <title><%= [content_for(:page_title), "Buildkite Documentation"].compact.join(" | ") %></title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= stylesheet_link_tag "docsearch", "application", media: "all" %>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -23,14 +23,6 @@
     <main id="main" role="main">
       <%= yield %>
     </main>
-    <%= javascript_tag nonce: true do %>
-      /* This api key is intentionally public */
-      docsearch({
-        apiKey: '<%= algolia_api_key %>',
-        indexName: '<%= algolia_index_name %>',
-        appId: '<%= algolia_app_id %>',
-        inputSelector: '#search'
-      });
-    <% end %>
+    <%= render "layouts/algolia" %>
   </body>
 </html>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,4 +1,4 @@
-<% provide :page_title, @page.title %>
-<% provide :page_description, @page.description %>
+<% content_for :page_title, @page.title %>
+<% content_for :page_description, @page.description %>
 
 <%= @page.body %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,8 +26,5 @@ module Docs
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-
-    # Don't generate system test files.
-    config.generators.system_tests = nil
   end
 end

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,0 +1,10 @@
+Rails.application.config.generators do |generate|
+  generate.helper false
+  generate.request_specs false
+  generate.routing_specs false
+  generate.stylesheets false
+  generate.system_tests = nil
+  generate.test_framework :rspec
+  generate.view_specs false
+end
+


### PR DESCRIPTION
... and other small cleanups

What has been done:

- Make `layout_by_path` private
  - This is a helper method that should not be accessed externally
- Disable auto generated files when using Rails generators
- Remove temp checks for `ENV` variables
- Define index action for homepage
  - To remove the confusion of where the home page is defined,
    making it easier to understand what is happening
  - Also removing one branch in the layout conditional
- Switch from `provide` to `content_for`
  - since we are not using or calling streaming anywhere in the app
  - Ref: https://api.rubyonrails.org/classes/ActionController/Streaming.html
- Match title in both layout files
  - in prep to clean up the layout views even more
- Pull out the head section in the three layout templates
  - to dry the duplication and to make it easier to see what is on the page
- Pull Algolia js tag into its own partial
  - Again, dry-ing the layouts templates

The principles behind the layout files cleanups are:

- Removing duplication
- Removing conditionals as much as possible
- Removing (or at least decreasing) the differences between the files - so that it is easier to see the differences and guide additional refactoring

Linear issue: https://linear.app/buildkite/issue/ONB-68/clean-up-application-layout-around-home-page 
