### PR TITLE
Block step and input step docs: always render dropdown on blockfieldmodal if required: false

### DIFF
--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -253,6 +253,7 @@ _Optional attributes:_
     <td><code>required</code></td>
     <td>
       A boolean value that defines whether the field is required for form submission.<br>
+      When this value is set to <code>false</code>, non-multiple options will always displayed in a dropdown box, regardless of how many are provided.<br>
       <em>Default:</em> <code>true</code>
     </td>
   </tr>

--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -18,7 +18,7 @@ steps:
 
 <%= image "block-step.png", width: 944/2, height: 364/2, alt: "Screenshot of a basic block step" %>
 
-You can add form fields to block steps by adding a `fields` attribute. There are two field types available: text or select. The select input type is displayed as radio buttons when it contains less than six items, and as a drop down list when it contains more than six items. Block steps with input fields can only be defined using a `pipeline.yml`.
+You can add form `fields` to block steps by adding a fields attribute. Block steps with input fields can only be defined using a `pipeline.yml`. There are two field types available: text or select. The select input type displays differently depending on how you configure the options. If you allow people to select multiple options, they display as checkboxes. If you are required to select only one option from six or fewer, they display as radio buttons. Otherwise, the options display in a dropdown menu.
 
 <%= image "block-step-with-fields.png", width: 944/2, height: 1178/2, alt: "Screenshot of a block step with input fields" %>
 
@@ -253,7 +253,7 @@ _Optional attributes:_
     <td><code>required</code></td>
     <td>
       A boolean value that defines whether the field is required for form submission.<br>
-      When this value is set to <code>false</code>, non-multiple options will always displayed in a dropdown box, regardless of how many are provided.<br>
+      When this value is set to <code>false</code> and users can only select one option, the options display in a dropdown menu, regardless of how many options there are.<br>
       <em>Default:</em> <code>true</code>
     </td>
   </tr>

--- a/pages/pipelines/input_step.md.erb
+++ b/pages/pipelines/input_step.md.erb
@@ -19,7 +19,7 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-You can add form fields to input steps by adding the `fields` attribute. There are two field types available: text or select. The select input type is displayed as radio buttons when it contains less than six items, and as a drop down list when it contains more than six items.
+You can add form `fields` to block steps by adding a fields attribute. Block steps with input fields can only be defined using a `pipeline.yml`. There are two field types available: text or select. The select input type displays differently depending on how you configure the options. If you allow people to select multiple options, they display as checkboxes. If you are required to select only one option from six or fewer, they display as radio buttons. Otherwise, the options display in a dropdown menu.
 
 The data you collect from these fields is available to subsequent steps through the [build meta-data](/docs/pipelines/build-meta-data) command.
 
@@ -238,7 +238,7 @@ _Optional attributes:_
     <td><code>required</code></td>
     <td>
       A boolean value that defines whether the field is required for form submission.<br>
-      When this value is set to <code>false</code>, non-multiple options will always displayed in a dropdown box, regardless of how many are provided.<br>
+      When this value is set to <code>false</code> and users can only select one option, the options display in a dropdown menu, regardless of how many options there are.<br>
       <em>Default:</em> <code>true</code>
     </td>
   </tr>

--- a/pages/pipelines/input_step.md.erb
+++ b/pages/pipelines/input_step.md.erb
@@ -238,6 +238,7 @@ _Optional attributes:_
     <td><code>required</code></td>
     <td>
       A boolean value that defines whether the field is required for form submission.<br>
+      When this value is set to <code>false</code>, non-multiple options will always displayed in a dropdown box, regardless of how many are provided.<br>
       <em>Default:</em> <code>true</code>
     </td>
   </tr>


### PR DESCRIPTION
### Description ✏️
Recently Pipelines Edge had an [escalation](https://3.basecamp.com/3453178/buckets/23112918/card_tables/cards/5744680321) where a customer was confused as to why the BlockFieldsModal was rendering a dropdown when they had less than 6 options provided. Turns out it's because the `required` field was set to `false`. It's expected behaviour in that it's purposely build into the code, but it also took us a minute to figure out whether this was a bug or not, and why it was implemented this way, as this behaviour is not currently mentioned in the docs! 

The reason is this:
If required == false and radio buttons are rendered, the user cannot "unselect" once an option has been checked. 

This PR adds a bit of extra context to the docs to avoid this confusion in the future.

### Context 🥟
[Linear Ticket](https://linear.app/buildkite/issue/EDGE-507/samsara-possible-ui-bug-on-select-input)