### PR TITLE
[ONB-136] Add pipeline for keeping GraphQL docs up-to-date

### DIFF
--- a/.buildkite/pipeline.graphql.yml
+++ b/.buildkite/pipeline.graphql.yml
@@ -1,0 +1,13 @@
+steps:
+  - label: Update GraphQL docs
+    command: .buildkite/update_graphql_docs
+    plugins:
+      - docker-compose#v4.9.0:
+          run: app
+          mount-ssh-agent: true
+          mount-buildkite-agent: true
+          env:
+            - API_ACCESS_TOKEN
+            - GIT_NAME
+            - GIT_EMAIL
+            - GH_TOKEN

--- a/.buildkite/update_graphql_docs
+++ b/.buildkite/update_graphql_docs
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "+++ Fetch latest schema"
+rake graphql:fetch_schema >| data/graphql_data_schema.json
+
+echo "+++ Check for schema changes"
+if git diff --exit-code --quiet data/graphql_data_schema.json; then
+  buildkite-agent annotate  "Nothing to change, schema is up to date." --style "info"
+  exit 0
+fi
+
+echo "+++ Generate GraphQL docs"
+./scripts/generate-graphql-api-content.sh
+
+echo "--- Commit and push changes"
+BRANCH=buildkite-docs-bot/graphql/$(git rev-parse --short :data/graphql_data_schema.json)
+
+git config user.email $GIT_EMAIL
+git config user.name $GIT_NAME
+git checkout -b $BRANCH
+git add .
+git commit -m "Update GraphQL docs"
+git push -u origin $BRANCH
+
+echo "+++ Create pull request"
+gh pr create \
+  --title "Update GraphQL docs" \
+  --body "This is an automated PR based on the current GraphQL schema" \
+  | buildkite-agent annotate --style "success"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM public.ecr.aws/docker/library/ruby:2.7.5-buster@sha256:d76f1c822df854ecc6a9
 ARG RAILS_ENV
 ENV RAILS_ENV=${RAILS_ENV:-production}
 
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+
 ADD https://deb.nodesource.com/gpgkey/nodesource.gpg.key /etc/apt/trusted.gpg.d/nodesource.asc
 ADD https://dl.yarnpkg.com/debian/pubkey.gpg /etc/apt/trusted.gpg.d/yarn.asc
 RUN echo "--- :package: Installing system deps" \
@@ -19,7 +23,7 @@ RUN echo "--- :package: Installing system deps" \
     && echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     # Install all the things
     && apt-get update \
-    && apt-get install -y nodejs yarn \
+    && apt-get install -y nodejs yarn gh \
     # Upgrade rubygems and bundler
     && gem update --system \
     && gem install bundler \
@@ -44,9 +48,9 @@ COPY . /app
 
 # Compile sprockets
 RUN if [ "$RAILS_ENV" = "production" ]; then \
-      echo "--- :sprockets: Precompiling assets" \
-      && RAILS_ENV=production RAILS_GROUPS=assets bundle exec rake assets:precompile \
-      && cp -r /app/public/docs/assets /app/public/assets; \
+    echo "--- :sprockets: Precompiling assets" \
+    && RAILS_ENV=production RAILS_GROUPS=assets bundle exec rake assets:precompile \
+    && cp -r /app/public/docs/assets /app/public/assets; \
     fi
 
 EXPOSE 3000

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development do
   gem "web-console"
   gem "listen"
   gem "pry"
+  gem 'graphql-client'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,10 @@ GEM
     execjs (2.8.1)
     ffi (1.15.3)
     foreman (0.87.2)
+    graphql (2.0.16)
+    graphql-client (0.18.0)
+      activesupport (>= 3.0)
+      graphql
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     listen (3.5.1)
@@ -173,6 +177,7 @@ DEPENDENCIES
   dotenv-rails
   escape_utils
   foreman
+  graphql-client
   listen
   lograge
   pry

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -1,0 +1,19 @@
+require "graphql/client"
+require "graphql/client/http"
+
+namespace :graphql do
+  desc "Fetch current Buildkite GraphQL schema"
+  task :fetch_schema do
+    if ENV["API_ACCESS_TOKEN"].blank?
+      raise "API_ACCESS_TOKEN is required"
+    end
+
+    HTTP = GraphQL::Client::HTTP.new("https://graphql.buildkite.com/v1") do
+      def headers(context)
+        { "Authorization": "Bearer #{ENV["API_ACCESS_TOKEN"]}" }
+      end
+    end
+
+    puts GraphQL::Client.load_schema(HTTP).to_json
+  end
+end


### PR DESCRIPTION
This PR adds a new pipeline for auto-generating a pull request with content generated from the latest Buildkite GraphQL schema.

The [pipeline](https://buildkite.com/buildkite/docs-graphql) is currently setup to fetch the latest/active introspected GraphQL schema from buildkite.com which to start with will be triggered on a schedule. This is only temporary as I'm keen to fast follow to instead trigger the pipeline when schema changes are being deployed.

Here's an [example build](https://buildkite.com/buildkite/docs-graphql/builds/44#) and [PR](https://github.com/buildkite/docs/pull/1856) (ignore all the commits from this branch).

Keen to see how this goes. I decided to lean into the PR for visibility in changes but once we're more comfortable then perhaps merging directly into main may also be the way to go.. 