### PR TITLE
add clarification in merge queue tutorial around the "skip builds with existing commits" option

### DIFF
--- a/pages/tutorials/github_merge_queue.md
+++ b/pages/tutorials/github_merge_queue.md
@@ -13,7 +13,7 @@ Familiarize yourself with [managing a merge queue in GitHub](https://docs.github
 
 ## Enable a merge queue for a pipeline
 
-The merge queue creates temporary branches with a special prefix to validate pull request changes. You need to update the pipeline configuration to match branches with the special prefix. You also need to enable build skipping to avoid running redundant builds on commits that have already passed validation.
+The merge queue creates temporary branches with a special prefix to validate pull request changes. You need to update the pipeline configuration to match branches with the special prefix. To avoid these temporary branches triggering multiple builds on the same pipeline for the same commit, we recommend enabling the option to skip builds on existing commits.
 
 To enable a merge queue for a pipeline:
 
@@ -24,8 +24,6 @@ To enable a merge queue for a pipeline:
     ```text
     gh-readonly-queue/{base_branch}/*
     ```
-
-This will configure your pipeline to create builds on the specifically for the temporary branch created by GitHub, used by the merge queue. If you do not want multiple builds on the same pipeline for the same commit, you can configure skipping builds on existing commits here:
 
 1. In the _GitHub Settings_ section, select the _Skip builds with existing commits_ checkbox.
 

--- a/pages/tutorials/github_merge_queue.md
+++ b/pages/tutorials/github_merge_queue.md
@@ -25,6 +25,8 @@ To enable a merge queue for a pipeline:
     gh-readonly-queue/{base_branch}/*
     ```
 
+This will configure your pipeline to create builds on the specifically for the temporary branch created by GitHub, used by the merge queue. If you do not want multiple builds on the same pipeline for the same commit, you can configure skipping builds on existing commits here:
+
 1. In the _GitHub Settings_ section, select the _Skip builds with existing commits_ checkbox.
 
 That's it! Your pipeline supports merge queues in GitHub. 🎉


### PR DESCRIPTION
This should help clarify the purpose of the `skip builds with existing commits` option in the pipeline settings, and why it might be used when setting up merge queues in a repo.

It is not a required option, but is useful if you don't want to be creating multiple builds on the same commit, since GitHub will create a temporary branch that will kick off a new build.