### PR TITLE
Minor clarifications

### DIFF
--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -51,7 +51,7 @@ The `configuration` property defines the validation rules for the plugin configu
 
 Configuration properties are available to the hook script as environment variables with the naming pattern `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>` where `<PLUGIN_NAME>` is not the name defined in `plugin.yml` but the repository or folder name compatible with Bash environment variables (in uppercase and only letters, numbers and underscores). In this case, the configured value of `pattern` will be available as `BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN`.
 
->🚧 Variables and non-standard git plugins
+>🚧 Accessing properties on plugins referenced with Git URLs
 > Note that if you <a href="/docs/plugins/using#plugin-sources">reference a plugin</a> with a full URL ending in <code>.git</code> and that plugin's name does not end with `-buildkite-plugin`, variable names will include `_GIT` as part of the plugin name. For example, the value of the configuration <code>pattern</code> in <code>https://github.com/my-org/my-plugin.git#v1.0.0</code> will be available as <code>BUILDKITE_PLUGIN_MY_PLUGIN_GIT_PATTERN</code>.
 
 ### Valid plugin.yml properties

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -19,13 +19,16 @@ steps:
 
 ## Step 1: Create a new git repository
 
-Every Buildkite plugin is a Git repository, ending in `-buildkite-plugin`. This suffix is required: Buildkite automatically adds `-buildkite-plugin` to the plugin name specified in the `pipeline.yml`. Let's create a new Git repository following these naming conventions:
+The most common kind of Buildkite plugin is a Git repository, with a descriptive name ending in `-buildkite-plugin`. This suffix is required: Buildkite automatically adds `-buildkite-plugin` to the plugin name specified in the `pipeline.yml`. Let's create a new Git repository following these naming conventions:
 
 ```shell
 mkdir file-counter-buildkite-plugin
 cd file-counter-buildkite-plugin
 git init
 ```
+
+> 🚧 The `buildkite-plugin` suffix
+> Not including `-buildkite-plugin` as the end of your plugin's repository is possible but may cause you unexpected issues. It will also prevent other members of the community from easily finding and using the plugin.
 
 ## Step 2: Add a plugin.yml
 
