### PR TITLE
Added description for what 'fixed' means for Slack

### DIFF
--- a/pages/integrations/slack.md.erb
+++ b/pages/integrations/slack.md.erb
@@ -26,7 +26,7 @@ Once you have granted access to your Slack workspace, give it a description, cho
 
 <%= image "buildkite-slack-connected.png", width: 1458/2, height: 1540/2, alt: "Screenshot of Buildkite Slack Notification Settings, requesting a description, your choice of text or emoji message themes, which pipelines and branches to include, and which build states should trigger a notification" %>
 
-The function of the "fixed" option displayed above is to notify you of a successful build of a pipeline after it has errored and will not be issued based on the actions of individual steps within a pipeline. The notifications configured above are at the pipeline level, not at the step level.
+The function of the "fixed" option displayed above is to notify you of a successful build of a pipeline after it has failed and will not be issued based on the actions of individual steps within a pipeline. The notifications configured above are at the pipeline level, not at the step level.
 
 If you're using the [`notify` YAML attribute](/docs/pipelines/notifications) for more fine grained control over your Slack notifications, select the 'Only Some Pipelines...' option. Once you're using a Slack `notify` attribute in your `pipeline.yml`, the branch and build filtering from the Slack Notification Service will be overridden by the YAML options you choose.
 

--- a/pages/integrations/slack.md.erb
+++ b/pages/integrations/slack.md.erb
@@ -26,6 +26,8 @@ Once you have granted access to your Slack workspace, give it a description, cho
 
 <%= image "buildkite-slack-connected.png", width: 1458/2, height: 1540/2, alt: "Screenshot of Buildkite Slack Notification Settings, requesting a description, your choice of text or emoji message themes, which pipelines and branches to include, and which build states should trigger a notification" %>
 
+The function of the "fixed" option displayed above is to notify you of a successful build of a pipeline after it has errored and will not be issued based on the actions of individual steps within a pipeline. The notifications configured above are at the pipeline level, not at the step level.
+
 If you're using the [`notify` YAML attribute](/docs/pipelines/notifications) for more fine grained control over your Slack notifications, select the 'Only Some Pipelines...' option. Once you're using a Slack `notify` attribute in your `pipeline.yml`, the branch and build filtering from the Slack Notification Service will be overridden by the YAML options you choose.
 
 ## Changing channels


### PR DESCRIPTION
Currently the only definition I could find for what 'fixed' means in the context of Slack notifications was [here](https://buildkite.com/docs/integrations/slack#adding-a-notification-service), which is confusing and very difficult to find.

We should clarify what is meant by fixed as well as how it functions at the pipeline outcome level and not the step level.

:smile_cat: 