### PR TITLE
Add missing /etc/

### DIFF
--- a/pages/agent/v3/macos.md.erb
+++ b/pages/agent/v3/macos.md.erb
@@ -42,7 +42,7 @@ To see the paths to the agent's configuration, hooks, builds, and logs on your s
 The typical paths for [Mac computers with Apple silicon](https://support.apple.com/en-gb/HT211814) (such as M1 chips) are:
 
 * Configuration: `/opt/homebrew/etc/buildkite-agent/buildkite-agent.cfg`
-* Agent Hooks: `/opt/homebrew//buildkite-agent/hooks`
+* Agent Hooks: `/opt/homebrew/etc/buildkite-agent/hooks`
 * Builds: `/opt/homebrew/buildkite-agent/builds`
 * Log: `/opt/homebrew/var/log/buildkite-agent.log`
 


### PR DESCRIPTION
`/etc/` is missing in the hooks path in the docs for the MacOS file location.