### PR TITLE
Update documented versions of buildkite-agent to v.3.42.0

### DIFF
--- a/pages/agent/v3/elastic_ci_aws.md.erb
+++ b/pages/agent/v3/elastic_ci_aws.md.erb
@@ -194,7 +194,7 @@ CloudWatch Logs and EC2 instance log data are forwarded to CloudWatch Logs, but 
 <!-- vale off -->
 
 * [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/)
-* [Buildkite Agent v3.39.1](https://buildkite.com/docs/agent)
+* [Buildkite Agent v3.42.0](https://buildkite.com/docs/agent)
 * [Docker](https://www.docker.com) - 20.10.7 (Linux) and 20.10.0 (Windows)
 * [Docker Compose](https://docs.docker.com/compose/) - 1.29.2 (Linux) and 1.28.5 (Windows)
 * [AWS CLI](https://aws.amazon.com/cli/) - useful for performing any ops-related tasks


### PR DESCRIPTION
This PR updates the documentation to reflect the latest Buildkite Agent version within the Elastic CI Stack for AWS.

<img width="1512" alt="Screenshot highlighting the visual change made in this PR" src="https://user-images.githubusercontent.com/37649155/212788198-03f0df64-07c6-4509-a2ce-28b09bfa47c7.png">
