### PR TITLE
💄 Typography improvements

### DIFF
--- a/app/assets/stylesheets/base/_article.scss
+++ b/app/assets/stylesheets/base/_article.scss
@@ -8,7 +8,7 @@
   }
 
   p {
-    @include margin;
+    margin-bottom: 1.25rem;
   }
 
   blockquote,

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -74,6 +74,7 @@ button {
     $color-aliases,
     "text-base"
   ) !important; // override possible nested content styling
+  font-weight: 500;
 
   &:hover {
     background-color: map-get($color-aliases, "panel-background");
@@ -84,6 +85,7 @@ button {
   gap: 4px;
   margin: 0;
   padding: 0;
+  font-weight: 500;
 }
 
 .Button--small {

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -8,9 +8,8 @@
 
 .Footer__heading {
   color: map-get($color-aliases, "text-base");
-  font-size: 0.875rem;
-  font-weight: bold;
-  margin-bottom: 5px;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
 }
 
 .Footer__links {

--- a/app/assets/stylesheets/components/_nav.scss
+++ b/app/assets/stylesheets/components/_nav.scss
@@ -57,6 +57,7 @@
     color: $charcoal-900;
     display: flex;
     font-size: $font-size-template;
+    font-weight: 500;
     gap: 5px;
     line-height: map-get($line-heights, "default");
     margin: 0;


### PR DESCRIPTION
- Use same medium heading style like the Marketing site
- Adjust spacing between paragraphs and headings

## Screenshots of changes

### Docs article pages

#### Before

![Screen Shot 2023-03-14 at 10 48 45 AM](https://user-images.githubusercontent.com/7202667/224856736-0632da7a-1f28-4f7c-bd0d-7690f2fca583.png)

#### After

![Screen Shot 2023-03-14 at 10 49 15 AM](https://user-images.githubusercontent.com/7202667/224856804-b52f201d-61a2-4417-ae77-488ecce49229.png)

- More consistent font for table of contents
- Heading 2+ uses Medium weight

### Homepage and footer

#### Before

![Screen Shot 2023-03-14 at 10 50 56 AM](https://user-images.githubusercontent.com/7202667/224856990-55989f33-fa23-434d-8184-20c1dabe5575.png)

#### After

![Screen Shot 2023-03-14 at 10 51 27 AM](https://user-images.githubusercontent.com/7202667/224857082-86f22f23-9396-4391-a3f6-20be0340b435.png)

Use medium weight headings.
