### PR TITLE
🐛 Reduce filter saturation to fix Safari color

### DIFF
--- a/app/assets/stylesheets/components/_nav.scss
+++ b/app/assets/stylesheets/components/_nav.scss
@@ -1,5 +1,5 @@
 @mixin _make-nav-icon-purple {
-  filter: invert(24%) sepia(92%) saturate(7443%) hue-rotate(258deg) brightness(81%) contrast(109%);
+  filter: invert(15%) sepia(80%) saturate(550%) hue-rotate(210deg) brightness(80%) contrast(110%);
 }
 
 .Nav {
@@ -234,6 +234,7 @@
     &::before {
       background: transparent asset-url("icons/angle-down.svg") 50% 50% no-repeat;
       transform: rotate(-90deg);
+      will-change: transform;
     }
 
     &--on::before {


### PR DESCRIPTION
Fix a subtle visual bug that only occurs in Safari. When the nav's chev icon rotates during a css transition its color turns pink briefly.

After some investigation I think it's due to the `saturation` value in the css filter.

I've fixed this for now by reducing the `saturation` value and adjusted other values to mimic the purple.

Note: this is a patch as using css filters to change color still has discrepancy. In a future ticket it would be good to use a more elegant solution like inline SVG.
