### PR TITLE
Fix typos in getting started guide

### DIFF
--- a/pages/tutorials/getting_started.md.erb
+++ b/pages/tutorials/getting_started.md.erb
@@ -14,12 +14,9 @@ This guide will help you set up your first Buildkite pipeline. If you don't have
 
 To confirm that your Buildkite agent is running, and configured correctly with your credentials, go to your organization's *Agents* page. You should see a list of all agents linked to the account, and their status.
 
-
-
 ## Add the sample pipeline
 
 [Pipelines](/docs/pipelines/) are how Buildkite represents your CI workflow, a series of steps that you run on your code.
-
 
 Choose a sample pipeline to use as your first pipeline:
 

--- a/pages/tutorials/getting_started.md.erb
+++ b/pages/tutorials/getting_started.md.erb
@@ -1,6 +1,6 @@
 # Getting Started
 
-This guide will help you setup your first Buildkite pipeline. If you don't have a Buildkite account you'll first need to <a href="<%= url_helpers.signup_path %>">sign up</a>. This guide uses GitHub but Buildkite can work with any version control system.
+This guide will help you set up your first Buildkite pipeline. If you don't have a Buildkite account you'll first need to <a href="<%= url_helpers.signup_path %>">sign up</a>. This guide uses GitHub but Buildkite can work with any version control system.
 
 {:toc}
 
@@ -12,7 +12,7 @@ This guide will help you setup your first Buildkite pipeline. If you don't have 
 2. Make sure you've configured the agent token, as that is what connects the agent to your Buildkite account. Refer to [Buildkite Agent Configuration](/docs/agent/v3/configuration) for more information.
 3. Opt in to the YAML steps editor. This is the newer way of configuring pipelines. Refer to [Pipeline Upgrade - Using YAML Steps for new pipelines](/docs/tutorials/pipeline-upgrade#using-yaml-steps-for-new-pipelines) for more information.
 
-To confirm that your Buildkite agent is running, and configured correctly with your credentials, go to you organization's *Agents* page. You should see a list of all agents linked to the account, and their status.
+To confirm that your Buildkite agent is running, and configured correctly with your credentials, go to your organization's *Agents* page. You should see a list of all agents linked to the account, and their status.
 
 
 


### PR DESCRIPTION
The main point of this PR is to give me a chance to walk through the process of contributing a change to the documentation. The side benefit is fixing up a couple of typos on the Getting started page.