### PR TITLE
add clarification for agent token configuration command

### DIFF
--- a/pages/agent/v3/macos.md
+++ b/pages/agent/v3/macos.md
@@ -11,7 +11,7 @@ If you have <a href="http://brew.sh/">Homebrew</a> installed you can use our <a 
 brew tap buildkite/buildkite && brew install buildkite-agent
 ```
 
-Then configure your [agent token](/docs/agent/v3/tokens):
+Then configure your [agent token](/docs/agent/v3/tokens) by replacing `INSERT-YOUR-AGENT-TOKEN-HERE` with your agent token and running:
 
 ```shell
 sed -i '' "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" "$(brew --prefix)"/etc/buildkite-agent/buildkite-agent.cfg

--- a/pages/agent/v3/macos.md
+++ b/pages/agent/v3/macos.md
@@ -17,8 +17,6 @@ Then configure your [agent token](/docs/agent/v3/tokens) by replacing `INSERT-YO
 sed -i '' "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" "$(brew --prefix)"/etc/buildkite-agent/buildkite-agent.cfg
 ```
 
-In the above command, you only need to replace `INSERT-YOUR-AGENT-TOKEN-HERE` and then run the command.
-
 If you don't use Homebrew you should follow the [Linux](/docs/agent/v3/linux) install instructions.
 
 ## SSH key configuration

--- a/pages/agent/v3/macos.md
+++ b/pages/agent/v3/macos.md
@@ -17,6 +17,8 @@ Then configure your [agent token](/docs/agent/v3/tokens):
 sed -i '' "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" "$(brew --prefix)"/etc/buildkite-agent/buildkite-agent.cfg
 ```
 
+In the above command, you only need to replace `INSERT-YOUR-AGENT-TOKEN-HERE` and then run the command.
+
 If you don't use Homebrew you should follow the [Linux](/docs/agent/v3/linux) install instructions.
 
 ## SSH key configuration


### PR DESCRIPTION
This commit will add a small subsection under the Agent Token configuration that describes only needing to replace the "INSERT-YOUR-AGENT-TOKEN-HERE" for clarification.