### PR TITLE
Add underscores to the list of allowed characters for key

### DIFF
--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -130,7 +130,7 @@ _Required attributes:_
     <td><code>key</code></td>
     <td>
       The meta-data key that stores the field's input (using the <a href="/docs/agent/v3/cli-meta-data">buildkite-agent meta-data command</a>)<br>
-      The key may only contain alphanumeric characters, slashes or dashes.
+      The key may only contain alphanumeric characters, slashes, dashes or underscores.
       <em>Example:</em> <code>"release-name"</code>
     </td>
   </tr>
@@ -192,7 +192,7 @@ _Required attributes:_
     <td><code>key</code></td>
     <td>
       The meta-data key that stores the field's input (using the <a href="/docs/agent/v3/cli-meta-data">buildkite-agent meta-data command</a>)<br>
-      The key may only contain alphanumeric characters, slashes or dashes.
+      The key may only contain alphanumeric characters, slashes, dashes or underscores.
       <em>Example:</em> <code>"release-stream"</code>
     </td>
   </tr>

--- a/pages/pipelines/block_step.md.erb
+++ b/pages/pipelines/block_step.md.erb
@@ -130,7 +130,7 @@ _Required attributes:_
     <td><code>key</code></td>
     <td>
       The meta-data key that stores the field's input (using the <a href="/docs/agent/v3/cli-meta-data">buildkite-agent meta-data command</a>)<br>
-      The key may only contain alphanumeric characters, slashes, dashes or underscores.
+      The key may only contain alphanumeric characters, slashes, dashes, or underscores.
       <em>Example:</em> <code>"release-name"</code>
     </td>
   </tr>
@@ -192,7 +192,7 @@ _Required attributes:_
     <td><code>key</code></td>
     <td>
       The meta-data key that stores the field's input (using the <a href="/docs/agent/v3/cli-meta-data">buildkite-agent meta-data command</a>)<br>
-      The key may only contain alphanumeric characters, slashes, dashes or underscores.
+      The key may only contain alphanumeric characters, slashes, dashes, or underscores.
       <em>Example:</em> <code>"release-stream"</code>
     </td>
   </tr>

--- a/pages/pipelines/input_step.md.erb
+++ b/pages/pipelines/input_step.md.erb
@@ -115,7 +115,7 @@ _Required attributes:_
     <td><code>key</code></td>
     <td>
       The meta-data key that stores the field's input (using the <a href="/docs/agent/v3/cli-meta-data">buildkite-agent meta-data command</a>)<br>
-      The key may only contain alphanumeric characters, slashes, dashes or underscores.
+      The key may only contain alphanumeric characters, slashes, dashes, or underscores.
       <em>Example:</em> <code>"release-name"</code>
     </td>
   </tr>
@@ -177,7 +177,7 @@ _Required attributes:_
     <td><code>key</code></td>
     <td>
       The meta-data key that stores the field's input (using the <a href="/docs/agent/v3/cli-meta-data">buildkite-agent meta-data command</a>)<br>
-      The key may only contain alphanumeric characters, slashes, dashes or underscores.
+      The key may only contain alphanumeric characters, slashes, dashes, or underscores.
       <em>Example:</em> <code>"release-stream"</code>
     </td>
   </tr>

--- a/pages/pipelines/input_step.md.erb
+++ b/pages/pipelines/input_step.md.erb
@@ -115,7 +115,7 @@ _Required attributes:_
     <td><code>key</code></td>
     <td>
       The meta-data key that stores the field's input (using the <a href="/docs/agent/v3/cli-meta-data">buildkite-agent meta-data command</a>)<br>
-      The key may only contain alphanumeric characters, slashes or dashes.
+      The key may only contain alphanumeric characters, slashes, dashes or underscores.
       <em>Example:</em> <code>"release-name"</code>
     </td>
   </tr>
@@ -177,7 +177,7 @@ _Required attributes:_
     <td><code>key</code></td>
     <td>
       The meta-data key that stores the field's input (using the <a href="/docs/agent/v3/cli-meta-data">buildkite-agent meta-data command</a>)<br>
-      The key may only contain alphanumeric characters, slashes or dashes.
+      The key may only contain alphanumeric characters, slashes, dashes or underscores.
       <em>Example:</em> <code>"release-stream"</code>
     </td>
   </tr>


### PR DESCRIPTION
Going through PR's for https://github.com/buildkite/pipeline-schema there was one for adding underscores to the schema definition for the meta-data key field.

This PR updates the docs to say 'underscore' is an allowed character in the key field.