### PR TITLE
[PIE-1519] Update TA docs on 'Test result objects' when importing JSON

### DIFF
--- a/data/content/test_analytics_json_fields_test_result.yaml
+++ b/data/content/test_analytics_json_fields_test_result.yaml
@@ -16,20 +16,12 @@ fields:
   examples:
       - Student.isEnrolled()
 - name: name
-  required: false
+  required: true
   type: string
   desc: |
       A name or description for the test
   examples:
       - Manager.isEnrolled() returns_boolean
-- name: identifier
-  required: true
-  type: string
-  enumerated_values:
-  desc: |
-      A unique identifier for the test. If your test runner supports it, use the identifier needed to rerun this test
-  examples:
-      - Manager.isEnrolled#returns_boolean
 - name: location
   required: false
   type: string
@@ -69,7 +61,7 @@ fields:
   type: array of hashes
   desc: |
        A more detailed explanation of why the test failed
-  examples: 
+  examples:
 
 - name: history
   required: true

--- a/pages/test_analytics/importing_json.md
+++ b/pages/test_analytics/importing_json.md
@@ -210,7 +210,6 @@ end
   "id": "95f7e024-9e0a-450f-bc64-9edb62d43fa9",
   "scope": "Analytics::Upload associations",
   "name": "fails",
-  "identifier": "./spec/models/analytics/upload_spec.rb[1:1:3]",
   "location": "./spec/models/analytics/upload_spec.rb:24",
   "file_name": "./spec/models/analytics/upload_spec.rb",
   "result": "failed",


### PR DESCRIPTION
PIE-1519

We recently removed support of the 'identifier' attribute and
made the 'name' attribute mandatory.

This PR updates the documentation on importing JSON to reflect
this recent change.

For additional context, the collectors have been updated to
remove support for the 'identifier' attribute.
Importing JUnit XML never support the 'identifier' attribute so
no documentation changes are required for that page.
