### PR TITLE
Correct logs file path

### DIFF
--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -41,23 +41,23 @@ To see the paths to the agent's configuration, hooks, builds, and logs on your s
 
 The typical paths for [Mac computers with Apple silicon](https://support.apple.com/en-gb/HT211814) (such as M1 chips) are:
 
-- Configuration: `/opt/homebrew/etc/buildkite-agent/buildkite-agent.cfg`
-- Agent Hooks: `/opt/homebrew//buildkite-agent/hooks`
-- Builds: `/opt/homebrew/buildkite-agent/builds`
-- Log: `/opt/homebrew/var/log/buildkite-agent.log`
+* Configuration: `/opt/homebrew/etc/buildkite-agent/buildkite-agent.cfg`
+* Agent Hooks: `/opt/homebrew//buildkite-agent/hooks`
+* Builds: `/opt/homebrew/buildkite-agent/builds`
+* Log: `/opt/homebrew/var/log/buildkite-agent.log`
 
 The typical paths for Mac computers with Intel processors are:
 
-- Configuration: `/usr/local/etc/buildkite-agent/buildkite-agent.cfg`
-- Agent Hooks: `/usr/local/etc/buildkite-agent/hooks`
-- Builds: `/usr/local/var/buildkite-agent/builds`
-- Log: `/usr/local/var/log/buildkite-agent.log`
+* Configuration: `/usr/local/etc/buildkite-agent/buildkite-agent.cfg`
+* Agent Hooks: `/usr/local/etc/buildkite-agent/hooks`
+* Builds: `/usr/local/var/buildkite-agent/builds`
+* Log: `/usr/local/var/log/buildkite-agent.log`
 
 ### Linux installer script on macOS
 
-- Configuration: `~/.buildkite-agent/buildkite-agent.cfg`
-- Agent Hooks: `~/.buildkite-agent/hooks`
-- Builds: `~/.buildkite-agent/builds`
+* Configuration: `~/.buildkite-agent/buildkite-agent.cfg`
+* Agent Hooks: `~/.buildkite-agent/hooks`
+* Builds: `~/.buildkite-agent/builds`
 
 ## Configuration
 

--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -41,23 +41,23 @@ To see the paths to the agent's configuration, hooks, builds, and logs on your s
 
 The typical paths for [Mac computers with Apple silicon](https://support.apple.com/en-gb/HT211814) (such as M1 chips) are:
 
-* Configuration: `/opt/homebrew/etc/buildkite-agent/buildkite-agent.cfg`
-* Agent Hooks: `/opt/homebrew//buildkite-agent/hooks`
-* Builds: `/opt/homebrew/buildkite-agent/builds`
-* Log: `/usr/local/var/log/buildkite-agent.log`
+- Configuration: `/opt/homebrew/etc/buildkite-agent/buildkite-agent.cfg`
+- Agent Hooks: `/opt/homebrew//buildkite-agent/hooks`
+- Builds: `/opt/homebrew/buildkite-agent/builds`
+- Log: `/opt/homebrew/var/log/buildkite-agent.log`
 
 The typical paths for Mac computers with Intel processors are:
 
-* Configuration: `/usr/local/etc/buildkite-agent/buildkite-agent.cfg`
-* Agent Hooks: `/usr/local/etc/buildkite-agent/hooks`
-* Builds: `/usr/local/var/buildkite-agent/builds`
-* Log: `/usr/local/var/log/buildkite-agent.log`
+- Configuration: `/usr/local/etc/buildkite-agent/buildkite-agent.cfg`
+- Agent Hooks: `/usr/local/etc/buildkite-agent/hooks`
+- Builds: `/usr/local/var/buildkite-agent/builds`
+- Log: `/usr/local/var/log/buildkite-agent.log`
 
 ### Linux installer script on macOS
 
-* Configuration: `~/.buildkite-agent/buildkite-agent.cfg`
-* Agent Hooks: `~/.buildkite-agent/hooks`
-* Builds: `~/.buildkite-agent/builds`
+- Configuration: `~/.buildkite-agent/buildkite-agent.cfg`
+- Agent Hooks: `~/.buildkite-agent/hooks`
+- Builds: `~/.buildkite-agent/builds`
 
 ## Configuration
 
@@ -94,7 +94,7 @@ launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist
 tail -f ~/.buildkite-agent/log/buildkite-agent.log
 ```
 
->🚧 Troubleshooting: <code>launchctl</code> fails with "Could not find domain for"
+> 🚧 Troubleshooting: <code>launchctl</code> fails with "Could not find domain for"
 > Ensure that you have a user logged in to the macOS host, then re-run:<br><code>launchctl load ~/Library/LaunchAgents/com.buildkite.buildkite-agent.plist</code>
 
 ## Running multiple agents


### PR DESCRIPTION
Copying changes from https://github.com/buildkite/docs/pull/1769 into this PR so I can trigger checks from the feature branch.

Summary of changes:
> The logs file location in the docs for M1 chips points to the location for Intel chips
