### PR TITLE
Replace link following test with `muffet`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,18 @@ steps:
             - BUILDKITE_ANALYTICS_TOKEN
 
   - label: ":spider: muffet"
-    command: http://app:3000/docs --include=/docs/ --exclude=https://github.com/buildkite/docs/ --max-connections=10 --color=always --verbose
+    # We need to wait until rails has started before running muffet as otherwise it will error out
+    # and the test will appear to have failed without having run. The time to wait is hard to
+    # predict, and furthermore, some paths take longer to be be ready than others. The path in this
+    # loop was chosen after some non-systematic observations. So it does not guarantee that the
+    # server will be ready. But it seems to work well in practice.
+    command: >-
+      while ! wget --spider -Sq http://app:3000/docs/agent/v3/hooks;
+        do echo 💎🛤️🦥 Rails is still starting;
+        sleep 0.5;
+      done &&
+      echo 💎🛤️🚆 Rails has started running &&
+      /muffet http://app:3000/docs --include=/docs/ --exclude=https://github.com/buildkite/docs/ --max-connections=10 --color=always
     env:
       RAILS_ENV: test
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,13 +7,27 @@ steps:
     env:
       RAILS_ENV: test
     plugins:
-      - docker-compose#v3.0.0:
+      - docker-compose#v3.9.0:
           run: app
           env:
             - BUILDKITE_JOB_ID
             - CI
             - RAILS_ENV
             - BUILDKITE_ANALYTICS_TOKEN
+
+  - label: ":spider: muffet"
+    command: http://app:3000/docs --include=/docs/ --exclude=https://github.com/buildkite/docs/ --max-connections=10 --color=always --verbose
+    env:
+      RAILS_ENV: test
+    plugins:
+      - docker-compose#v3.9.0:
+          run: muffet
+          shell: false
+          upload-container-logs: always
+          env:
+            - BUILDKITE_JOB_ID
+            - CI
+            - RAILS_ENV
 
   - label: ":junit: Test Summary"
     depends_on: "rspec"
@@ -65,4 +79,3 @@ steps:
         plugins:
           - docker#v3.7.0:
               image: "node:lts-alpine3.14"
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,9 @@ services:
       - '.:/app'
     ports:
       - '3000:3000'
+
+  muffet:
+    depends_on:
+      - app
+    image: raviqqe/muffet
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,6 @@ services:
     depends_on:
       - app
     image: raviqqe/muffet
-
+    entrypoint:
+      - ash
+      - -c

--- a/pages/agent/v2/gcloud.md.erb
+++ b/pages/agent/v2/gcloud.md.erb
@@ -23,7 +23,7 @@ Follow the [setup instructions for Ubuntu](/docs/agent/v2/ubuntu).
 
 ## Running the agent on Google Kubernetes Engine
 
-[Google Kubernetes Engine](https://cloud.google.com/container-engine) can run the agent as a [Docker](https://www.docker.com) container using [Kubernetes](https://kubernetes.io). To [run Docker–based builds](/docs/tutorials/docker-containerized-builds), ensure the container is started with a [privileged security context](https://kubernetes.io/docs/user-guide/pods/#privileged-mode-for-pod-containers) and mount the Docker socket and binary as volumes. For example:
+[Google Kubernetes Engine](https://cloud.google.com/container-engine) can run the agent as a [Docker](https://www.docker.com) container using [Kubernetes](https://kubernetes.io). To [run Docker–based builds](/docs/tutorials/docker-containerized-builds), ensure the container is started with a [privileged security context](https://kubernetes.io/docs/user-guide/pods/#privileged-mode-for-containers) and mount the Docker socket and binary as volumes. For example:
 
 Start a Google Kubernetes Engine cluster [through the console](https://console.cloud.google.com/kubernetes/add):
 

--- a/pages/agent/v3/gcloud.md.erb
+++ b/pages/agent/v3/gcloud.md.erb
@@ -20,7 +20,7 @@ Follow the [setup instructions for Ubuntu](/docs/agent/v3/ubuntu).
 
 ## Running the agent on Google Kubernetes Engine
 
-[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine) can run the agent as a [Docker](https://www.docker.com) container using [Kubernetes](https://kubernetes.io). To [run Docker–based builds](/docs/tutorials/docker-containerized-builds), ensure the container is started with a [privileged security context](https://kubernetes.io/docs/user-guide/pods/#privileged-mode-for-pod-containers) and mount the Docker socket as a volume.
+[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine) can run the agent as a [Docker](https://www.docker.com) container using [Kubernetes](https://kubernetes.io). To [run Docker–based builds](/docs/tutorials/docker-containerized-builds), ensure the container is started with a [privileged security context](https://kubernetes.io/docs/user-guide/pods/#privileged-mode-for-containers) and mount the Docker socket as a volume.
 
 In the [Google Cloud Console](https://console.cloud.google.com/kubernetes/add), create a _Standard_ Google Kubernetes Engine cluster:
 

--- a/pages/integrations/docker_hub.md.erb
+++ b/pages/integrations/docker_hub.md.erb
@@ -37,7 +37,7 @@ DOCKER_LOGIN_PASSWORD="the-password"
 
 All agents check the local filesystem for [hook scripts to execute during a job](/docs/agent/v3/hooks).
 
-A [pre-command hook](https://buildkite.com/docs/agent/v3/hooks#available-hooks) script like this is one option for authenticating with Docker Hub, and can be configured to fetch credentials from the system you use to store them in:
+A [pre-command hook](https://buildkite.com/docs/agent/v3/hooks#job-lifecycle-hooks) script like this is one option for authenticating with Docker Hub, and can be configured to fetch credentials from the system you use to store them in:
 
 ```bash
 #!/bin/bash


### PR DESCRIPTION
This makes https://github.com/buildkite/docs/pull/1546 work.

Muffet is much faster. The builds used to take ~14-16 min. They are now around 2.5 min. (If the docker images are cached)

However, because rails is so slow to start up, I had to make the `muffet` container wait for a bit before running. Docker-Compose does not have a good way to say that a container should depend on the “readiness” of another container before it starts. So I simulated that with a loop polling the endpoint until it responds 2xx. Unfortunately, just polling the `/` route is not sufficient, as other routes seem to take a while to become “warm” (see some failed builds on this branch). So I chose a route that failed frequently and used it as the test to see if the server is “ready”.

Closes https://github.com/buildkite/docs/pull/1546