### PR TITLE
Update docs for developer plan nomenclature and limits/inclusions

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -199,7 +199,7 @@ _Optional attributes:_
   <tr id="timeout_in_minutes">
     <td><code>timeout_in_minutes</code></td>
     <td>
-      The maximum number of minutes a job created from this step is allowed to run. If the job exceeds this time limit, or if it finishes with a non-zero exit status, the job is automatically canceled and the build fails. Jobs that time out with an exit status of 0 are marked as "passed".<br> Note that command steps on the Buildkite <a href="https://buildkite.com/pricing">Free plan</a> have a maximum job timeout of 240 minutes.<br> You can also set <a href="/docs/pipelines/command-step#command-step-attributes-build-timeouts">default and maximum timeouts</a> in the Buildkite UI.
+      The maximum number of minutes a job created from this step is allowed to run. If the job exceeds this time limit, or if it finishes with a non-zero exit status, the job is automatically canceled and the build fails. Jobs that time out with an exit status of 0 are marked as "passed".<br> Note that command steps on the Buildkite <a href="https://buildkite.com/pricing">Developer Plan</a> have a maximum job timeout of 240 minutes.<br> You can also set <a href="/docs/pipelines/command-step#command-step-attributes-build-timeouts">default and maximum timeouts</a> in the Buildkite UI.
       <em>Example:</em> <code>60</code>
     </td>
   </tr>

--- a/pages/pipelines/job_minutes.md.erb
+++ b/pages/pipelines/job_minutes.md.erb
@@ -29,5 +29,5 @@ The Developer Plan has a limit of 5,000 job minutes per month. When this limit i
 
 ### Build timeouts
 
-Free plans have a [command step maximum timeout](/docs/pipelines/command-step#timeout_in_minutes) of 240 minutes.
+The Developer Plan has a [command step maximum timeout](/docs/pipelines/command-step#timeout_in_minutes) of 240 minutes.
 

--- a/pages/pipelines/job_minutes.md.erb
+++ b/pages/pipelines/job_minutes.md.erb
@@ -26,8 +26,6 @@ The [Usage page](https://buildkite.com/organizations/~/usage) is available on ev
 
 The Developer Plan has a limit of 5,000 job minutes per month. When this limit is reached, builds are not cancelled, but jobs will not be run. The limit is reset when your billing period rolls over, or your organization is upgraded to a different plan.
 
-
 ### Build timeouts
 
 The Developer Plan has a [command step maximum timeout](/docs/pipelines/command-step#timeout_in_minutes) of 240 minutes.
-

--- a/pages/pipelines/job_minutes.md.erb
+++ b/pages/pipelines/job_minutes.md.erb
@@ -22,9 +22,9 @@ The [Usage page](https://buildkite.com/organizations/~/usage) is available on ev
 
 <%= image "usage.png", width: 554, height: 794, alt: "Job minute usage page" %>
 
-## Limits for the free plan
+## Limits for the Developer Plan
 
-The free plan has a limit of 10,000 job minutes per month. When this limit is reached, builds are not cancelled, but jobs will not be run. The limit is reset when your billing period rolls over, or your organization is upgraded to a different plan.
+The Developer Plan has a limit of 5,000 job minutes per month. When this limit is reached, builds are not cancelled, but jobs will not be run. The limit is reset when your billing period rolls over, or your organization is upgraded to a different plan.
 
 
 ### Build timeouts

--- a/pages/test_analytics/monitors.md.erb
+++ b/pages/test_analytics/monitors.md.erb
@@ -17,7 +17,7 @@ There are three different types of monitors in Test Analytics:
 
 These can be set to monitor data from all branches, or only your configured default branch.
 
-The number of available monitors depends on your [Buildkite payment plan](https://buildkite.com/pricing). You can configure up to 5 monitors with the free plan and up to 20 with any of the paid plans. (Archived monitors do not count against this limit.)
+The number of available monitors depends on your [Buildkite payment plan](https://buildkite.com/pricing). You can configure up to 5 monitors with the Developer Plan and up to 20 with any of the paid plans. (Archived monitors do not count against this limit.)
 
 <%= image "monitors.png", width: 851, height: 559, alt: "Screenshot of monitor settings showing the ability to alert on changes to test duration, reliability, and consecutive failures." %>
 


### PR DESCRIPTION
**Context**

- On Tuesday (2022-11-15) we [launched the developer plan](https://3.basecamp.com/3453178/buckets/29865999/messages/5526387953)
- The deadline was moved up 2 days to get in ahead of the [funding announcement](https://buildkite.com/blog/buildkite-series-b)
- In all the hubbub updating the docs was missed.

**Actions**

- This updates the docs to reflect:
  - the **_Developer Plan_** in place of _**Free Plan**_
  - Updated job minutes inclusions to reflect pricing page