### PR TITLE
Cancellation is excluded from continue_on_failure

### DIFF
--- a/pages/pipelines/wait_step.md
+++ b/pages/pipelines/wait_step.md
@@ -106,7 +106,9 @@ steps:
 
 <%= image "continue-on-fail-example2.png", width: 1402/2, height: 417/2, alt: "Screenshot of a failed pipeline which did run the continue_on_failure wait steps" %>
 
-The explicit null `~` character used in the above examples isn't required, but is recommended as a best practice. It ensures that nothing else is accidentally added to the `wait` before the `continue_on_failure` attribute.
+The explicit null `~` character used in the above examples isn't required, but is recommended as a best practice. It ensures that nothing else is accidentally added to the `wait` before the `continue_on_failure` attribute. 
+
+If command step before wait step with `continue_on_failure: true` is cancelled then all the steps after this cancelled step will not get executed because cancellation is purposefully excluded from continue_on_failure behaviour. In above example, if we cancel `echo THIRD command` which is step before wait step with `continue_on_failure: true` then `echo FOURTH command` step will not get executed.
 
 ## Block steps interacting with wait steps
 


### PR DESCRIPTION
This PR adds explanation about the behavior on how cancellation is purposefully excluded from continue_on_failure setting for wait step.