### PR TITLE
Fix Rspec link to instance_of

### DIFF
--- a/pages/test_analytics/ruby_collectors.md
+++ b/pages/test_analytics/ruby_collectors.md
@@ -62,7 +62,7 @@ Failure/Error: allow_any_instance_of(Object).to receive(:sleep)
        Using `any_instance` to stub a method (sleep) that has been defined on a prepended module (Buildkite::TestCollector::Object::CustomObjectSleep) is not supported.
 ```
 
-You can fix them by being more specific in your stubbing, which is [better practice](https://relishapp.com/rspec/rspec-mocks/v/3-11/docs/working-with-legacy-code/any-instance), by replacing `allow_any_instance_of(Object).to receive(:sleep)` with `allow_any_instance_of(TheClassUnderTest).to receive(:sleep)`.
+You can fix them by being more specific in your stubbing, which is [better practice](https://web.archive.org/web/20220810120550/https://relishapp.com/rspec/rspec-mocks/v/3-11/docs/working-with-legacy-code/any-instance), by replacing `allow_any_instance_of(Object).to receive(:sleep)` with `allow_any_instance_of(TheClassUnderTest).to receive(:sleep)`.
 
 ## minitest collector
 


### PR DESCRIPTION
Relishapp has historically been an official source of ruby documentation. However, the maintainer was recently made redundant from his job and the website is currently returning a 503. The ruby community will probably either fix the website or find a new site to host this content; however, in the mean time we're linking to the Internet Archive as a stop gap.