### PR TITLE
Remove empty env vars

### DIFF
--- a/pages/agent/v3/help/_artifact_download.md
+++ b/pages/agent/v3/help/_artifact_download.md
@@ -54,7 +54,7 @@ You can also use the step&#39;s jobs id (provided by the environment variable $B
 <!-- vale off -->
 
 <table class="Docs__attribute__table">
-<tr id="step"><th><code>--step value</code> <a class="Docs__attribute__link" href="#step">#</a></th><td><p>Scope the search to a particular step by using either its name or job ID<br /><strong>Environment variable</strong>: <code></code></p></td></tr>
+<tr id="step"><th><code>--step value</code> <a class="Docs__attribute__link" href="#step">#</a></th><td><p>Scope the search to a particular step by using either its name or job ID</p></td></tr>
 <tr id="build"><th><code>--build value</code> <a class="Docs__attribute__link" href="#build">#</a></th><td><p>The build that the artifacts were uploaded to<br /><strong>Environment variable</strong>: <code>$BUILDKITE_BUILD_ID</code></p></td></tr>
 <tr id="include-retried-jobs"><th><code>--include-retried-jobs </code> <a class="Docs__attribute__link" href="#include-retried-jobs">#</a></th><td><p>Include artifacts from retried jobs in the search<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS</code></p></td></tr>
 <tr id="agent-access-token"><th><code>--agent-access-token value</code> <a class="Docs__attribute__link" href="#agent-access-token">#</a></th><td><p>The access token used to identify the agent<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_ACCESS_TOKEN</code></p></td></tr>

--- a/pages/agent/v3/help/_artifact_search.md
+++ b/pages/agent/v3/help/_artifact_search.md
@@ -49,10 +49,10 @@ The above will return a list of filenames separated by newline.
 <!-- vale off -->
 
 <table class="Docs__attribute__table">
-<tr id="step"><th><code>--step value</code> <a class="Docs__attribute__link" href="#step">#</a></th><td><p>Scope the search to a particular step by using either its name or job ID<br /><strong>Environment variable</strong>: <code></code></p></td></tr>
+<tr id="step"><th><code>--step value</code> <a class="Docs__attribute__link" href="#step">#</a></th><td><p>Scope the search to a particular step by using either its name or job ID</p></td></tr>
 <tr id="build"><th><code>--build value</code> <a class="Docs__attribute__link" href="#build">#</a></th><td><p>The build that the artifacts were uploaded to<br /><strong>Environment variable</strong>: <code>$BUILDKITE_BUILD_ID</code></p></td></tr>
 <tr id="include-retried-jobs"><th><code>--include-retried-jobs </code> <a class="Docs__attribute__link" href="#include-retried-jobs">#</a></th><td><p>Include artifacts from retried jobs in the search<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS</code></p></td></tr>
-<tr id="format"><th><code>--format value</code> <a class="Docs__attribute__link" href="#format">#</a></th><td><p>Output formatting of results. See below for listing of available format specifiers. (default: "%j %p %c\n")<br /><strong>Environment variable</strong>: <code></code></p></td></tr>
+<tr id="format"><th><code>--format value</code> <a class="Docs__attribute__link" href="#format">#</a></th><td><p>Output formatting of results. See below for listing of available format specifiers. (default: "%j %p %c\n")</p></td></tr>
 <tr id="agent-access-token"><th><code>--agent-access-token value</code> <a class="Docs__attribute__link" href="#agent-access-token">#</a></th><td><p>The access token used to identify the agent<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_ACCESS_TOKEN</code></p></td></tr>
 <tr id="endpoint"><th><code>--endpoint value</code> <a class="Docs__attribute__link" href="#endpoint">#</a></th><td><p>The Agent API endpoint (default: "<code>https://agent.buildkite.com/v3</code>")<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_ENDPOINT</code></p></td></tr>
 <tr id="no-http2"><th><code>--no-http2 </code> <a class="Docs__attribute__link" href="#no-http2">#</a></th><td><p>Disable HTTP2 when communicating with the Agent API.<br /><strong>Environment variable</strong>: <code>$BUILDKITE_NO_HTTP2</code></p></td></tr>

--- a/pages/agent/v3/help/_artifact_shasum.md
+++ b/pages/agent/v3/help/_artifact_shasum.md
@@ -54,8 +54,8 @@ agent.
 <!-- vale off -->
 
 <table class="Docs__attribute__table">
