### PR TITLE
DOCS-573: Add CLI annotation reference back to the nav

### DIFF
--- a/data/nav.yml
+++ b/data/nav.yml
@@ -117,6 +117,8 @@
               path: "agent/v3/cli-start"
             - name: "annotate"
               path: "agent/v3/cli-annotate"
+            - name: "annotation"
+              path: "agent/v3/cli-annotation"
             - name: "artifact"
               path: "agent/v3/cli-artifact"
             - name: "meta-data"

--- a/pages/agent/v3/cli_annotation.md
+++ b/pages/agent/v3/cli_annotation.md
@@ -4,10 +4,6 @@ The Buildkite Agent's `annotation` command allows manipulating existing build an
 
 Annotations are added using [the `buildkite-agent annotate` command](cli-annotate).
 
->📘 Newly-added feature
-> This feature was introduced in <a href="https://github.com/buildkite/agent/releases/tag/v3.28.1">v3.28.1</a> of the agent.
-
-
 ## Removing an annotation
 
 The `buildkite-agent annotation remove` command removes an existing annotation associated with the current build.


### PR DESCRIPTION
This was already being linked to from the annotate page.