### PR TITLE
Clarified exclusivity for Private S3 bucket logging

### DIFF
--- a/pages/pipelines/managing_log_output.md
+++ b/pages/pipelines/managing_log_output.md
@@ -143,7 +143,7 @@ For example, if you have environment variable `MY_SECRET="topsecret"`and you run
 
 ## Private build log archive storage
 
-By default, build logs are stored in encrypted form in Buildkite's Amazon S3 buckets, but you can also store the archived build logs in your private AWS S3 bucket.
+By default, build logs are stored in encrypted form in Buildkite's managed Amazon S3 buckets, but you can instead store the archived build logs into your private AWS S3 bucket.
 
 >📘
 > This feature is only available to customers on the Buildkite <a href="https://buildkite.com/pricing">Enterprise</a> plan.

--- a/pages/pipelines/managing_log_output.md
+++ b/pages/pipelines/managing_log_output.md
@@ -143,7 +143,7 @@ For example, if you have environment variable `MY_SECRET="topsecret"`and you run
 
 ## Private build log archive storage
 
-By default, build logs are stored in encrypted form in Buildkite's managed Amazon S3 buckets, but you can instead store the archived build logs into your private AWS S3 bucket.
+By default, build logs are stored in encrypted form in Buildkite's managed Amazon S3 buckets, but you can instead store the archived build logs in your private AWS S3 bucket.
 
 >📘
 > This feature is only available to customers on the Buildkite <a href="https://buildkite.com/pricing">Enterprise</a> plan.


### PR DESCRIPTION
Changed the description of our Private S3 Bucket logging docs to say that it is exclusive: basically Buildkite managed logs are default, but tenants can choose to have logs located in their own S3 bucket instead.

**Original Issue**

Customer asked us if turning this on would be exclusive or inclusive: i.e if logs are duplicated across BK and private buckets, or if it is a cutover.