### PR TITLE
Add GraphQL cookbook entry for getting pipelines by team

### DIFF
--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -428,7 +428,7 @@ mutation PipelineUpdate {
 
 To get the first 100 pipelines managed by the first 100 teams, use the following query.
 
-```graphql 
+```graphql
 query getPipelinesByTeam {
   organization(slug: "organization-slug") {
     id

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -424,6 +424,45 @@ mutation PipelineUpdate {
 }
 ```
 
+## Get pipelines by team
+
+To get the first 100 pipelines managed by the first 100 teams, use the following query.
+
+```graphql 
+query getPipelinesByTeam {
+  organization(slug: "organization-slug") {
+    id
+    name
+    teams(first: 100) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          name
+          pipelines(first: 100) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            edges {
+              node {
+                pipeline {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+If you have more than 100 teams or more than 100 pipelines per team, use the pagination information in `pageInfo` to get the next results page.
+
 ## Set teams' pipeline edit access to READ_ONLY or BUILD_AND_READ
 
 Remove edit access from existing teams. This is helpful when you want to centralize pipeline edit permissions to a single system user, controlled by an organization admin.


### PR DESCRIPTION
I saw [your discussion on Basecamp](https://3.basecamp.com/3453178/buckets/1713315/chats/269048534@5899272373) and thought it would make a good entry into the cookbook. What do you think?

**Preview:** [Get pipelines by team](https://bk-docs-pr-1913.onrender.com/docs/apis/graphql/graphql-cookbook#get-pipelines-by-team)