### PR TITLE
Add signal and signal reason in retry rules

### DIFF
--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -300,7 +300,7 @@ _Optional Attributes_
   <tr>
     <td><code>exit_status</code></td>
     <td>
-      The exit status number that will cause this job to retry ('*' does not include 0) <br>
+      The exit status number that causes this job to retry ('*' does not include 0) <br>
       <p><em>Examples:</em></p>
       <ul>
         <li><code>"*"</code></li>
@@ -311,7 +311,7 @@ _Optional Attributes_
   <tr>
     <td><code>signal</code></td>
     <td>
-      The signal that will cause this job to retry. This signal will only be present if the agent sends a signal to the job and an interior process does not handle the signal. `SIGKILL` propagates reliably because it cannot be handled, and is a useful to differentiate graceful cancelation and timeouts.
+      The signal that causes this job to retry. This signal will only be present if the agent sends a signal to the job and an interior process does not handle the signal. `SIGKILL` propagates reliably because it cannot be handled, and is a useful to differentiate graceful cancelation and timeouts.
       <p><em>Examples:</em></p>
       <ul>
         <li><code>"*"</code></li>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -301,26 +301,35 @@ _Optional Attributes_
     <td><code>exit_status</code></td>
     <td>
       The exit status number that will cause this job to retry ('*' does not include 0) <br>
-      <em>Example:</em> <code>"*"</code><br>
-      <em>Example:</em> <code>2</code>
+      <p><em>Examples:</em></p>
+      <ul>
+        <li><code>"*"</code></li>
+        <li><code>2</code></li>
+      </ul>
     </td>
   </tr>
   <tr>
     <td><code>signal</code></td>
     <td>
       The signal causing the job to exit, if a signal was sent, and the currently running process did not intercept and handle the signal supplying a non-default exit status.<br>
-      <em>Example:</em> <code>"*"</code><br>
-      <em>Example:</em> <code>kill</code><br>
-      <em>Example:</em> <code>SIGINT</code>
+      <p><em>Examples:</em></p>
+      <ul>
+        <li><code>"*"</code></li>
+        <li><code>kill</code></li>
+        <li><code>SIGINT</code></li>
+      </ul>
     </td>
   </tr>
   <tr>
     <td><code>signal_reason</code></td>
     <td>
       The reason a process was signaled.<br>
-      <em>Example:</em> <code>"*"</code><br>
-      <em>Example:</em> <code>none</code><br>
-      <em>Example:</em> <code>cancel</code>
+      <p><em>Examples:</em></p>
+      <ul>
+        <li><code>"*"</code></li>
+        <li><code>none</code></li>
+        <li><code>cancel</code></li>
+      </ul>
     </td>
   </tr>
   <tr>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -311,7 +311,7 @@ _Optional Attributes_
   <tr>
     <td><code>signal</code></td>
     <td>
-      The signal causing the job to exit, if a signal was sent, and the currently running process did not intercept and handle the signal supplying a non-default exit status.<br>
+      The signal that will cause this job to retry. This signal will only be present if the agent sends a signal to the job and an interior process does not handle the signal. `SIGKILL` propagates reliably because it cannot be handled, and is a useful to differentiate graceful cancelation and timeouts.
       <p><em>Examples:</em></p>
       <ul>
         <li><code>"*"</code></li>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -308,7 +308,7 @@ _Optional Attributes_
   <tr>
     <td><code>signal</code></td>
     <td>
-      The signal sent to a process, if the process did not intercept and handle the signal<br>
+      The signal sent to a process, if the process did not intercept and handle the signal.<br>
       <em>Example:</em> <code>"*"</code><br>
       <em>Example:</em> <code>kill</code><br>
       <em>Example:</em> <code>SIGINT</code>
@@ -317,7 +317,7 @@ _Optional Attributes_
   <tr>
     <td><code>signal_reason</code></td>
     <td>
-      The reason a process was signalled<br>
+      The reason a process was signaled.<br>
       <em>Example:</em> <code>"*"</code><br>
       <em>Example:</em> <code>none</code><br>
       <em>Example:</em> <code>cancel</code>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -311,7 +311,7 @@ _Optional Attributes_
   <tr>
     <td><code>signal</code></td>
     <td>
-      The signal that causes this job to retry. This signal will only be present if the agent sends a signal to the job and an interior process does not handle the signal. `SIGKILL` propagates reliably because it cannot be handled, and is a useful to differentiate graceful cancelation and timeouts.
+      The signal that causes this job to retry. This signal will only be present if the agent sends a signal to the job and an interior process does not handle the signal. <code>SIGKILL</code> propagates reliably because it cannot be handled, and is a useful to differentiate graceful cancelation and timeouts.
       <p><em>Examples:</em></p>
       <ul>
         <li><code>"*"</code></li>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -308,7 +308,7 @@ _Optional Attributes_
   <tr>
     <td><code>signal</code></td>
     <td>
-      The signal sent to a process, if the process did not intercept and handle the signal.<br>
+      The signal causing the job to exit, if a signal was sent, and the currently running process did not intercept and handle the signal supplying a non-default exit status.<br>
       <em>Example:</em> <code>"*"</code><br>
       <em>Example:</em> <code>kill</code><br>
       <em>Example:</em> <code>SIGINT</code>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -311,7 +311,7 @@ _Optional Attributes_
   <tr>
     <td><code>signal</code></td>
     <td>
-      The signal that causes this job to retry. This signal will only be present if the agent sends a signal to the job and an interior process does not handle the signal. <code>SIGKILL</code> propagates reliably because it cannot be handled, and is a useful to differentiate graceful cancelation and timeouts.
+      The signal that causes this job to retry. This signal only appears if the agent sends a signal to the job and an interior process does not handle the signal. <code>SIGKILL</code> propagates reliably because it cannot be handled, and is a useful to differentiate graceful cancelation and timeouts.
       <p><em>Examples:</em></p>
       <ul>
         <li><code>"*"</code></li>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -311,7 +311,7 @@ _Optional Attributes_
   <tr>
     <td><code>signal</code></td>
     <td>
-      The signal that causes this job to retry. This signal only appears if the agent sends a signal to the job and an interior process does not handle the signal. <code>SIGKILL</code> propagates reliably because it cannot be handled, and is a useful to differentiate graceful cancelation and timeouts.
+      The signal that causes this job to retry. This signal only appears if the agent sends a signal to the job and an interior process does not handle the signal. <code>SIGKILL</code> propagates reliably because it cannot be handled, and is a useful way to differentiate graceful cancelation and timeouts.
       <p><em>Examples:</em></p>
       <ul>
         <li><code>"*"</code></li>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -306,6 +306,24 @@ _Optional Attributes_
     </td>
   </tr>
   <tr>
+    <td><code>signal</code></td>
+    <td>
+      The signal sent to a process, if the process did not intercept and handle the signal<br>
+      <em>Example:</em> <code>"*"</code><br>
+      <em>Example:</em> <code>kill</code><br>
+      <em>Example:</em> <code>SIGINT</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>signal_reason</code></td>
+    <td>
+      The reason a process was signalled<br>
+      <em>Example:</em> <code>"*"</code><br>
+      <em>Example:</em> <code>none</code><br>
+      <em>Example:</em> <code>cancel</code>
+    </td>
+  </tr>
+  <tr>
     <td><code>limit</code></td>
     <td>
       The number of times this job can be retried. The maximum value this can be set to is 10.<br>


### PR DESCRIPTION
Add reference documentation for the signal and signal reason attributes which will soon be available in automatic retry rules.

Fixes PDP-211.