### PR TITLE
Adds BUILDKITE_PLUGIN_CONFIGURATION env var + more

### DIFF
--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -298,7 +298,7 @@ variables:
 - name: BUILDKITE_PLUGIN_CONFIGURATION
   desc: |
     A JSON string holding the current plugin's configuration (as opposed to all the plugin configurations in the `BUILDKITE_PLUGINS` environment variable).
-  example: "{\"array-key\":[{\"subkey\":[1,2,\"llamas\"]}]}"
+  example: "{\"image\":\"node:lts-alpine3.14\"}"
 - name: BUILDKITE_PLUGIN_NAME
   desc: |
     The "env key-compatible" version of the current plugin name. Used for constructing the `BUILDKITE_PLUGIN_<name>_<param>` variables.

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -297,7 +297,7 @@ variables:
   example: "deploy:ops:production"
 - name: BUILDKITE_PLUGIN_CONFIGURATION
   desc: |
-    JSON string holding the current plugin's configuration (as opposed to all the plugin configurations in the `BUILDKITE_PLUGINS` environment variable).
+    A JSON string holding the current plugin's configuration (as opposed to all the plugin configurations in the `BUILDKITE_PLUGINS` environment variable).
   example: "{\"array-key\":[{\"subkey\":[1,2,\"llamas\"]}]}"
 - name: BUILDKITE_PLUGIN_NAME
   desc: |

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -295,6 +295,10 @@ variables:
     A colon separated list of the pipeline's non-private team slugs.
   modifiable: false
   example: "deploy:ops:production"
+- name: BUILDKITE_PLUGIN_CONFIGURATION
+  desc: |
+    JSON string holding the current plugin's configuration (as opposed to all the plugin configurations in the BUILDKITE_PLUGINS environment variable).
+  example: "{\"array-key\":[{\"subkey\":[1,2,\"llamas\"]}]}"
 - name: BUILDKITE_PLUGINS
   desc: |
     A JSON object containing a list plugins used in the step, and their configuration.

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -301,7 +301,7 @@ variables:
   example: "{\"image\":\"node:lts-alpine3.14\"}"
 - name: BUILDKITE_PLUGIN_NAME
   desc: |
-    The "env key-compatible" version of the current plugin name. Used for constructing the `BUILDKITE_PLUGIN_<name>_<param>` variables.
+    The current plugin's name, with all letters in uppercase and any spaces replaced with underscores.
   example: "DOCKER"
 - name: BUILDKITE_PLUGINS
   desc: |

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -297,7 +297,7 @@ variables:
   example: "deploy:ops:production"
 - name: BUILDKITE_PLUGIN_CONFIGURATION
   desc: |
-    JSON string holding the current plugin's configuration (as opposed to all the plugin configurations in the BUILDKITE_PLUGINS environment variable).
+    JSON string holding the current plugin's configuration (as opposed to all the plugin configurations in the `BUILDKITE_PLUGINS` environment variable).
   example: "{\"array-key\":[{\"subkey\":[1,2,\"llamas\"]}]}"
 - name: BUILDKITE_PLUGINS
   desc: |

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -302,7 +302,7 @@ variables:
 - name: BUILDKITE_PLUGIN_NAME
   desc: |
     The "env key-compatible" version of the current plugin name. Used for constructing the `BUILDKITE_PLUGIN_<name>_<param>` variables.
-  example: "DOCKER_COMPOSE"
+  example: "DOCKER"
 - name: BUILDKITE_PLUGINS
   desc: |
     A JSON object containing a list plugins used in the step, and their configuration.

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -299,6 +299,10 @@ variables:
   desc: |
     JSON string holding the current plugin's configuration (as opposed to all the plugin configurations in the `BUILDKITE_PLUGINS` environment variable).
   example: "{\"array-key\":[{\"subkey\":[1,2,\"llamas\"]}]}"
+- name: BUILDKITE_PLUGIN_NAME
+  desc: |
+    The "env key-compatible" version of the current plugin name. Used for constructing the `BUILDKITE_PLUGIN_<name>_<param>` variables.
+  example: "DOCKER_COMPOSE"
 - name: BUILDKITE_PLUGINS
   desc: |
     A JSON object containing a list plugins used in the step, and their configuration.


### PR DESCRIPTION
This PR adds BUILDKITE_PLUGIN_CONFIGURATION environment variable according to https://github.com/buildkite/agent/pull/1382. 

It also adds the information about BUILDKITE_PLUGIN_NAME from the same PR. This part is a separate commit and can be removed.