### PR TITLE
Assert user has permission before pushing to ECR

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -1,45 +1,36 @@
 steps:
-  - name: ":docker::ecr: Push to ECR"
-    command: ".buildkite/push-image.sh"
-    depends_on: "rspec"
-    key: "ecr-push"
-    if: |
-      build.branch == "main"
-    agents:
-      queue: deploy
-    plugins:
-     ecr#v2.0.0:
-       login: true
-       account-ids: ${ECR_ACCOUNT_ID}
-
-  # If the current user is part of the deploy team, then wait for everything to
-  # finish before deploying
-  - wait: ~
-    key: "deploy-check-wait"
-    depends_on: "ecr-push"
-    if: "(build.creator.teams includes 'deploy') && build.branch == 'main'"
+  - wait
 
   # If the user *isn't* in the deploy team, require a block step for manual
   # verification by someone who is in the team.
   - block: ":rocket: Deploy"
     key: "deploy-check-block"
-    depends_on: "ecr-push"
     if: "!(build.creator.teams includes 'deploy') && build.branch == 'main'"
 
+  - name: ":docker::ecr: Push to ECR"
+    key: "ecr-push"
+    command: ".buildkite/push-image.sh"
+    depends_on: "deploy-check-block"
+    if: "build.branch == 'main'"
+    agents:
+      queue: deploy
+    plugins:
+      ecr#v2.0.0:
+        login: true
+        account-ids: ${ECR_ACCOUNT_ID}
+
   - label: ":docker::rocket:"
+    key: deploy
     branches: main
-    depends_on:
-      - "deploy-check-wait"
-      - "deploy-check-block"
+    depends_on: ecr-push
     concurrency: 1
     concurrency_group: docs-deploy
     agents:
       queue: deploy
     command: scripts/deploy-ecs
 
-  - wait
-
   # Refresh the search index after a deployment
   - label: "🔎🪄"
     trigger: docs-algolia-crawler
     async: true
+    depends_on: deploy


### PR DESCRIPTION
We frequently see permission denied errors when merging PRs from users that don't have permission to deploy. This PR changes the deployment pipeline for first check the user team earlier for manual intervention (in the form a block step) if necessary. This is what would've happened if one of these failing builds were to ever make it to the final deployment step. 

Still not the ideal workflow but it should make merging marginally simpler.