### PR TITLE
Readme Update: Use git clone ssh command in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ or use [`rbenv`](https://github.com/rbenv/rbenv) to automatically select the cor
 1. Get the source. Run:
 
    ```bash
-   git clone https://github.com/buildkite/docs.git
+   git clone git@github.com:buildkite/docs.git
    cd docs
    git submodule update --init
    ```


### PR DESCRIPTION
The `git clone` command currently in the README uses HTTPS, and I think most buildkiters are authenticating using SSH. Using the HTTPS command resulted in this error when I tried to push up a branch: 

```
remote: Invalid username or password.
fatal: Authentication failed for 'https://github.com/buildkite/docs.git/'
```

It took me a minute to realise the issue as I'd just sort of auto-pilot copy+pasted the command. This change will help ensure others don't get caught out in the same way 🌻