### PR TITLE
Be explicit about the yaml file attribute

### DIFF
--- a/pages/pipelines/environment_variables.md.erb
+++ b/pages/pipelines/environment_variables.md.erb
@@ -216,7 +216,7 @@ In the final job environment, the value of `MY_ENV1` would be `"c"`.
 There are two places in a pipeline.yml file that you can set environment variables:
 
   1. In the `env` attribute of command and trigger steps.
-  2. At the top of the yaml file, before you define your pipeline's steps.
+  2. In the `env` attribute at the top of the yaml file, before you define your pipeline's steps.
 
 Defining an environment variable at the top of your yaml file will set that variable on each of the command steps in the pipeline, and is equivalent to setting the `env` attribute on every step. This includes further pipeline uploads through `buildkite-agent pipeline upload`.
 


### PR DESCRIPTION
While using this documentation today I was unsure if the attribute at the top of the yaml file was named the same (`env`).