### PR TITLE
Fix typo (secretes) in pagerduty integration docs

### DIFF
--- a/pages/integrations/pagerduty.md.erb
+++ b/pages/integrations/pagerduty.md.erb
@@ -38,7 +38,7 @@ By default, after you've added an Integration API Key, Buildkite will send Pager
 
 Add the PagerDuty [Integration API Key](#generating-a-pagerduty-integration-api-key) to the [`notify` attribute](/docs/pipelines/notifications) of your build configuration.
 
-Make sure that you're using a secure secrets management solution to handle the PagerDuty Integration key, and never commit it in plaintext to source control in a YAML file. See [Managing Pipeline Secrets](/docs/pipelines/secrets) for more information on safely handling your secretes within your infrastructure.
+Make sure that you're using a secure secrets management solution to handle the PagerDuty Integration key, and never commit it in plaintext to source control in a YAML file. See [Managing Pipeline Secrets](/docs/pipelines/secrets) for more information on safely handling secrets within your infrastructure.
 
 ```yaml
 steps:


### PR DESCRIPTION
- `secretes` -> `secrets`
- Also removed a superfluous `your` that was making the sentence a little awkward