### PR TITLE
Custom status caveat

### DIFF
--- a/pages/integrations/github.md
+++ b/pages/integrations/github.md
@@ -121,7 +121,7 @@ You can customize the commit statuses, for example to reuse the same pipeline fo
     <%= image "github-custom-status.png", alt: "Screenshot of GitHub build settings and the resulting GitHub pull request statuses" %>
 
 >🚧 Build source limitations when using custom statuses
-> In order for Buildkite to deliver custom status updates the build source must be "Webhook", builds from other sources will not allow Buildkite to identify the destination for the custom status updates.
+> In order for Buildkite to deliver custom status updates, the build source must be "Webhook"; builds from other sources will not allow Buildkite to identify the destination for the custom status updates, so deselecting _Update commit statuses_ will result in the failure to update custom commit statuses.
 
 In a setup for a repository containing one codebase and one `pipeline.yml`, this customizes the commit status for the pipeline. However, if you have multiple `pipeline.yml` files in one repo, feeding in to the same Buildkite pipeline, this allows you to have different statuses when building different sections of the repo.
 

--- a/pages/integrations/github.md
+++ b/pages/integrations/github.md
@@ -120,6 +120,9 @@ You can customize the commit statuses, for example to reuse the same pipeline fo
 3. When you make a new commit or pull request, you should see _my-custom-status_ as the commit status:
     <%= image "github-custom-status.png", alt: "Screenshot of GitHub build settings and the resulting GitHub pull request statuses" %>
 
+>🚧 Build source limitations when using custom statuses
+> In order for Buildkite to deliver custom status updates the build source must be "Webhook", builds from other sources will not allow Buildkite to identify the destination for the custom status updates.
+
 In a setup for a repository containing one codebase and one `pipeline.yml`, this customizes the commit status for the pipeline. However, if you have multiple `pipeline.yml` files in one repo, feeding in to the same Buildkite pipeline, this allows you to have different statuses when building different sections of the repo.
 
 For example, if you have a monorepo containing three applications, you could use the same pipeline, with different `pipeline.yml` files for each application. Each `pipeline.yml` can contain a different GitHub status.


### PR DESCRIPTION
Custom status updates can only be used with builds from a webhook, when the _Update commit statuses_ box is unchecked.