@@ -46,10 +49,10 @@ configuration:
 
 The `configuration` property defines the validation rules for the plugin configuration using the [JSON Schema](https://json-schema.org) format. The plugin in this tutorial has a single `pattern` property, of type `string`.
 
-Configuration properties are available to the hook script as environment variables with the naming pattern `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>` where `<PLUGIN_NAME>` is the GitHub repository slug, not the name defined in `plugin.yml`. In this case, the configured value of `pattern` will be available as `BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN`.
+Configuration properties are available to the hook script as environment variables with the naming pattern `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>` where `<PLUGIN_NAME>` is not the name defined in `plugin.yml` but an uppercase version of the plugin's ID. In this case, the configured value of `pattern` will be available as `BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN`.
 
->🚧 Plugin properties and git
-> Note that if you <a href="/docs/plugins/using#plugin-sources">reference a plugin</a> using a full URL and <code>.git</code> extension, you need to use a slightly different syntax to get access to the configuration properties. For example, to get the value of <code>pattern</code> in <code>https://github.com/my-org/my-plugin.git#v1.0.0</code> use  <code>BUILDKITE_PLUGIN_MY_PLUGIN_GIT_PATTERN</code>.
+>🚧 Variables and non-standard git plugins
+> Note that if you <a href="/docs/plugins/using#plugin-sources">reference a plugin</a> with a full URL ending in <code>.git</code> and that plugin's name does not end with `buildkite-plugin`, variable names will include `_GIT` as if it were part of the plugin name. For example, the value of the configuration <code>pattern</code> in <code>https://github.com/my-org/my-plugin.git#v1.0.0</code> will be available as <code>BUILDKITE_PLUGIN_MY_PLUGIN_GIT_PATTERN</code>.
 
 ### Valid plugin.yml properties
 
@@ -94,7 +97,20 @@ You can run the plugin linter with the following Docker command:
 docker run -it --rm -v "$PWD:/plugin:ro" buildkite/plugin-linter --id a-github-user/file-counter
 ```
 
-To make it easier to run this command, add it to the `docker-compose.yml` file:
+### Plugin linter plugin
+
+If your plugin has a Buildkite pipeline, you can add a step to lint it using the corresponding plugin:
+
+```yml
+  - label: ":shell: Lint"
+    plugins:
+      plugin-linter#v3.0.0:
+        id: a-gihub-user/file-counter
+```
+{: codeblock-file=".buildkite/pipeline.yml"}
+
+### Docker compose
+You can also make it easier to run this command during development by adding the following to a `docker-compose.yml` file:
 
 ```yml
 services:
@@ -238,3 +254,20 @@ When writing plugins, there are two patterns you can choose from:
 
 * A single-command plugin: a small, declarative plugin, which exposes a single command for use in your pipeline steps. Most plugins follow this pattern.
 * A library plugin, or super-plugin: this plugin type assembles multiple commands into one plugin. Refer to the [library example Buildkite plugin](https://github.com/buildkite-plugins/library-example-buildkite-plugin) for an example of how to set up this type of plugin.
+
+## Vendored plugins
+
+If your plugin has functionality that makes sense on several of your pipelines or repositories, and maybe even for others in the community, creating a special repository as mentioned in these instructions is the way to go. But there is also the possiblity to have a whole plugin as part of a folder inside a bigger repository, this is what is called a _vendored plugin_.
+
+You can use a vendorded plugin as normal referencing it in your pipeline using a relative path:
+
+```yml
+steps:
+  - command: ls
+    plugins:
+      - ./relative/path/to/plugin:
+          pattern: '*.md'
+```
+{: codeblock-file="pipeline.yml"}
+
+Make sure to review [the documentation about job lifecycle hooks](docs/agent/v3/hooks#job-lifecycle-hooks) to understand when vendored plugins are run. Not only they are normally run after non-vendored plugins, but also some hooks are not available.

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -52,7 +52,7 @@ The `configuration` property defines the validation rules for the plugin configu
 Configuration properties are available to the hook script as environment variables with the naming pattern `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>` where `<PLUGIN_NAME>` is not the name defined in `plugin.yml` but an uppercase version of the plugin's ID. In this case, the configured value of `pattern` will be available as `BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN`.
 
 >🚧 Variables and non-standard git plugins
-> Note that if you <a href="/docs/plugins/using#plugin-sources">reference a plugin</a> with a full URL ending in <code>.git</code> and that plugin's name does not end with `buildkite-plugin`, variable names will include `_GIT` as if it were part of the plugin name. For example, the value of the configuration <code>pattern</code> in <code>https://github.com/my-org/my-plugin.git#v1.0.0</code> will be available as <code>BUILDKITE_PLUGIN_MY_PLUGIN_GIT_PATTERN</code>.
+> Note that if you <a href="/docs/plugins/using#plugin-sources">reference a plugin</a> with a full URL ending in <code>.git</code> and that plugin's name does not end with `-buildkite-plugin`, variable names will include `_GIT` as part of the plugin name. For example, the value of the configuration <code>pattern</code> in <code>https://github.com/my-org/my-plugin.git#v1.0.0</code> will be available as <code>BUILDKITE_PLUGIN_MY_PLUGIN_GIT_PATTERN</code>.
 
 ### Valid plugin.yml properties
 

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -49,7 +49,7 @@ configuration:
 
 The `configuration` property defines the validation rules for the plugin configuration using the [JSON Schema](https://json-schema.org) format. The plugin in this tutorial has a single `pattern` property, of type `string`.
 
-Configuration properties are available to the hook script as environment variables with the naming pattern `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>` where `<PLUGIN_NAME>` is not the name defined in `plugin.yml` but an uppercase version of the plugin's ID. In this case, the configured value of `pattern` will be available as `BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN`.
+Configuration properties are available to the hook script as environment variables with the naming pattern `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>` where `<PLUGIN_NAME>` is not the name defined in `plugin.yml` but the repository or folder name compatible with Bash environment variables (in uppercase and only letters, numbers and underscores). In this case, the configured value of `pattern` will be available as `BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN`.
 
 >🚧 Variables and non-standard git plugins
 > Note that if you <a href="/docs/plugins/using#plugin-sources">reference a plugin</a> with a full URL ending in <code>.git</code> and that plugin's name does not end with `-buildkite-plugin`, variable names will include `_GIT` as part of the plugin name. For example, the value of the configuration <code>pattern</code> in <code>https://github.com/my-org/my-plugin.git#v1.0.0</code> will be available as <code>BUILDKITE_PLUGIN_MY_PLUGIN_GIT_PATTERN</code>.

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -276,4 +276,4 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-Vendored plugins run after non-vendored plugins and don't have access to all the same hooks. See [the documentation about job lifecycle hooks](docs/agent/v3/hooks#job-lifecycle-hooks) to learn more.
+Vendored plugins run after non-vendored plugins and don't have access to all the same hooks. See [the documentation about job lifecycle hooks](/docs/agent/v3/hooks#job-lifecycle-hooks) to learn more.

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -257,9 +257,7 @@ When writing plugins, there are two patterns you can choose from:
 
 ## Vendored plugins
 
-If your plugin has functionality that makes sense on several of your pipelines or repositories, and maybe even for others in the community, creating a special repository as mentioned in these instructions is the way to go. But there is also the possiblity to have a whole plugin as part of a folder inside a bigger repository, this is what is called a _vendored plugin_.
-
-You can use a vendorded plugin as normal referencing it in your pipeline using a relative path:
+If you don't plan to share the plugin outside of one repository, you can use a _vendored plugin_. Vendored plugins sit alongside the rest of the repository code, and you include them with a relative path:
 
 ```yml
 steps:

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -268,4 +268,4 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-Make sure to review [the documentation about job lifecycle hooks](docs/agent/v3/hooks#job-lifecycle-hooks) to understand when vendored plugins are run. Not only they are normally run after non-vendored plugins, but also some hooks are not available.
+Vendored plugins run after non-vendored plugins and don't have access to all the same hooks. See [the documentation about job lifecycle hooks](docs/agent/v3/hooks#job-lifecycle-hooks) to learn more.

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -27,8 +27,13 @@ cd file-counter-buildkite-plugin
 git init
 ```
 
-> 🚧 The `-buildkite-plugin` suffix
-> Not including the `-buildkite-plugin` suffix in the repository name not only will prevent you from using the `user/plugin-name` syntax in the pipeline (you will need to reference the plugin with a full URL instead) but also makes it **more difficult for community members to find and use the plugin**. And even when you know it will be used through a full URL, only in your organization, or it is a vendored plugin the suffix should help identify the purpose of its contents to anyone looking at it. 
+> 📘 The `-buildkite-plugin` suffix
+> We recommend using the `-buildkite-plugin` suffix in the repository name because:
+> <ul>
+>   <li>You can reference the plugin in pipelines using the `user/plugin-name` syntax rather than the full URL.</li>
+>   <li>It makes it easier for community members to find and use the plugin if you make it public.</li>
+>   <li>It communicates the purpose of the code.</li>
+> </ul>
 
 ## Step 2: Add a plugin.yml
 
@@ -51,7 +56,7 @@ The `configuration` property defines the validation rules for the plugin configu
 
 Configuration properties are available to the hook script as environment variables with the naming pattern `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>` where `<PLUGIN_NAME>` is not the name defined in `plugin.yml` but the repository or folder name compatible with Bash environment variables (in uppercase and only letters, numbers and underscores). In this case, the configured value of `pattern` will be available as `BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN`.
 
->🚧 Accessing properties on plugins referenced with Git URLs
+> 📘 Accessing properties on plugins referenced with Git URLs
 > Note that if you <a href="/docs/plugins/using#plugin-sources">reference a plugin</a> with a full URL ending in <code>.git</code> and that plugin's name does not end with `-buildkite-plugin`, variable names will include `_GIT` as part of the plugin name. For example, the value of the configuration <code>pattern</code> in <code>https://github.com/my-org/my-plugin.git#v1.0.0</code> will be available as <code>BUILDKITE_PLUGIN_MY_PLUGIN_GIT_PATTERN</code>.
 
 ### Valid plugin.yml properties
@@ -87,9 +92,11 @@ Configuration properties are available to the hook script as environment variabl
   </tbody>
 </table>
 
-## Step 3: Validate the plugin.yml
+## Step 3: Validate the plugin
 
-The [Buildkite Plugin Linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) helps ensure your plugin is up-to-date, and has all the required files to be listed in the plugins directory.
+The [Buildkite Plugin Linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) is an app that helps ensure your plugin is up-to-date and has all the files required to list it in the plugins directory. The app is available as a Docker image you can run on the command line, with a dedicated plugin, or with Docker Compose. We recommend you start by running the linter on the command line, and then include the dedicated plugin in the pipeline for your plugin.
+
+### Run on the command line
 
 You can run the plugin linter with the following Docker command:
 
@@ -97,7 +104,7 @@ You can run the plugin linter with the following Docker command:
 docker run -it --rm -v "$PWD:/plugin:ro" buildkite/plugin-linter --id a-github-user/file-counter
 ```
 
-### Plugin linter plugin
+### Run with the dedicated plugin
 
 If your plugin has a Buildkite pipeline, you can add a step to lint it using the corresponding plugin:
 
@@ -109,8 +116,9 @@ If your plugin has a Buildkite pipeline, you can add a step to lint it using the
 ```
 {: codeblock-file=".buildkite/pipeline.yml"}
 
-### Docker compose
-You can also make it easier to run this command during development by adding the following to a `docker-compose.yml` file:
+### Run with Docker Compose
+
+If you want to run the linter using Docker Compose, you can add the following to a `docker-compose.yml` file:
 
 ```yml
 services:
@@ -122,7 +130,7 @@ services:
 ```
 {: codeblock-file="docker-compose.yml"}
 
-You can now run the tests using the following command:
+You can then run the tests using the following command:
 
 ```shell
 docker-compose run --rm lint

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -54,7 +54,7 @@ configuration:
 
 The `configuration` property defines the validation rules for the plugin configuration using the [JSON Schema](https://json-schema.org) format. The plugin in this tutorial has a single `pattern` property, of type `string`.
 
-Configuration properties are available to the hook script as environment variables with the naming pattern `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>` where `<PLUGIN_NAME>` is not the name defined in `plugin.yml` but the repository or folder name compatible with Bash environment variables (in uppercase and only letters, numbers and underscores). In this case, the configured value of `pattern` will be available as `BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN`.
+Configuration properties are available to the hook script as environment variables with the naming pattern `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>` where `<PLUGIN_NAME>` is not the name defined in `plugin.yml` but the repository or folder name compatible with Bash environment variables (in uppercase and only letters, numbers, and underscores). In this case, the configured value of `pattern` will be available as `BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN`.
 
 > 📘 Accessing properties on plugins referenced with Git URLs
 > Note that if you <a href="/docs/plugins/using#plugin-sources">reference a plugin</a> with a full URL ending in <code>.git</code> and that plugin's name does not end with `-buildkite-plugin`, variable names will include `_GIT` as part of the plugin name. For example, the value of the configuration <code>pattern</code> in <code>https://github.com/my-org/my-plugin.git#v1.0.0</code> will be available as <code>BUILDKITE_PLUGIN_MY_PLUGIN_GIT_PATTERN</code>.

--- a/pages/plugins/writing.md.erb
+++ b/pages/plugins/writing.md.erb
@@ -19,7 +19,7 @@ steps:
 
 ## Step 1: Create a new git repository
 
-The most common kind of Buildkite plugin is a Git repository, with a descriptive name ending in `-buildkite-plugin`. This suffix is required: Buildkite automatically adds `-buildkite-plugin` to the plugin name specified in the `pipeline.yml`. Let's create a new Git repository following these naming conventions:
+The most common kind of Buildkite plugin is a Git repository, with a descriptive name ending in `-buildkite-plugin`. This suffix is required to allow using the `user/plugin-name` syntax in pipelines. Let's create a new Git repository following these naming conventions:
 
 ```shell
 mkdir file-counter-buildkite-plugin
@@ -27,8 +27,8 @@ cd file-counter-buildkite-plugin
 git init
 ```
 
-> 🚧 The `buildkite-plugin` suffix
-> Not including `-buildkite-plugin` as the end of your plugin's repository is possible but may cause you unexpected issues. It will also prevent other members of the community from easily finding and using the plugin.
+> 🚧 The `-buildkite-plugin` suffix
+> Not including the `-buildkite-plugin` suffix in the repository name not only will prevent you from using the `user/plugin-name` syntax in the pipeline (you will need to reference the plugin with a full URL instead) but also makes it **more difficult for community members to find and use the plugin**. And even when you know it will be used through a full URL, only in your organization, or it is a vendored plugin the suffix should help identify the purpose of its contents to anyone looking at it. 
 
 ## Step 2: Add a plugin.yml
 


### PR DESCRIPTION
After some comments in [issue 372 in the plugin linter](https://github.com/buildkite-plugins/buildkite-plugin-linter/issues/372) I believe that some clarifications are necessary on the documentation to write plugins with regards to the `builkite-plugin` suffix and vendored plugins.