-<tr id="sha256"><th><code>--sha256 </code> <a class="Docs__attribute__link" href="#sha256">#</a></th><td><p>Request SHA-256 instead of SHA-1, errors if SHA-256 not available<br /><strong>Environment variable</strong>: <code></code></p></td></tr>
-<tr id="step"><th><code>--step value</code> <a class="Docs__attribute__link" href="#step">#</a></th><td><p>Scope the search to a particular step by its name or job ID<br /><strong>Environment variable</strong>: <code></code></p></td></tr>
+<tr id="sha256"><th><code>--sha256 </code> <a class="Docs__attribute__link" href="#sha256">#</a></th><td><p>Request SHA-256 instead of SHA-1, errors if SHA-256 not available</p></td></tr>
+<tr id="step"><th><code>--step value</code> <a class="Docs__attribute__link" href="#step">#</a></th><td><p>Scope the search to a particular step by its name or job ID</p></td></tr>
 <tr id="build"><th><code>--build value</code> <a class="Docs__attribute__link" href="#build">#</a></th><td><p>The build that the artifact was uploaded to<br /><strong>Environment variable</strong>: <code>$BUILDKITE_BUILD_ID</code></p></td></tr>
 <tr id="include-retried-jobs"><th><code>--include-retried-jobs </code> <a class="Docs__attribute__link" href="#include-retried-jobs">#</a></th><td><p>Include artifacts from retried jobs in the search<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS</code></p></td></tr>
 <tr id="agent-access-token"><th><code>--agent-access-token value</code> <a class="Docs__attribute__link" href="#agent-access-token">#</a></th><td><p>The access token used to identify the agent<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_ACCESS_TOKEN</code></p></td></tr>

--- a/pages/agent/v3/help/_meta_data_get.md
+++ b/pages/agent/v3/help/_meta_data_get.md
@@ -29,7 +29,7 @@ Get data from a builds key/value store.
 <!-- vale off -->
 
 <table class="Docs__attribute__table">
-<tr id="default"><th><code>--default value</code> <a class="Docs__attribute__link" href="#default">#</a></th><td><p>If the meta-data value doesn't exist return this instead<br /><strong>Environment variable</strong>: <code></code></p></td></tr>
+<tr id="default"><th><code>--default value</code> <a class="Docs__attribute__link" href="#default">#</a></th><td><p>If the meta-data value doesn't exist return this instead</p></td></tr>
 <tr id="job"><th><code>--job value</code> <a class="Docs__attribute__link" href="#job">#</a></th><td><p>Which job's build should the meta-data be retrieved from<br /><strong>Environment variable</strong>: <code>$BUILDKITE_JOB_ID</code></p></td></tr>
 <tr id="agent-access-token"><th><code>--agent-access-token value</code> <a class="Docs__attribute__link" href="#agent-access-token">#</a></th><td><p>The access token used to identify the agent<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_ACCESS_TOKEN</code></p></td></tr>
 <tr id="endpoint"><th><code>--endpoint value</code> <a class="Docs__attribute__link" href="#endpoint">#</a></th><td><p>The Agent API endpoint (default: "<code>https://agent.buildkite.com/v3</code>")<br /><strong>Environment variable</strong>: <code>$BUILDKITE_AGENT_ENDPOINT</code></p></td></tr>

--- a/scripts/cli2md.rb
+++ b/scripts/cli2md.rb
@@ -46,7 +46,15 @@ ARGF.each_with_index do |line, line_num|
         # Replace all prime symbols with backticks. We use prime symbols instead of backticks in CLI helptext for... reasons.
         # See: https://github.com/buildkite/agent/blob/main/clicommand/prime-signs.md
         desc.tr!('′', '`')
-        puts "<tr id=\"#{command}\"><th><code>--#{command} #{value}</code> <a class=\"Docs__attribute__link\" href=\"##{command}\">#</a></th><td><p>#{desc}<br /><strong>Environment variable</strong>: <code>#{env_var}</code></p></td></tr>"
+        print "<tr id=\"#{command}\">"
+        print "<th><code>--#{command} #{value}</code> <a class=\"Docs__attribute__link\" href=\"##{command}\">#</a></th>"
+        print "<td><p>#{desc}"
+        unless env_var.nil? || env_var.empty?
+            print "<br /><strong>Environment variable</strong>: <code>#{env_var}</code>"
+        end
+        print "</p></td>"
+        print "</tr>"
+        puts
     else
         if(first_param==true)
             puts "</table>\n\n<!-- vale on -->\n"


### PR DESCRIPTION
We're annotating the agent docs with environment variables that don't exist in some cases:

<img width="898" alt="Screen Shot 2022-12-05 at 11 59 32 am" src="https://user-images.githubusercontent.com/14028/205527496-5934fd04-19b3-451c-b133-37479edf663a.png">

So skip that bit when there is no variable:

<img width="901" alt="Screen Shot 2022-12-05 at 12 00 24 pm" src="https://user-images.githubusercontent.com/14028/205527548-80cf7c40-1239-4dab-a7c7-771a5c2c0b87.png">