### PR TITLE
Fix docs diagram

### DIFF
--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -29,30 +29,3 @@
   font-style: normal;
   font-display: swap;
 }
-
-@font-face {
-  font-family: "Maison Neue";
-  src: url("https://www2.buildkiteassets.com/assets/maison-neue/MaisonNeue-BookItalic-2a5e47b91af0050b44c21f9038ef63a37e228fd53b0289dfccbcdd3aa44ba19c.woff2")
-    format("woff2");
-  font-weight: normal;
-  font-style: oblique;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "Maison Neue";
-  src: url("https://www2.buildkiteassets.com/assets/maison-neue/MaisonNeue-Bold-b76254964ac5dfd24f6500339e2dd7b29433d19f62dc0395720e339359fb2e61.woff2")
-    format("woff2");
-  font-weight: bold;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "Maison Neue";
-  src: url("https://www2.buildkiteassets.com/assets/maison-neue/MaisonNeue-BoldItalic-f834c7a46132c4df3cf948dd4c005775f758fb68b77b5199d75f814e5abf3484.woff2")
-    format("woff2");
-  font-weight: bold;
-  font-style: oblique;
-  font-display: swap;
-}

--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -29,3 +29,12 @@
   font-style: normal;
   font-display: swap;
 }
+
+@font-face {
+  font-family: "Maison Neue";
+  src: url("https://www2.buildkiteassets.com/assets/maison-neue/MaisonNeueWEB-Medium-9884c2338b4896f2fd56d7a93ee2150c2855644550ee60a9a9ff2137b6d3b507.woff2")
+    format("woff2");
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}

--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -3,6 +3,7 @@
 <link rel="dns-prefetch" href="//www2.buildkiteassets.com" />
 <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/aeonik/Aeonik-Bold-78fff47500f27f2f0d8d777c9d431a87036e566af7577a58ccc0776b4eb4b994.woff2" crossorigin="anonymous" />
 <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/maison-neue/MaisonNeueWEB-Book-e597278911055949a05fe1001e37bd61905409344995f03a0fa8a13f442be31b.woff2" crossorigin="anonymous" />
+<link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/maison-neue/MaisonNeueWEB-Medium-9884c2338b4896f2fd56d7a93ee2150c2855644550ee60a9a9ff2137b6d3b507.woff2" crossorigin="anonymous" />
 
 <title><%= [content_for(:page_title), "Buildkite Documentation"].compact.join(" | ") %></title>
 

--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -3,9 +3,6 @@
 <link rel="dns-prefetch" href="//www2.buildkiteassets.com" />
 <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/aeonik/Aeonik-Bold-78fff47500f27f2f0d8d777c9d431a87036e566af7577a58ccc0776b4eb4b994.woff2" crossorigin="anonymous" />
 <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/maison-neue/MaisonNeueWEB-Book-e597278911055949a05fe1001e37bd61905409344995f03a0fa8a13f442be31b.woff2" crossorigin="anonymous" />
-<link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/maison-neue/MaisonNeue-BookItalic-2a5e47b91af0050b44c21f9038ef63a37e228fd53b0289dfccbcdd3aa44ba19c.woff2" crossorigin="anonymous" />
-<link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/maison-neue/MaisonNeue-Bold-b76254964ac5dfd24f6500339e2dd7b29433d19f62dc0395720e339359fb2e61.woff2" crossorigin="anonymous" />
-<link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/maison-neue/MaisonNeue-BoldItalic-f834c7a46132c4df3cf948dd4c005775f758fb68b77b5199d75f814e5abf3484.woff2" crossorigin="anonymous" />
 
 <title><%= [content_for(:page_title), "Buildkite Documentation"].compact.join(" | ") %></title>
 


### PR DESCRIPTION
There's a diagram that's expecting a bold font that doesn't currently exist.

https://buildkite.com/docs/agent/v3
<img width="760" alt="Screenshot 2023-03-23 at 3 52 32 pm" src="https://user-images.githubusercontent.com/656826/227106674-94f8e925-b16e-428f-82c7-df275497e4cd.png">

Similar to https://github.com/buildkite/docs/pull/1941 this PR adds the necessary bold font variant in addition to removing a few other unused/invalid fonts.