### PR TITLE
PIE-1508: Add mocha and jasmine to TA Get Started page

### DIFF
--- a/pages/test_analytics.md
+++ b/pages/test_analytics.md
@@ -21,7 +21,9 @@ Test Analytics helps you track and analyze the steps in that pipeline that invol
 <div class="ButtonGroup">
   <%= button ":rspec: RSpec", "/docs/test-analytics/ruby-collectors#rspec-collector" %>
   <%= button ":ruby: minitest", "/docs/test-analytics/ruby-collectors#minitest-collector" %>
-  <%= button ":jest: Jest", "/docs/test-analytics/javascript-collectors" %>
+  <%= button ":jest: Jest", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-jest" %>
+  <%= button ":mocha: Mocha", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-mocha-collector" %>
+  <%= button ":jasmine: Jasmine", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-jasmine-collector" %>
   <%= button ":swift: Swift", "/docs/test-analytics/swift-collectors" %>
   <%= button ":android: Android", "/docs/test-analytics/android-collectors" %>
   <%= button ":pytest: pytest", "/docs/test-analytics/python-collectors" %>


### PR DESCRIPTION
Jasmine and Mocha support was added to TA last year. The JS test collector README and docs were updated recently, but these test suites had not been listed on the "Get Started" page.

<img width="1920" alt="Screenshot 2023-03-27 at 09 58 27 (2)" src="https://user-images.githubusercontent.com/13619812/227804366-16e3808e-8505-4779-8819-473d1d0765e6.png">

[PIE-1508](https://linear.app/buildkite/issue/PIE-1508/add-jasmine-and-mocha-support-to-docs-overview-page-and-in-app)