### PR TITLE
Add copy button on code examples

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,4 @@
-window.addEventListener('DOMContentLoaded', () => {
+window.addEventListener("DOMContentLoaded", () => {
   document.onkeydown = (e) => {
     const event = window.event || e;
 
@@ -8,5 +8,13 @@ window.addEventListener('DOMContentLoaded', () => {
         document.getElementById("search").focus();
         break;
     }
-  }
+  };
+
+  // todo: use data attributes
+  document.querySelectorAll("[data-copy-to-clipboard-btn]").forEach((el) => {
+    el.addEventListener("click", (e) => {
+      copyText = el.previousElementSibling.textContent;
+      navigator.clipboard.writeText(copyText);
+    });
+  });
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,5 @@
+//= require copyToClipboardButton
+
 window.addEventListener("DOMContentLoaded", () => {
   document.onkeydown = (e) => {
     const event = window.event || e;
@@ -10,11 +12,8 @@ window.addEventListener("DOMContentLoaded", () => {
     }
   };
 
-  // todo: use data attributes
-  document.querySelectorAll("[data-copy-to-clipboard-btn]").forEach((el) => {
-    el.addEventListener("click", (e) => {
-      copyText = el.previousElementSibling.textContent;
-      navigator.clipboard.writeText(copyText);
-    });
+  document.querySelectorAll("pre.highlight").forEach((code) => {
+    code.setAttribute("tabindex", 0);
+    createCopyToClipboardButton(code);
   });
 });

--- a/app/assets/javascripts/copyToClipboardButton.js
+++ b/app/assets/javascripts/copyToClipboardButton.js
@@ -1,0 +1,34 @@
+const checkedCircleIcon = `
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M9 12.75L11.25 15L15 9.75M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" stroke="#0F172A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>
+`;
+
+const clipboardDocumentIcon = `
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M8.25 7.5V6.10822C8.25 4.97324 9.09499 4.01015 10.2261 3.91627C10.5994 3.88529 10.9739 3.85858 11.3495 3.83619M15.75 18H18C19.2426 18 20.25 16.9926 20.25 15.75V6.10822C20.25 4.97324 19.405 4.01015 18.2739 3.91627C17.9006 3.88529 17.5261 3.85858 17.1505 3.83619M15.75 18.75V16.875C15.75 15.011 14.239 13.5 12.375 13.5H10.875C10.2537 13.5 9.75 12.9963 9.75 12.375V10.875C9.75 9.01104 8.23896 7.5 6.375 7.5H5.25M17.1505 3.83619C16.8672 2.91757 16.0116 2.25 15 2.25H13.5C12.4884 2.25 11.6328 2.91757 11.3495 3.83619M17.1505 3.83619C17.2152 4.04602 17.25 4.26894 17.25 4.5V5.25H11.25V4.5C11.25 4.26894 11.2848 4.04602 11.3495 3.83619M6.75 7.5H4.875C4.25368 7.5 3.75 8.00368 3.75 8.625V20.625C3.75 21.2463 4.25368 21.75 4.875 21.75H14.625C15.2463 21.75 15.75 21.2463 15.75 20.625V16.5C15.75 11.5294 11.7206 7.5 6.75 7.5Z" stroke="#0F172A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>`;
+
+const COPY_TIMEOUT = 600;
+
+function createCopyToClipboardButton(code) {
+  const button = document.createElement("button");
+  button.setAttribute("class", "CopyToClipboardButton");
+  setButtonChecked(false);
+
+  function setButtonChecked(checked) {
+    code.setAttribute("aria-copied", checked);
+    button.setAttribute("aria-checked", checked);
+    button.innerHTML = checked
+      ? `<label>Copied</label>` + checkedCircleIcon
+      : clipboardDocumentIcon;
+  }
+
+  button.addEventListener("click", (e) => {
+    navigator.clipboard.writeText(code.textContent);
+    setButtonChecked(true);
+    setTimeout(() => setButtonChecked(false), COPY_TIMEOUT);
+  });
+
+  code.insertAdjacentElement("afterend", button);
+}

--- a/app/assets/stylesheets/public/_copy-to-clipboard-button.scss
+++ b/app/assets/stylesheets/public/_copy-to-clipboard-button.scss
@@ -1,0 +1,43 @@
+.CopyToClipboardButton {
+  @extend .Button;
+  @extend .Button--default;
+
+  transition: opacity .05s linear;
+  font-family: BK-Circular, $font-family;
+  font-size: 14px;
+  font-weight: 400;
+
+  opacity: 0;
+  position: absolute;
+  gap: .4em;
+  right: .4em;
+  top: .4em;
+  padding: .4em;
+  cursor: pointer;
+
+  > svg {
+    @extend .Button__icon;
+
+    padding: 0;
+    border: 0;
+  }
+
+  // Render when focusing sibling (<pre>) element
+  pre:focus-visible + &,
+  pre:hover + & {
+    opacity: 1;
+  }
+
+  &:hover, &:focus {
+    opacity: 1;
+  }
+
+  &[aria-checked="true"] {
+    border-color: $color-lime;
+    background: transparent;
+
+    svg > path {
+      stroke: $color-lime;
+    }
+  }
+}

--- a/app/assets/stylesheets/public/_variables.scss
+++ b/app/assets/stylesheets/public/_variables.scss
@@ -4,6 +4,7 @@ $text-on-dark-very-subdued-opacity: .7;
 $color-brand-green: #14cc80;
 $filter-brand-green: invert(58%) sepia(82%) saturate(466%) hue-rotate(103deg) brightness(95%) contrast(86%);
 $color-highlight-green: #03a562;
+$color-lime: #14cc80;
 $transition-speed: 300ms;
 $header-height: 108px;
 $sidebar-width: 275px;

--- a/app/assets/stylesheets/pygments.scss
+++ b/app/assets/stylesheets/pygments.scss
@@ -66,30 +66,4 @@
 
 .highlight {
   position: relative;
-
-  &:focus, &:hover {
-    .highlight__button {
-      visibility: visible;
-    }
-  }
-}
-
-.highlight__button {
-  visibility: hidden;
-  position: absolute;
-  right: .8em;
-  top: 1em;
-  padding: 5px;
-  cursor: pointer;
-
-  > svg {
-    height: 100%;
-    width: 100%;
-    padding: 0;
-    border: 0;
-  }
-
-  &:hover {
-    visibility: visible;
-  }
 }

--- a/app/assets/stylesheets/pygments.scss
+++ b/app/assets/stylesheets/pygments.scss
@@ -67,7 +67,7 @@
 .highlight {
   position: relative;
 
-  &:hover {
+  &:focus, &:hover {
     .highlight__button {
       visibility: visible;
     }

--- a/app/assets/stylesheets/pygments.scss
+++ b/app/assets/stylesheets/pygments.scss
@@ -63,3 +63,33 @@
 .highlight .ld, /* Literal.Date */
 .highlight .m   /* Literal.Number */
 { color: #ca1655; }
+
+.highlight {
+  position: relative;
+
+  &:hover {
+    .highlight__button {
+      visibility: visible;
+    }
+  }
+}
+
+.highlight__button {
+  visibility: hidden;
+  position: absolute;
+  right: .8em;
+  top: 1em;
+  padding: 5px;
+  cursor: pointer;
+
+  > svg {
+    height: 100%;
+    width: 100%;
+    padding: 0;
+    border: 0;
+  }
+
+  &:hover {
+    visibility: visible;
+  }
+}

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -57,9 +57,11 @@ class Page::Renderer
   end
 
   def add_copy_to_clipboard_button(doc)
-    doc.css("div.highlight").map do |block|
+    doc.css("div.highlight").map do |node|
+      node.set_attribute("tabindex", 0)
+
       # Render clipboard icon from https://www.figma.com/file/zJ2OfBZPY0bYGkv0TZ2FNR/Heroicons?node-id=2%3A943&t=igXNWnw6MjFltc3X-4
-      block.add_child('<button class="Button Button--small Button--default highlight__button" data-copy-to-clipboard-btn aria-label="Copy to clipboard" title="Copy to clipboard"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      node.add_child('<button class="Button Button--small Button--default highlight__button" data-copy-to-clipboard-btn aria-label="Copy to clipboard" title="Copy to clipboard"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M8.25 7.5V6.10822C8.25 4.97324 9.09499 4.01015 10.2261 3.91627C10.5994 3.88529 10.9739 3.85858 11.3495 3.83619M15.75 18H18C19.2426 18 20.25 16.9926 20.25 15.75V6.10822C20.25 4.97324 19.405 4.01015 18.2739 3.91627C17.9006 3.88529 17.5261 3.85858 17.1505 3.83619M15.75 18.75V16.875C15.75 15.011 14.239 13.5 12.375 13.5H10.875C10.2537 13.5 9.75 12.9963 9.75 12.375V10.875C9.75 9.01104 8.23896 7.5 6.375 7.5H5.25M17.1505 3.83619C16.8672 2.91757 16.0116 2.25 15 2.25H13.5C12.4884 2.25 11.6328 2.91757 11.3495 3.83619M17.1505 3.83619C17.2152 4.04602 17.25 4.26894 17.25 4.5V5.25H11.25V4.5C11.25 4.26894 11.2848 4.04602 11.3495 3.83619M6.75 7.5H4.875C4.25368 7.5 3.75 8.00368 3.75 8.625V20.625C3.75 21.2463 4.25368 21.75 4.875 21.75H14.625C15.2463 21.75 15.75 21.2463 15.75 20.625V16.5C15.75 11.5294 11.7206 7.5 6.75 7.5Z" stroke="#0F172A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>')
     end
 

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -22,6 +22,8 @@ class Page::Renderer
     doc = add_code_filenames(doc)
     doc = add_callout(doc)
     doc = init_responsive_tables(doc)
+    doc = add_copy_to_clipboard_button(doc)
+
     doc.to_html.html_safe
   end
 
@@ -52,6 +54,16 @@ class Page::Renderer
     def codespan(code)
       %{<code>#{EscapeUtils.escape_html(code)}</code>}
     end
+  end
+
+  def add_copy_to_clipboard_button(doc)
+    doc.css("div.highlight").map do |block|
+      # Render clipboard icon from https://www.figma.com/file/zJ2OfBZPY0bYGkv0TZ2FNR/Heroicons?node-id=2%3A943&t=igXNWnw6MjFltc3X-4
+      block.add_child('<button class="Button Button--small Button--default highlight__button" data-copy-to-clipboard-btn aria-label="Copy to clipboard" title="Copy to clipboard"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M8.25 7.5V6.10822C8.25 4.97324 9.09499 4.01015 10.2261 3.91627C10.5994 3.88529 10.9739 3.85858 11.3495 3.83619M15.75 18H18C19.2426 18 20.25 16.9926 20.25 15.75V6.10822C20.25 4.97324 19.405 4.01015 18.2739 3.91627C17.9006 3.88529 17.5261 3.85858 17.1505 3.83619M15.75 18.75V16.875C15.75 15.011 14.239 13.5 12.375 13.5H10.875C10.2537 13.5 9.75 12.9963 9.75 12.375V10.875C9.75 9.01104 8.23896 7.5 6.375 7.5H5.25M17.1505 3.83619C16.8672 2.91757 16.0116 2.25 15 2.25H13.5C12.4884 2.25 11.6328 2.91757 11.3495 3.83619M17.1505 3.83619C17.2152 4.04602 17.25 4.26894 17.25 4.5V5.25H11.25V4.5C11.25 4.26894 11.2848 4.04602 11.3495 3.83619M6.75 7.5H4.875C4.25368 7.5 3.75 8.00368 3.75 8.625V20.625C3.75 21.2463 4.25368 21.75 4.875 21.75H14.625C15.2463 21.75 15.75 21.2463 15.75 20.625V16.5C15.75 11.5294 11.7206 7.5 6.75 7.5Z" stroke="#0F172A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>')
+    end
+
+    doc
   end
 
   def add_automatic_ids_to_headings(doc)

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -22,8 +22,6 @@ class Page::Renderer
     doc = add_code_filenames(doc)
     doc = add_callout(doc)
     doc = init_responsive_tables(doc)
-    doc = add_copy_to_clipboard_button(doc)
-
     doc.to_html.html_safe
   end
 
@@ -54,18 +52,6 @@ class Page::Renderer
     def codespan(code)
       %{<code>#{EscapeUtils.escape_html(code)}</code>}
     end
-  end
-
-  def add_copy_to_clipboard_button(doc)
-    doc.css("div.highlight").map do |node|
-      node.set_attribute("tabindex", 0)
-
-      # Render clipboard icon from https://www.figma.com/file/zJ2OfBZPY0bYGkv0TZ2FNR/Heroicons?node-id=2%3A943&t=igXNWnw6MjFltc3X-4
-      node.add_child('<button class="Button Button--small Button--default highlight__button" data-copy-to-clipboard-btn aria-label="Copy to clipboard" title="Copy to clipboard"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M8.25 7.5V6.10822C8.25 4.97324 9.09499 4.01015 10.2261 3.91627C10.5994 3.88529 10.9739 3.85858 11.3495 3.83619M15.75 18H18C19.2426 18 20.25 16.9926 20.25 15.75V6.10822C20.25 4.97324 19.405 4.01015 18.2739 3.91627C17.9006 3.88529 17.5261 3.85858 17.1505 3.83619M15.75 18.75V16.875C15.75 15.011 14.239 13.5 12.375 13.5H10.875C10.2537 13.5 9.75 12.9963 9.75 12.375V10.875C9.75 9.01104 8.23896 7.5 6.375 7.5H5.25M17.1505 3.83619C16.8672 2.91757 16.0116 2.25 15 2.25H13.5C12.4884 2.25 11.6328 2.91757 11.3495 3.83619M17.1505 3.83619C17.2152 4.04602 17.25 4.26894 17.25 4.5V5.25H11.25V4.5C11.25 4.26894 11.2848 4.04602 11.3495 3.83619M6.75 7.5H4.875C4.25368 7.5 3.75 8.00368 3.75 8.625V20.625C3.75 21.2463 4.25368 21.75 4.875 21.75H14.625C15.2463 21.75 15.75 21.2463 15.75 20.625V16.5C15.75 11.5294 11.7206 7.5 6.75 7.5Z" stroke="#0F172A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>')
-    end
-
-    doc
   end
 
   def add_automatic_ids_to_headings(doc)


### PR DESCRIPTION
It's annoying having to manually copy code snippets from the docs into a shell / editor. 

This PR adds the most basic version of a "Copy to clipboard" button that becomes visible on hover and focus for all code blocks. 

This change still needs a round of design but you get the gist. There's currently no success state (i.e. "Copied 👍🏻) and I've totally guessed my way around icons! 

https://user-images.githubusercontent.com/656826/211252617-a90917cf-2424-4fd5-a973-ecabdefb80b9.mov

