### PR TITLE
Fix typo in tags-from-host default value

### DIFF
--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -292,7 +292,7 @@ attributes:
       Include the host's Google Cloud instance labels as tags.
 - name: tags-from-host
   env_var: BUILDKITE_AGENTS_TAGS_FROM_HOST
-  default_value: "fals"
+  default_value: "false"
   required: false
   desc: |
       Include the host's meta-data as tags (hostname, machine-id, and OS).


### PR DESCRIPTION
Tiny fix to update a typo in https://buildkite.com/docs/agent/v3/configuration#tags-from-host

<img width="900" alt="image" src="https://user-images.githubusercontent.com/754567/211226778-bd7f43ea-7f6f-41ed-89a9-a672039d8fd6.png">