### PR TITLE
Rebuild search index after deployment

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -36,3 +36,10 @@ steps:
     agents:
       queue: deploy
     command: scripts/deploy-ecs
+
+  - wait
+
+  # Refresh the search index after a deployment
+  - label: "🔎🪄"
+    trigger: docs-algolia-crawler
+    async: true


### PR DESCRIPTION
The rebuild happens once a day so may miss significant new content for up to 24 hours, so trigger a rebuild on deployment.