### PR TITLE
Update to GraphQL only functionality on Jobs

### DIFF
--- a/pages/apis/api_differences.md
+++ b/pages/apis/api_differences.md
@@ -41,7 +41,6 @@ On this page, we've collected the known limitation where some API features are o
 * <%= pill "USERS", "users" %> [Create and revoke](/docs/apis/rest-api/access-token) user API tokens (while REST can only revoke user API tokens).
 * <%= pill "USERS", "users" %> [Invite a user into a specific team with a specific role and permissions set](/docs/apis/graphql/graphql-cookbook#create-a-user-add-them-to-a-team-and-set-user-permissions).
 
-
 ## Known missing API features
 
 These are known requested features that are currently missing from both REST and GraphQL APIs:

--- a/pages/apis/api_differences.md
+++ b/pages/apis/api_differences.md
@@ -27,6 +27,7 @@ On this page, we've collected the known limitation where some API features are o
 * <%= pill "JOBS", "jobs" %> [Get all jobs in a given queue for a given timeframe](/docs/apis/graphql/graphql-cookbook#get-all-jobs-in-a-given-queue-for-a-given-timeframe).
 * <%= pill "JOBS", "jobs" %> [Get all jobs in a particular concurrency group](/docs/apis/graphql/graphql-cookbook#get-all-jobs-in-a-particular-concurrency-group).
 * <%= pill "JOBS", "jobs" %> list job events.
+* <%= pill "JOBS", "jobs" %> [Cancel a job](/docs/apis/graphql/schemas/mutation/jobtypecommandcancel)
 * <%= pill "ORGANIZATIONS", "organizations" %> [Remove users from an organization](/docs/apis/graphql/graphql-cookbook#delete-an-organization-member).
 * <%= pill "ORGANIZATIONS", "organizations" %> Manage teams - [add](/docs/apis/graphql/graphql-cookbook#add-an-existing-organization-user-to-a-team) or [remove](/docs/apis/graphql/graphql-cookbook#remove-a-team-member) a team member. Most of the team management features are only available for GraphQL. The REST API can only list teams and can create pipelines in teams.
 * <%= pill "ORGANIZATIONS", "organizations" %> [Set up SSO](/docs/integrations/sso/sso-setup-with-graphql).
@@ -39,6 +40,7 @@ On this page, we've collected the known limitation where some API features are o
 * <%= pill "PIPELINES", "pipelines" %> Create and manage pipeline schedules.
 * <%= pill "USERS", "users" %> [Create and revoke](/docs/apis/rest-api/access-token) user API tokens (while REST can only revoke user API tokens).
 * <%= pill "USERS", "users" %> [Invite a user into a specific team with a specific role and permissions set](/docs/apis/graphql/graphql-cookbook#create-a-user-add-them-to-a-team-and-set-user-permissions).
+
 
 ## Known missing API features
 

--- a/pages/apis/api_differences.md
+++ b/pages/apis/api_differences.md
@@ -27,7 +27,7 @@ On this page, we've collected the known limitation where some API features are o
 * <%= pill "JOBS", "jobs" %> [Get all jobs in a given queue for a given timeframe](/docs/apis/graphql/graphql-cookbook#get-all-jobs-in-a-given-queue-for-a-given-timeframe).
 * <%= pill "JOBS", "jobs" %> [Get all jobs in a particular concurrency group](/docs/apis/graphql/graphql-cookbook#get-all-jobs-in-a-particular-concurrency-group).
 * <%= pill "JOBS", "jobs" %> list job events.
-* <%= pill "JOBS", "jobs" %> [Cancel a job](/docs/apis/graphql/schemas/mutation/jobtypecommandcancel)
+* <%= pill "JOBS", "jobs" %> [Cancel a job](/docs/apis/graphql/schemas/mutation/jobtypecommandcancel).
 * <%= pill "ORGANIZATIONS", "organizations" %> [Remove users from an organization](/docs/apis/graphql/graphql-cookbook#delete-an-organization-member).
 * <%= pill "ORGANIZATIONS", "organizations" %> Manage teams - [add](/docs/apis/graphql/graphql-cookbook#add-an-existing-organization-user-to-a-team) or [remove](/docs/apis/graphql/graphql-cookbook#remove-a-team-member) a team member. Most of the team management features are only available for GraphQL. The REST API can only list teams and can create pipelines in teams.
 * <%= pill "ORGANIZATIONS", "organizations" %> [Set up SSO](/docs/integrations/sso/sso-setup-with-graphql).


### PR DESCRIPTION
Adds a line about cancelling jobs, which can only be done with the GraphQL API