### PR TITLE
Use `prettier` for linting Javascript files

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,6 +56,14 @@ steps:
   - group: "Lint all the things"
     key: linting
     steps:
+      - label: ":prettier: Lint assets"
+        commands:
+          - npm install
+          - npm run prettier-check
+        plugins:
+          - docker#v3.7.0:
+              image: "node:lts-alpine3.14"
+
       - label: ":lint-roller: Linting text and markdown"
         plugins:
           - docker-compose#v3.9.0:
@@ -72,6 +80,7 @@ steps:
               # Alpine 3.14 - EOS 01 May 2023
               # lts = Node 1415.1 - 2023-04-30
               image: "node:lts-alpine3.14"
+
       - label: "Validate YAML"
         command:
           - npm run -y validate-agent-attributes-yaml
@@ -79,6 +88,7 @@ steps:
         plugins:
           - docker#v3.7.0:
               image: "node:lts-alpine3.14"
+
       - label: ":lint-roller: :markdown: Linting the Markdown"
         command: npm run -y mdlint
         plugins:

--- a/app/assets/javascripts/nav.js
+++ b/app/assets/javascripts/nav.js
@@ -1,33 +1,35 @@
 (function () {
-  const maxWidth = 1536
+  const maxWidth = 1536;
 
   initCurrentNavs();
   bindToggles();
   initSidebarsPos();
 
-  function initCurrentNavs () {
-    const currentNode = Array.from(document.getElementsByClassName('Nav__link--current')).pop();
+  function initCurrentNavs() {
+    const currentNode = Array.from(
+      document.getElementsByClassName("Nav__link--current")
+    ).pop();
 
     recurseCurrentParentNavs(currentNode);
   }
 
-  function recurseCurrentParentNavs (currentNode) {
+  function recurseCurrentParentNavs(currentNode) {
     const { parentNode } = currentNode;
     const { className } = parentNode;
 
-    if (className.includes('Nav')) {
-      if (className.includes('Nav__section')) {
-        parentNode.classList.add('Nav__section--parent', 'Nav__section--show');
+    if (className.includes("Nav")) {
+      if (className.includes("Nav__section")) {
+        parentNode.classList.add("Nav__section--parent", "Nav__section--show");
       }
-      if (className.includes('Nav__item')) {
-        parentNode.classList.add('Nav__section--parent', 'Nav__section--show');
-        
-        const toggleNode = parentNode.querySelector('.Nav__link');
+      if (className.includes("Nav__item")) {
+        parentNode.classList.add("Nav__section--parent", "Nav__section--show");
+
+        const toggleNode = parentNode.querySelector(".Nav__link");
         if (toggleNode) {
-          if (toggleNode.className.includes('Nav__toggle')) {
-            toggleNode.classList.add('Nav__toggle--on', 'Nav__toggle--parent');
+          if (toggleNode.className.includes("Nav__toggle")) {
+            toggleNode.classList.add("Nav__toggle--on", "Nav__toggle--parent");
           } else {
-            toggleNode.classList.add('Nav__link--parent');
+            toggleNode.classList.add("Nav__link--parent");
           }
         }
       }
@@ -36,51 +38,72 @@
     }
   }
 
-  function bindToggles () {
-    const toggleNodes = Array.from(document.getElementsByClassName('Nav__toggle'));
-    
-    toggleNodes.map(toggle => toggle.onclick = function (e) {
-      const currentLevel = parseInt(e.target.getAttribute('data-toggle-nav-level'));
-      const sectionNodes = Array.from(
-        document.getElementsByClassName(`Nav__section--level${currentLevel + 1}`)
-      );
+  function bindToggles() {
+    const toggleNodes = Array.from(
+      document.getElementsByClassName("Nav__toggle")
+    );
 
-      if (e.target.className.includes('Nav__toggle--on')) {
-        e.target.nextSibling.nextSibling.classList.remove('Nav__section--show');
-        e.target.classList.remove('Nav__toggle--on');
-      } else {
-        sectionNodes.map(section => section.classList.remove('Nav__section--show'));
-        e.target.nextSibling.nextSibling.classList.add('Nav__section--show');
-        toggleNodes.map(toggle => {
-          if (parseInt(toggle.getAttribute('data-toggle-nav-level')) === currentLevel) {
-            toggle.classList.remove('Nav__toggle--on')
+    toggleNodes.map(
+      (toggle) =>
+        (toggle.onclick = function (e) {
+          const currentLevel = parseInt(
+            e.target.getAttribute("data-toggle-nav-level")
+          );
+          const sectionNodes = Array.from(
+            document.getElementsByClassName(
+              `Nav__section--level${currentLevel + 1}`
+            )
+          );
+
+          if (e.target.className.includes("Nav__toggle--on")) {
+            e.target.nextSibling.nextSibling.classList.remove(
+              "Nav__section--show"
+            );
+            e.target.classList.remove("Nav__toggle--on");
+          } else {
+            sectionNodes.map((section) =>
+              section.classList.remove("Nav__section--show")
+            );
+            e.target.nextSibling.nextSibling.classList.add(
+              "Nav__section--show"
+            );
+            toggleNodes.map((toggle) => {
+              if (
+                parseInt(toggle.getAttribute("data-toggle-nav-level")) ===
+                currentLevel
+              ) {
+                toggle.classList.remove("Nav__toggle--on");
+              }
+            });
+            e.target.classList.add("Nav__toggle--on");
           }
-        });
-        e.target.classList.add('Nav__toggle--on');
-      }
 
-      if (window.matchMedia('screen and (max-width: 959px)').matches) {
-        window.scrollTo({
-          top: e.target.offsetTop,
-          behavior: 'smooth'
-        });
-      }
-    });
+          if (window.matchMedia("screen and (max-width: 959px)").matches) {
+            window.scrollTo({
+              top: e.target.offsetTop,
+              behavior: "smooth",
+            });
+          }
+        })
+    );
   }
 
-  function initSidebarsPos () {
-    const leftMenuNode = document.querySelector('.Nav__section--level2.Nav__section--show');
-    const tocNode = document.querySelector('.Toc');
+  function initSidebarsPos() {
+    const leftMenuNode = document.querySelector(
+      ".Nav__section--level2.Nav__section--show"
+    );
+    const tocNode = document.querySelector(".Toc");
 
     if (leftMenuNode || tocNode) {
       setSidebarsPos();
-      addEventListener('resize', (event) => setSidebarsPos());
+      addEventListener("resize", (event) => setSidebarsPos());
     }
 
-    function setSidebarsPos () {
-      const pos = window.innerWidth > maxWidth
-        ? Math.floor((window.innerWidth - maxWidth) / 2)
-        : 0
+    function setSidebarsPos() {
+      const pos =
+        window.innerWidth > maxWidth
+          ? Math.floor((window.innerWidth - maxWidth) / 2)
+          : 0;
 
       if (leftMenuNode) leftMenuNode.style.left = `${pos}px`;
       if (tocNode) tocNode.style.right = `${pos}px`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "name": "docs",
       "devDependencies": {
-        "husky": "^8.0.0"
+        "husky": "^8.0.0",
+        "prettier": "2.8.4"
       }
     },
     "node_modules/husky": {
@@ -23,6 +24,21 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     }
   },
   "dependencies": {
@@ -30,6 +46,12 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
       "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "validate-environment-variables-yaml": "npx --package ajv-cli ajv validate -s \"data/content/environment_variables.schema.yaml\" -d \"data/content/environment_variables.yaml\"",
     "lint": "npx alex@10 -q --diff \"pages/**/*.erb\" \"pages/**/*.txt\"",
     "mdlint": "npx markdownlint-cli2@0.3 pages \"#pages/agent/v3/help/*\"",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "prettier-check": "prettier -c app/assets/**/*.js",
+    "prettier-fix": "prettier -w app/assets/**/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "docs",
   "private": true,
   "devDependencies": {
-    "husky": "^8.0.0"
+    "husky": "^8.0.0",
+    "prettier": "2.8.4"
   },
   "scripts": {
     "validate-agent-attributes-yaml": "npx --package ajv-cli ajv validate -s \"data/content/agent_attributes.schema.yaml\" -d \"data/content/agent_attributes.yaml\"",


### PR DESCRIPTION
To ensure our text editors are all doing the same thing, this change bring in [Prettier](https://prettier.io/) to keep javascript formatting consistent in addition to linting as part of CI.