### PR TITLE
Add CODEOWNERS file to auto-assign reviewer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+@dannymidnight
+
+pages/ @mbelton-buildkite
+app/assets/ @buildkite/onboarding
+app/views/ @buildkite/onboarding

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,10 @@
 @dannymidnight
 
 pages/ @mbelton-buildkite
+data/ @mbelton-buildkite
+images/ @mbelton-buildkite
+vale/ @mbelton-buildkite
+styleguide/ @mbelton-buildkite
+
 app/assets/ @buildkite/onboarding
 app/views/ @buildkite/onboarding


### PR DESCRIPTION
This PR assigns myself as the default reviewer for everything non-content related, @mbelton-buildkite for everything content related, and the onboarding team for everything that's mostly related to the frontend. 

Does this seem about right @mbelton-buildkite? 