### PR TITLE
Bm/redacted env

### DIFF
--- a/pages/pipelines/managing_log_output.md.erb
+++ b/pages/pipelines/managing_log_output.md.erb
@@ -135,7 +135,7 @@ To further tighten the security in a Buildkite organization, you can use the [AP
 
 The Buildkite agent can redact the values of environment variables whose names match common patterns for passwords, and other secure information, before the build log is uploaded to Buildkite.
 
-The default environment variable name patterns are `*_PASSWORD`, `*_SECRET` and `*_TOKEN`. You can replace the default patterns by [setting redacted-vars](/docs/agent/v3/configuration#redacted-vars) **on your agent**.
+The default environment variable name patterns are `*_PASSWORD`, `*_SECRET`, `*_TOKEN`, `*_ACCESS_KEY`, and `*_SECRET_KEY`. You can replace the default patterns by [setting redacted-vars](/docs/agent/v3/configuration#redacted-vars) **on your agent**.
 
 For example, if you have environment variable `MY_SECRET="topsecret"`and you run a command that outputs `This is topsecret info`, the log output will actually be `This is [REDACTED] info`.
 

--- a/pages/pipelines/secrets.md.erb
+++ b/pages/pipelines/secrets.md.erb
@@ -110,10 +110,9 @@ env:
 steps:
   - command: scripts/trigger-github-deploy
 ```
-
 {: codeblock-file="pipeline.yml"}
 
-> 📘 Never store secrets in the <code>env</code> section of your pipeline.
+>📘 Never store secrets in the <code>env</code> section of your pipeline.
 
 ## Anti-pattern: Referencing secrets in your pipeline YAML
 

--- a/pages/pipelines/secrets.md.erb
+++ b/pages/pipelines/secrets.md.erb
@@ -32,6 +32,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "pipeline-one" ]]; then
   export BUILDKITE_ANALYTICS_TOKEN="oS3AG0eBuUJMWRgkRvek"
 fi
 ```
+
 {: codeblock-file="hooks/environment"}
 
 Adding conditional checks, such as the pipeline slug and step identifier, helps to limit accidental disclosure of secrets.
@@ -42,6 +43,7 @@ steps:
   - command: scripts/trigger-deploy
     key: trigger-deploy
 ```
+
 {: codeblock-file="pipeline.yml"}
 
 In your `environment` hook, you can export the deployment token only when when the job is the deployment step in a specific pipeline:
@@ -54,6 +56,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "my-app" && "$BUILDKITE_STEP_KEY" == "trigge
   export SECRET_DEPLOYMENT_ACCESS_TOKEN="bd0fa963610b..."
 fi
 ```
+
 {: codeblock-file="hooks/environment"}
 
 The script exports `SECRET_DEPLOYMENT_ACCESS_TOKEN` only for the named pipeline and step.
@@ -77,6 +80,7 @@ if [[ "$BUILDKITE_STEP_KEY" == "trigger-github-deploy" ]]; then
   export GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN="bd0fa963610b..."
 fi
 ```
+
 {: codeblock-file="env"}
 
 You then upload the `env` file, encrypted, into the secrets S3 bucket with the
@@ -95,7 +99,7 @@ See the [Elastic CI Stack for AWS](https://github.com/buildkite/elastic-ci-stack
 
 You should never store secrets on your Buildkite Pipeline Settings page. Not only does this expose the secret value to Buildkite, but pipeline settings are often returned in REST and GraphQL API payloads.
 
->📘Never store secret values in your Buildkite pipeline settings.
+> 📘Never store secret values in your Buildkite pipeline settings.
 
 ## Anti-pattern: Storing secrets in your pipeline.yml
 
@@ -110,9 +114,10 @@ env:
 steps:
   - command: scripts/trigger-github-deploy
 ```
+
 {: codeblock-file="pipeline.yml"}
 
->📘 Never store secrets in the <code>env</code> section of your pipeline.
+> 📘 Never store secrets in the <code>env</code> section of your pipeline.
 
 ## Anti-pattern: Referencing secrets in your pipeline YAML
 
@@ -129,11 +134,12 @@ steps:
         --data "{\"ref\": \"$BUILDKITE_COMMIT\"}" \
         https://api.github.com/repos/my-org/my-app/deployments
 ```
+
 {: codeblock-file="pipeline.yml"}
 
 Referencing secrets in your steps risks them being interpolated, uploaded to Buildkite, and shown in plain text in the "Uploaded Pipelines" list in the job's Timeline tab.
 
-The Buildkite agent does [redact strings](/docs/pipelines/managing-log-output#redacted-environment-variables) that match the values off of environment variables whose names match common password patterns such as `*_PASSWORD`, `*_SECRET` and `*_TOKEN`.
+The Buildkite agent does [redact strings](/docs/pipelines/managing-log-output#redacted-environment-variables) that match the values off of environment variables whose names match common password patterns such as `*_PASSWORD`, `*_SECRET`, `*_TOKEN`, `*_ACCESS_KEY` and `*_SECRET_KEY`.
 
 To prevent the risk of interpolation, it is recommended that you replace the command block with a script in your repository, for example:
 
@@ -141,9 +147,10 @@ To prevent the risk of interpolation, it is recommended that you replace the com
 steps:
   - command: scripts/trigger-github-deploy
 ```
+
 {: codeblock-file="pipeline.yml"}
 
->📘
+> 📘
 > Use <a href="/docs/pipelines/writing-build-scripts">build scripts</a> instead of <code>command</code> blocks for steps that use secrets.
 
 If you must define your script in your steps, you can prevent interpolation by using the `$$` syntax:
@@ -160,4 +167,5 @@ steps:
         --data "{\"ref\": \"$$BUILDKITE_COMMIT\"}" \
         https://api.github.com/repos/my-org/my-app/deployments
 ```
+
 {: codeblock-file="pipeline.yml"}

--- a/pages/pipelines/secrets.md.erb
+++ b/pages/pipelines/secrets.md.erb
@@ -133,7 +133,7 @@ steps:
 
 Referencing secrets in your steps risks them being interpolated, uploaded to Buildkite, and shown in plain text in the "Uploaded Pipelines" list in the job's Timeline tab.
 
-The Buildkite agent does [redact strings](/docs/pipelines/managing-log-output#redacted-environment-variables) that match the values off of environment variables whose names match common password patterns such as `*_PASSWORD`, `*_SECRET`, `*_TOKEN`, `*_ACCESS_KEY` and `*_SECRET_KEY`.
+The Buildkite agent does [redact strings](/docs/pipelines/managing-log-output#redacted-environment-variables) that match the values off of environment variables whose names match common password patterns such as `*_PASSWORD`, `*_SECRET`, `*_TOKEN`, `*_ACCESS_KEY`, and `*_SECRET_KEY`.
 
 To prevent the risk of interpolation, it is recommended that you replace the command block with a script in your repository, for example:
 

--- a/pages/pipelines/secrets.md.erb
+++ b/pages/pipelines/secrets.md.erb
@@ -32,7 +32,6 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "pipeline-one" ]]; then
   export BUILDKITE_ANALYTICS_TOKEN="oS3AG0eBuUJMWRgkRvek"
 fi
 ```
-
 {: codeblock-file="hooks/environment"}
 
 Adding conditional checks, such as the pipeline slug and step identifier, helps to limit accidental disclosure of secrets.
@@ -43,7 +42,6 @@ steps:
   - command: scripts/trigger-deploy
     key: trigger-deploy
 ```
-
 {: codeblock-file="pipeline.yml"}
 
 In your `environment` hook, you can export the deployment token only when when the job is the deployment step in a specific pipeline:
@@ -56,7 +54,6 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "my-app" && "$BUILDKITE_STEP_KEY" == "trigge
   export SECRET_DEPLOYMENT_ACCESS_TOKEN="bd0fa963610b..."
 fi
 ```
-
 {: codeblock-file="hooks/environment"}
 
 The script exports `SECRET_DEPLOYMENT_ACCESS_TOKEN` only for the named pipeline and step.
@@ -80,7 +77,6 @@ if [[ "$BUILDKITE_STEP_KEY" == "trigger-github-deploy" ]]; then
   export GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN="bd0fa963610b..."
 fi
 ```
-
 {: codeblock-file="env"}
 
 You then upload the `env` file, encrypted, into the secrets S3 bucket with the
@@ -99,7 +95,7 @@ See the [Elastic CI Stack for AWS](https://github.com/buildkite/elastic-ci-stack
 
 You should never store secrets on your Buildkite Pipeline Settings page. Not only does this expose the secret value to Buildkite, but pipeline settings are often returned in REST and GraphQL API payloads.
 
-> 📘Never store secret values in your Buildkite pipeline settings.
+>📘Never store secret values in your Buildkite pipeline settings.
 
 ## Anti-pattern: Storing secrets in your pipeline.yml
 
@@ -134,7 +130,6 @@ steps:
         --data "{\"ref\": \"$BUILDKITE_COMMIT\"}" \
         https://api.github.com/repos/my-org/my-app/deployments
 ```
-
 {: codeblock-file="pipeline.yml"}
 
 Referencing secrets in your steps risks them being interpolated, uploaded to Buildkite, and shown in plain text in the "Uploaded Pipelines" list in the job's Timeline tab.
@@ -147,10 +142,9 @@ To prevent the risk of interpolation, it is recommended that you replace the com
 steps:
   - command: scripts/trigger-github-deploy
 ```
-
 {: codeblock-file="pipeline.yml"}
 
-> 📘
+>📘
 > Use <a href="/docs/pipelines/writing-build-scripts">build scripts</a> instead of <code>command</code> blocks for steps that use secrets.
 
 If you must define your script in your steps, you can prevent interpolation by using the `$$` syntax:
@@ -167,5 +161,4 @@ steps:
         --data "{\"ref\": \"$$BUILDKITE_COMMIT\"}" \
         https://api.github.com/repos/my-org/my-app/deployments
 ```
-
 {: codeblock-file="pipeline.yml"}


### PR DESCRIPTION
As per https://github.com/buildkite/agent/blob/421d1043de75d527b49c7b11c527aa379d99d3ee/clicommand/global.go, there are additional redacted variables that aren't documented and it may cause confusion for folks wanting to use AWS secrets.