### PR TITLE
Added information around using YAML anchors

### DIFF
--- a/pages/plugins/using.md
+++ b/pages/plugins/using.md
@@ -47,7 +47,7 @@ location.
 
 ## Configuring plugins
 
-Plugins are configured using attributes on steps in your pipeline YAML configuration. While you can't define plugins at a pipeline level, you can use [YAML anchors](https://github.com/buildkite/docs/pull/1968#using-yaml-anchors-with-plugins) to avoid repeating the plugin code over multiple steps. The simplest plugin is one that accepts no configuration, such as the [Library Example plugin](https://github.com/buildkite-plugins/library-example-buildkite-plugin):
+Plugins are configured using attributes on steps in your pipeline YAML definition. While you can't define plugins at a pipeline level, you can use [YAML anchors](/docs/plugins/using#using-yaml-anchors-with-plugins) to avoid repeating the plugin code over multiple steps. The simplest plugin is one that accepts no configuration, such as the [Library Example plugin](https://github.com/buildkite-plugins/library-example-buildkite-plugin):
 ```yml
 steps:
   - label: "\:books\:"

--- a/pages/plugins/using.md
+++ b/pages/plugins/using.md
@@ -48,6 +48,7 @@ location.
 ## Configuring plugins
 
 Plugins are configured using attributes on steps in your pipeline YAML definition. While you can't define plugins at a pipeline level, you can use [YAML anchors](/docs/plugins/using#using-yaml-anchors-with-plugins) to avoid repeating the plugin code over multiple steps. The simplest plugin is one that accepts no configuration, such as the [Library Example plugin](https://github.com/buildkite-plugins/library-example-buildkite-plugin):
+
 ```yml
 steps:
   - label: "\:books\:"

--- a/pages/plugins/using.md
+++ b/pages/plugins/using.md
@@ -96,7 +96,9 @@ See each plugin's readme for a list of which options are available.
 
 ## Using YAML anchors with plugins
 
-YAML anchors allow you to identify an item with an anchor, also known as an alias. They allow us to then reference this azlias whenever we want to refer to the *thing* they are an alias for. The following example removes the need to repeat the plugin configuration on each individual step, provided the desired configuration is the same.
+YAML anchors enable you to identify an item with an anchor, also known as an _alias_. You can then reference the anchor when referring to that item. 
+
+The following example uses a YAML anchor (`docker`) to remove the need to repeat the same plugin configuration on each step:
 
 ```yml
 common:

--- a/pages/plugins/using.md
+++ b/pages/plugins/using.md
@@ -47,17 +47,13 @@ location.
 
 ## Configuring plugins
 
-Plugins are configured using attributes in your pipeline YAML configuration. The simplest plugin is one that accepts no configuration, such as the [Library Example plugin](https://github.com/buildkite-plugins/library-example-buildkite-plugin):
-
+Plugins are configured using attributes on steps in your pipeline YAML configuration. While you can't define plugins at a pipeline level, you can use [YAML anchors](https://github.com/buildkite/docs/pull/1968#using-yaml-anchors-with-plugins) to avoid repeating the plugin code over multiple steps. The simplest plugin is one that accepts no configuration, such as the [Library Example plugin](https://github.com/buildkite-plugins/library-example-buildkite-plugin):
 ```yml
 steps:
   - label: "\:books\:"
     plugins:
       - library-example#v1.0.0: ~
 ```
-
->🚧
-> Plugins cannot be defined at a pipeline level, however it is possiple to use YAML anchors in order to avoid repetition of plugin code.
 
 More commonly, plugins accept various configuration options. For example, the [Docker plugin](https://github.com/buildkite-plugins/docker-buildkite-plugin) requires the attribute `image`, and we have also included the optional `workdir` attribute:
 

--- a/pages/plugins/using.md
+++ b/pages/plugins/using.md
@@ -93,7 +93,7 @@ See each plugin's readme for a list of which options are available.
 
 ## Using YAML anchors with plugins
 
-YAML anchors enable you to identify an item with an anchor, also known as an _alias_. You can then reference the anchor when referring to that item. 
+YAML anchors enable you to identify an item with an anchor, also known as an _alias_. You can then reference the anchor when referring to that item.
 
 The following example uses a YAML anchor (`docker`) to remove the need to repeat the same plugin configuration on each step:
 

--- a/pages/plugins/using.md
+++ b/pages/plugins/using.md
@@ -56,6 +56,9 @@ steps:
       - library-example#v1.0.0: ~
 ```
 
+>🚧
+> Plugins cannot be defined at a pipeline level, however it is possiple to use YAML anchors in order to avoid repetition of plugin code.
+
 More commonly, plugins accept various configuration options. For example, the [Docker plugin](https://github.com/buildkite-plugins/docker-buildkite-plugin) requires the attribute `image`, and we have also included the optional `workdir` attribute:
 
 ```yml
@@ -90,6 +93,28 @@ steps:
 ```
 
 See each plugin's readme for a list of which options are available.
+
+## Using YAML anchors with plugins
+
+YAML anchors allow you to identify an item with an anchor, also known as an alias. They allow us to then reference this azlias whenever we want to refer to the *thing* they are an alias for. The following example removes the need to repeat the plugin configuration on each individual step, provided the desired configuration is the same.
+
+```yml
+common:
+  - docker_plugin: &docker
+      docker#v3.3.0:
+        image: something-quiet
+
+steps:
+  - label: "Read in isolation"
+    command: echo "I'm reading..."
+    plugins:
+      - *docker
+  - label: "Read something else"
+    command: echo "On to a new book"
+    plugins:
+      - *docker 
+
+```
 
 ## Plugin sources
 


### PR DESCRIPTION
We occasionally get questions around setting plugins on a pipeline rather than a step, this isn't possible but one can use yaml anchors in order to avoid repetition.