### PR TITLE
Add docs for agent-startup hook

### DIFF
--- a/pages/agent/v3/hooks.md.erb
+++ b/pages/agent/v3/hooks.md.erb
@@ -96,6 +96,7 @@ a plugin can define.
 | Hook             | Location Order | Description |
 | ---------------- | -------------- | ----------- |
 | `pre-bootstrap`  | <span class="add-icon-agent">Agent</span> | Executed before any job is started. Useful for [adding strict checks](/docs/agent/v3/securing#strict-checks-using-a-pre-bootstrap-hook) before jobs are permitted to run.<br /><br />The proposed job command and environment is written to a file and the path to this file provided in the `BUILDKITE_ENV_FILE` environment variable. Use the contents of this file to determine whether to permit the job to run on this agent.<br /><br />If the <code>pre-bootstrap</code> hook terminates with an exit code of `0`, the job is permitted to run. Any other exit code results in the job being rejected, and job failure being reported to the Buildkite API. |
+| `agent-startup` | <span class="add-icon-agent">Agent</span> | Executed at agent startup, immediately prior to the agent being registered with Buildkite. Useful for initialising resources that will be used by all jobs that an agent runs, outside of the job lifecycle. |
 | `agent-shutdown` | <span class="add-icon-agent">Agent</span> | Executed when the agent shuts down. Useful for performing cleanup tasks for the entire agent, outside of the job lifecycle. |
 {: class="table table--no-wrap"}
 


### PR DESCRIPTION
As part of [Agent v3.42.0](https://github.com/buildkite/agent/releases/tag/v3.42.0), we added a new hook to the agent, `agent-startup`. This hook runs at agent startup, immediately prior to the agent being registered with Buildkite.