### PR TITLE
Document maximum annotation body size

### DIFF
--- a/pages/agent/v3/cli_annotate.md.erb
+++ b/pages/agent/v3/cli_annotate.md.erb
@@ -10,7 +10,7 @@ The Buildkite Agent's `annotate` command allows you to add additional informatio
 
 The `buildkite-agent annotate` command creates an annotation associated with the current build.
 
-There is no limit to the amount of annotations you can create. All annotations can be retrieved using the [GraphQL API](/docs/apis/graphql-api).
+There is no limit to the amount of annotations you can create, but the maximum body size of each annotation is 1MiB. All annotations can be retrieved using the [GraphQL API](/docs/apis/graphql-api).
 
 Options for the `annotate` command can be found in the `buildkite-agent` cli help:
 


### PR DESCRIPTION
Buildkite imposes a maximum body size of 1MiB. I couldn't find this documented anywhere.

The `buildkite-agent annotate` CLI help will also be updated if https://github.com/buildkite/agent/pull/1844 is merged.