### PR TITLE
[PDP-603] Update build matrix docs to list use in agent query rules

### DIFF
--- a/pages/pipelines/build_matrix.md
+++ b/pages/pipelines/build_matrix.md
@@ -9,6 +9,7 @@ The following [command step](/docs/pipelines/command-step) attributes can contai
 * [labels](/docs/pipelines/command-step#label)
 * [commands](/docs/pipelines/command-step#command-step-attributes)
 * [plugins](/docs/pipelines/command-step#plugins)
+* [agents](/docs/pipelines/command-step#agents)
 
 You can't use matrix values in other attributes, including step keys.
 
@@ -52,6 +53,8 @@ For more complex builds, add multiple dimensions to `matrix.setup` instead of th
 steps:
 - label: "💥 Matrix Build"
   command: "echo {{matrix.os}} {{matrix.arch}} {{matrix.test}}"
+  agents:
+    queue: "builder-{{matrix.arch}}"
   matrix:
     setup:
       arch:

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -45,7 +45,7 @@ steps:
 _Optional attributes:_
 
 <table data-attributes>
-  <tr>
+  <tr id="agents">
     <td><code>agents</code></td>
     <td>
       A map of <a href="/docs/agent/v3/cli-start#setting-tags">agent tag</a> keys to values to <a href="/docs/agent/v3/cli-start#agent-targeting">target specific agents</a> for this step. <br>


### PR DESCRIPTION
We've updated matrices to support use in agent query rules. This updates the docs to reflect that, as well as adding in an example use.

The code change has hit production, so this can be merged when approved