### PR TITLE
ONB-192: Undo pride logo in March

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,7 +50,7 @@ module ApplicationHelper
     # and this is generally acknowledged around the world
     # even if jurisdictions have their own dates. We also recognize
     # Mardi Gras in Sydney as Australia's main Pride festival in February.
-    if DateTime.now.month == 6 || DateTime.now.month == 2 || DateTime.now.month == 3 # Remove case for March on March 6
+    if DateTime.now.month == 6 || DateTime.now.month == 2
       image = 'logo-pride.svg'
     end
 


### PR DESCRIPTION
Mardi Gras and WorldPride has ended in Sydney, so changing the logo to only display in February for future Sydney Mardi Gras.festivals.