### PR TITLE
feat: add docs about limiting API access by IP

### DIFF
--- a/pages/apis/managing_api_tokens.md
+++ b/pages/apis/managing_api_tokens.md
@@ -60,6 +60,12 @@ Removing access from a token will send a notification email to the token's owner
 >📘
 > Removing access from a token does not delete the token, however token owner cannot re-add your organization to their token's scope.
 
+## Limiting API Access by IP address
+
+If you'd like to limit access to your organization by IP address, you can create an allowlist of IP addresses in the [organization's permission settings](https://buildkite.com/organizations/~/member-permissions).
+
+You can also manage the allowlist with the [`organizationApiIpAllowlistUpdate`](/docs/apis/graphql/schemas/mutation/organizationapiipallowlistupdate) mutation in the GraphQL API.
+
 ## Programmatically managing tokens
 
 The `access-token` REST API endpoint can be used to retrieve or revoke an API access token. See the [REST API access token](/docs/apis/rest-api/access-token) page for further information.

--- a/vale/styles/vocab.txt
+++ b/vale/styles/vocab.txt
@@ -1,4 +1,5 @@
 Allowlist
+allowlist
 Artifactory
 Artifactory's
 Atlassian


### PR DESCRIPTION
we've just added this feature to the UI / Graphql, so just getting the docs site in order 😁

The `http://localhost:3000/docs/apis/managing-api-tokens` page seems like the most logical location.
https://bk-docs-pr-1924.onrender.com/docs/apis/managing-api-tokens#limiting-api-access-by-ip-address
