### PR TITLE
🛎 reword API token comment

### DIFF
--- a/pages/apis/managing_api_tokens.md.erb
+++ b/pages/apis/managing_api_tokens.md.erb
@@ -59,7 +59,7 @@ Click through the token you'd like to remove, then click the 'Remove Organizatio
 Removing access from a token will send a notification email to the token's owner.
 
 >📘
-> Removing access from a token does not delete the token. Token owners can re-add your organization to their token's scope.
+> Removing access from a token does not delete the token, however token owner cannot re-add your organization to their token's scope.
 
 ## Programmatically managing tokens
 


### PR DESCRIPTION
After this change: https://github.com/buildkite/buildkite/pull/10259 this comment is no longer correct.
We will prohibit an org being added back to an API access token in the following situations:
- An organization revokes the token
- The User is removed from an organization

basecamp context: https://3.basecamp.com/3453178/buckets/3258372/messages/4855872984#__recording_5456583703