### PR TITLE
Make schedule interval granularity more obvious

### DIFF
--- a/pages/pipelines/scheduled_builds.md.erb
+++ b/pages/pipelines/scheduled_builds.md.erb
@@ -14,7 +14,8 @@ You can also create and manage schedules using the [Buildkite GraphQL API](/docs
 
 The interval defines when the schedule will create builds. Schedules run in UTC time by default, and can be defined using either predefined intervals or standard crontab time syntax.
 
-Buildkite doesn't support intervals less than 10 minutes.
+>🚧 Interval granularity
+> Buildkite doesn't support intervals less than 10 minutes.
 
 ### Predefined intervals
 


### PR DESCRIPTION
This changes the sentence about schedule interval granularity to a warning label to make it more obvious on the page
