### PR TITLE
add clarity around methods that can be used to set meta-data

### DIFF
--- a/pages/pipelines/build_meta_data.md
+++ b/pages/pipelines/build_meta_data.md
@@ -7,7 +7,7 @@ Meta-data is intended to store data 1 kilobyte or less in size, to be used acros
 
 ## Setting data
 
-You can set meta-data using the command line or in a script. Both of these methods use the `buildkite-agent` cli with the `meta-data` command.
+You can set meta-data using the command line or in a script. Both of these methods use the `buildkite-agent` cli with the `meta-data` command. Meta-data can only be set using the `buildkite-agent meta-data set` command, setting meta-data via API or other methods is not possible.
 
 To set meta-data in the meta-data store, use the `set` command with a key/value pair:
 

--- a/pages/pipelines/build_meta_data.md
+++ b/pages/pipelines/build_meta_data.md
@@ -7,7 +7,7 @@ Meta-data is intended to store data 1 kilobyte or less in size, to be used acros
 
 ## Setting data
 
-You can set meta-data using the command line or in a script. Both of these methods use the `buildkite-agent` cli with the `meta-data` command. Meta-data can only be set using the `buildkite-agent meta-data set` command, setting meta-data via API or other methods is not possible.
+The agent's `meta-data` command is the only method for setting meta-data. You can run the command from the command line or in a script.
 
 To set meta-data in the meta-data store, use the `set` command with a key/value pair:
 


### PR DESCRIPTION
Meta-data can only be **set** via the `buildkite-agent meta-data set` command, as it requires an agent token for auth and can't be used outside of the agent context. 

I think this could be worded better, but wanted to get something started :)