### PR TITLE
DOCS-573: Add Docker Hub page back to the nav

### DIFF
--- a/data/nav.yml
+++ b/data/nav.yml
@@ -426,6 +426,8 @@
       path: "integrations/build-status-badges"
     - name: "CCMenu & CCTray"
       path: "integrations/cc-menu"
+    - name: "Docker Hub"
+      path: "integrations/docker-hub"
     - name: "PagerDuty"
       path: "integrations/pagerduty"
     - name: "Slack"


### PR DESCRIPTION
[Discussed on Basecamp](https://3.basecamp.com/3453178/buckets/1713315/chats/269048534@5949815373)