### PR TITLE
Add HelpScout Beacon 

### DIFF
--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -40,3 +40,5 @@
 <% if ENV.fetch("ROBOTS_NO_INDEX") { "false" } == "true" %>
   <meta name="robots" content="noindex, nofollow">
 <% end %>
+
+<%= render 'helpscout' %>

--- a/app/views/application/_helpscout.html.erb
+++ b/app/views/application/_helpscout.html.erb
@@ -1,0 +1,8 @@
+<% if probably_authenticated? %>
+  <%= javascript_tag nonce: true do -%>
+    !function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
+  <%- end %>
+  <%= javascript_tag nonce: true do -%>
+    window.Beacon('init', "<%= ENV.fetch('HELPSCOUT_BEACON_ID', "fe786ba2-4f17-4f4a-a70b-3c79fbf468fe")%>");
+  <%- end %>
+<% end %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -19,15 +19,23 @@
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
   policy.font_src    :self, "https://www2.buildkiteassets.com/"
-  policy.img_src     :self, "https://buildkiteassets.com/", "https://buildkite.com/", ENV.fetch("BADGE_DOMAIN", "https://badge.buildkite.com")
-  policy.object_src  :none
-  policy.style_src   :self, :unsafe_inline
+  policy.object_src  :none, "https://beacon-v2.helpscout.net"
+  policy.style_src   :self, :unsafe_inline, "https://beacon-v2.helpscout.net"
+
+  policy.img_src(
+    :self,
+    "https://buildkiteassets.com/",
+    "https://buildkite.com/",
+    ENV.fetch("BADGE_DOMAIN", "https://badge.buildkite.com"),
+    "https://beacon-v2.helpscout.net",
+  )
 
   policy.script_src(
     :self,
     "https://www.googletagmanager.com/",
     "https://cdn.segment.com/",
-    "https://cdn.emojicom.io/"
+    "https://cdn.emojicom.io/",
+    "https://beacon-v2.helpscout.net",
   )
 
   policy.connect_src(
@@ -39,11 +47,16 @@ Rails.application.config.content_security_policy do |policy|
 
     "https://cdn.segment.com/",
     "https://api.segment.io/",
-    "https://emojicom.io/"
+    "https://emojicom.io/",
+    "https://beacon-v2.helpscout.net"
   )
 
   policy.frame_src(
     "https://cdn.emojicom.io/"
+  )
+
+  policy.media_src(
+   "https://beacon-v2.helpscout.net"
   )
 
   # Specify URI for violation reports


### PR DESCRIPTION
Add [HelpScout Beacon](https://secure.helpscout.net/settings/beacons/fe786ba2-4f17-4f4a-a70b-3c79fbf468fe/customize) as an alternative approach for eliciting feedback from within the docs.

The beacon can be controlled indirectly via events in HelpScout or directly by using the JavaScript API. 