### PR TITLE
Fix link to Getting started page

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,6 +1,6 @@
 <div class="HomeSuggestions">
   <strong>Popular:</strong>
-  <%= link_to "Getting started", "/docs/pipelines" %>,
+  <%= link_to "Getting started", "/docs/tutorials/getting-started" %>,
   <%= link_to "Defining build steps", "/docs/pipelines/defining-steps" %>,
   <%= link_to "Command steps", "/docs/pipelines/command-step" %>,
   <%= link_to "Environment variables", "/docs/pipelines/environment-variables" %>,


### PR DESCRIPTION
Given the location and link text, this appears to be a mistake.