### PR TITLE
PIE-1458: Remove errant {:toc} from Flaky tests API page

### DIFF
--- a/pages/apis/rest_api/analytics/flaky_tests.md
+++ b/pages/apis/rest_api/analytics/flaky_tests.md
@@ -2,8 +2,6 @@
 
 The Flaky test API endpoint provides information about tests detected as flaky in a test suite.
 
-{:toc}
-
 ## List all flaky tests
 
 Returns a [paginated list](<%= paginated_resource_docs_url %>) of the flaky tests detected in a test suite.


### PR DESCRIPTION
`{:toc}` appears to have been removed since the original PR was created, and no longer renders correctly. This PR removes that random string from the API page for Flaky Tests

[PIE-1458](https://linear.app/buildkite/issue/PIE-1458/release-flaky-test-tracker-api-documentation)

<img width="1920" alt="Screenshot 2023-03-27 at 16 12 26 (2)" src="https://user-images.githubusercontent.com/13619812/227831716-36e29f37-904d-407b-b785-afa8624eede3.png">
