### PR TITLE
Fail fast settings has been removed

### DIFF
--- a/pages/pipelines/command_step.md.erb
+++ b/pages/pipelines/command_step.md.erb
@@ -454,10 +454,7 @@ steps:
 
 ## Fail fast
 
-To automatically cancel remaining jobs as soon the first job fails (except jobs that you've marked as `soft_fail`):
-
-1. Make sure that _Publish failed state early_ is checked in your _Pipeline Repository_ settings
-2. Mark jobs that you want to cancel immediately with `cancel_on_build_failing: true`
+To automatically cancel remaining jobs as soon the first job fails (except jobs that you've marked as `soft_fail`), mark jobs that you want to cancel immediately with `cancel_on_build_failing: true`.
 
 Next time a job in your build fails, those jobs will be automatically cancelled.
 


### PR DESCRIPTION
From this changelog https://buildkite.com/changelog/160-failing-builds-fast, the fail fast feature has been enabled for everybody so #1 is no longer applicable