### PR TITLE
Add GitHub Action for labelling PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+agent:
+  - pages/agent/**/*
+test-analytics:
+  - pages/test_analytics/**/*
+pipelines:
+  - pages/pipelines/**/*
+plugins:
+  - pages/plugins/**/*
+integrations:
+  - pages/integrations/**/*
+apis:
+  - pages/apis/**/*
+tutorials:
+  - pages/tutorials/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,11 +4,10 @@ test-analytics:
   - pages/test_analytics/**/*
 pipelines:
   - pages/pipelines/**/*
+  - pages/tutorials/**/*
 plugins:
   - pages/plugins/**/*
 integrations:
   - pages/integrations/**/*
 apis:
   - pages/apis/**/*
-tutorials:
-  - pages/tutorials/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
After recently browsing through PRs in this repository I thought it might be nice to add some basic categorisation in the form of GitHub labels. 

This PR adds a new GitHub Action Workflow to automatically apply labels (ie. `pipelines`, `test-analytics`, `agent`, etc). 
 I'm sure there's plenty more labels we could add but these seem like the most useful. 