### PR TITLE
Update states of cancel builds via API

### DIFF
--- a/pages/apis/rest_api/builds.md.erb
+++ b/pages/apis/rest_api/builds.md.erb
@@ -459,7 +459,7 @@ Error responses:
 
 ## Cancel a build
 
-Cancels the build if its state is either `scheduled` or `running`.
+Cancels the build if its state is either `scheduled`, `running` or `failing`.
 
 ```bash
 curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.slug}/builds/{number}/cancel"

--- a/pages/apis/rest_api/builds.md.erb
+++ b/pages/apis/rest_api/builds.md.erb
@@ -459,7 +459,7 @@ Error responses:
 
 ## Cancel a build
 
-Cancels the build if its state is either `scheduled`, `running` or `failing`.
+Cancels the build if its state is either `scheduled`, `running`, or `failing`.
 
 ```bash
 curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.slug}/builds/{number}/cancel"


### PR DESCRIPTION
Now is also possible to send a cancellation signal when the build is in a `failing` state