### PR TITLE
Update footer link to point to the correct Slack channel

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -23,7 +23,7 @@
       <img alt="Icon: paper dart" class="Button__icon Button__icon--16x16" src="<%= image_url('icons/email.svg') %>" />
       Email support
     </a>
-    <a class="Button Button--link" href="https://chat.buildkite.community/">
+    <a class="Button Button--link" href="https://join.slack.com/t/buildkite-community/shared_invite/zt-1lm0xnwqu-r11BLIt7ZWr8JQ8fVyvMUw">
       <img alt="Icon: Slack" class="Button__icon Button__icon--16x16" src="<%= image_url('icons/slack.svg') %>" />
       <% unless "test-analytics".in? request.path %>
         Ask our Slack community


### PR DESCRIPTION
This PR fixes a broken Slack link following the lead of our marketing site https://github.com/buildkite/site/pull/2285