### PR TITLE
Matrix values can now go into plugin config

### DIFF
--- a/pages/pipelines/build_matrix.md
+++ b/pages/pipelines/build_matrix.md
@@ -9,8 +9,9 @@ The following [command step](/docs/pipelines/command-step) attributes can contai
 * [environment variables](/docs/pipelines/environment-variables)
 * [labels](/docs/pipelines/command-step#label)
 * [commands](/docs/pipelines/command-step#command-step-attributes)
+* [plugins](/docs/pipelines/command-step#plugins)
 
-You can't use matrix values in other attributes, including step keys and plugin attributes.
+You can't use matrix values in other attributes, including step keys.
 
 For example, instead of writing three separate jobs for builds on **macOS**, **Linux** and **Windows**, like the following build configuration (which does not use a build matrix):
 

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -152,7 +152,7 @@ _Optional attributes:_
       <em>Example:</em> <code>3</code>
     </td>
   </tr>
-  <tr>
+  <tr id="plugins">
     <td><code>plugins</code></td>
     <td>
       An array of <a href="/docs/plugins">plugins</a> for this step.<br>


### PR DESCRIPTION
We're updating command steps to allow using matrix interpolation within plugin configuration. Adjust the docs to match.

Not ready to merge — the supporting change is yet to be deployed.