### PR TITLE
DOCS-573: Add emoji page to the nav

### DIFF
--- a/data/nav.yml
+++ b/data/nav.yml
@@ -218,6 +218,8 @@
           path: "pipelines/notifications"
         - name: "Job minutes"
           path: "pipelines/job-minutes"
+        - name: "Emojis"
+          path: "pipelines/emojis"
         - name: "Example pipelines"
           path: "pipelines/example-pipelines"
         - name: "Step types"


### PR DESCRIPTION
This page is still linked from the product, but not included in the docs nav. I believe this was a mistake, so I'm fixing it.

Adding it to previous location shown in: https://web.archive.org/web/20201125105028/https://buildkite.com/docs/pipelines/emojis