### PR TITLE
Link to a working Codepen example for the Emojis API

### DIFF
--- a/pages/apis/rest_api.md.erb
+++ b/pages/apis/rest_api.md.erb
@@ -88,7 +88,7 @@ API responses include the following [CORS headers](https://developer.mozilla.org
 * `Access-Controller-Allow-Origin: *`
 * `Access-Control-Expose-Headers: Link`
 
-For an example of this in use, see the [Emojis API example on CodePen](http://codepen.io/toolmantim/pen/xbQRaL) for adding emoji support to your own browser-based dashboards and build screens.
+For an example of this in use, see the [Emojis API example on CodePen](https://codepen.io/dannymidnight/pen/jOpJpmY) for adding emoji support to your own browser-based dashboards and build screens.
 
 ## Migrating from v1 to v2
 


### PR DESCRIPTION
This change updates a link in the REST API docs to use a revised codepen with a valid access token + organisation. 

_Note:_ The access token used has been scoped to a single organisation (buidkite-docs-examples) with no read/write permissions.