### PR TITLE
Improve the Provisioning existing users section for SSO Okta docs

### DIFF
--- a/pages/integrations/sso/okta.md.erb
+++ b/pages/integrations/sso/okta.md.erb
@@ -48,8 +48,10 @@ Existing Okta users aren't automatically provisioned in Buildkite; you'll need t
 
 This can be done one of two ways:
 
-1. Using the _Provision User_ function on the _Assignments_ tab of the Okta Buildkite app (if it's available), or
-1. By removing and re-assigning the users and groups to the Okta Buildkite app.
+1. Removing and re-assigning the users and groups to the Okta Buildkite app, or
+1. If your Okta tenant has [Lifecycle Management] enabled, then you can use the _Provision User_ function on the _Assignments_ tab of the Okta Buildkite app
+
+[Lifecycle Management]: https://www.okta.com/products/lifecycle-management/
 
 ## SAML user attributes
 


### PR DESCRIPTION
We recently learned more about how okta works and this section confuses our customers.

They are two options to provision existing users:

1. Remove and reassign users on okta; or
1. Use "Provision users" function (requires okta Lifecycle Management SKU feature)

![CleanShot 2022-11-24 at 13 51 32@2x](https://user-images.githubusercontent.com/1000669/203697010-f445132e-f8f0-49d8-a78e-44de577e451f.png)

More context at [this ticket](https://linear.app/buildkite/issue/FDN-1334/display-scim-panel-on-sso-page-for-all-orgs-with-an-appropriate-plan) (internal only)
