### PR TITLE
Docs for SSO Session IP Address Pinning

### DIFF
--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -350,9 +350,9 @@ mutation UpdateSessionDuration {
 }
 ```
 
-## Update the SSO provider session IP address pinning
+## Pin SSO sessions to IP addresses
 
-You can configure users must reauthorize with your SSO when their IP changes:
+You can require users to re-authenticate with your SSO provider when their IP address changes with the following call, replacing `ID` with the GraphQL ID of the SSO Provider:
 
 ```graphql
 mutation UpdateSessionIPAddressPinning {

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -352,7 +352,7 @@ mutation UpdateSessionDuration {
 
 ## Pin SSO sessions to IP addresses
 
-You can require users to re-authenticate with your SSO provider when their IP address changes with the following call, replacing `ID` with the GraphQL ID of the SSO Provider:
+You can require users to re-authenticate with your SSO provider when their IP address changes with the following call, replacing `ID` with the GraphQL ID of the SSO provider:
 
 ```graphql
 mutation UpdateSessionIPAddressPinning {

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -350,6 +350,20 @@ mutation UpdateSessionDuration {
 }
 ```
 
+## Update the SSO provider session IP address pinning
+
+You can configure users must reauthorize with your SSO when their IP changes:
+
+```graphql
+mutation UpdateSessionIPAddressPinning {
+  ssoProviderUpdate(input: { id: "ID", pinSessionToIpAddress: true }) {
+    ssoProvider {
+      pinSessionToIpAddress
+    }
+  }
+}
+```
+
 ## Search for an organization member by email address
 
 Get details of a single organization member by their email address.

--- a/pages/integrations/sso.md
+++ b/pages/integrations/sso.md
@@ -82,7 +82,7 @@ Prompt your users to re-authenticate when their IP address changes.
 
 With session IP address pinning, authorized sessions can only come from the IP address that created the session. If another IP address attempts to access Buildkite, the session will be immediately revoked. This helps to prevent session hijacking.
 
-To set up SSO session IP address pinning, use the [GraphQL API](/docs/apis/graphql/graphql-cookbook#update-the-sso-provider-session-ip-address-pinning) or complete the following steps in the Buildkite dashboard:
+To set up SSO session IP address pinning, use the [GraphQL API](/docs/apis/graphql/graphql-cookbook#pin-sso-sessions-to-ip-addresses) or complete the following steps in the Buildkite dashboard:
 
 * Select Provider
 * Under Session IP Address Pinning section

--- a/pages/integrations/sso.md
+++ b/pages/integrations/sso.md
@@ -75,12 +75,14 @@ You can configure the session duration to any timeout between 6 hours and 8,760 
 
 ## SSO session IP address pinning
 
-> 📘
-> Session IP Address Pinning is an Enterprise only feature.
+> 📘 Enterprise feature
+> Pinning SSO sessions to IP addresses is only available on an [Enterprise](https://buildkite.com/pricing) plan.
 
-You can configure the SSO Session IP Address Pinning to require re-authentication when user IP changes.
+Prompt your users to re-authenticate when their IP address changes.
 
-To set the Session IP Address Pinning you can either use the [GraphQL API](/docs/apis/graphql/graphql-cookbook#update-the-sso-provider-session-ip-address-pinning) or complete the following steps via the settings interface.
+With session IP address pinning, authorized sessions can only come from the IP address that created the session. If another IP address attempts to access Buildkite, the session will be immediately revoked. This helps to prevent session hijacking.
+
+To set up SSO session IP address pinning, use the [GraphQL API](/docs/apis/graphql/graphql-cookbook#update-the-sso-provider-session-ip-address-pinning) or complete the following steps in the Buildkite dashboard:
 
 * Select Provider
 * Under Session IP Address Pinning section

--- a/pages/integrations/sso.md
+++ b/pages/integrations/sso.md
@@ -78,9 +78,7 @@ You can configure the session duration to any timeout between 6 hours and 8,760 
 > 📘 Enterprise feature
 > Pinning SSO sessions to IP addresses is only available on an [Enterprise](https://buildkite.com/pricing) plan.
 
-Prompt your users to re-authenticate when their IP address changes.
-
-With session IP address pinning, authorized sessions can only come from the IP address that created the session. If another IP address attempts to access Buildkite, the session will be immediately revoked. This helps to prevent session hijacking.
+Session IP address pinning prompts users to re-authenticate when their IP address changes. This prevents session hijacking by restricting authorized sessions to only originate from the IP address used to create the session. If any attempt is made to access Buildkite from a different IP address, the session is instantly revoked and the user must re-authenticate.
 
 To set up SSO session IP address pinning, use the [GraphQL API](/docs/apis/graphql/graphql-cookbook#pin-sso-sessions-to-ip-addresses) or complete the following steps in the Buildkite dashboard:
 

--- a/pages/integrations/sso.md
+++ b/pages/integrations/sso.md
@@ -84,11 +84,11 @@ With session IP address pinning, authorized sessions can only come from the IP a
 
 To set up SSO session IP address pinning, use the [GraphQL API](/docs/apis/graphql/graphql-cookbook#pin-sso-sessions-to-ip-addresses) or complete the following steps in the Buildkite dashboard:
 
-* Select Provider
-* Under Session IP Address Pinning section
-  Click Update Session IP Address Pinning
-* Check Session IP Address Pinning checkbox
-* Click Save Session IP Address Pinning
+1. Navigate to the [organization's SSO settings](https://buildkite.com/organizations/~/sso).
+1. In the _Configured SSO Providers_ section, select the provider.
+1. In the _Session IP Address Pinning_ section, select _Update Session IP Address Pinning_.
+1. In the modal that appears, select the _Session IP Address Pinning_ checkbox.
+1. Select _Save Session IP Address Pinning_.
 
 ## Frequently asked questions
 

--- a/pages/integrations/sso.md
+++ b/pages/integrations/sso.md
@@ -73,6 +73,21 @@ You can configure the session duration to any timeout between 6 hours and 8,760 
 
 <%= image "session_duration/configure_session_duration.png", width: 623, height: 315, alt: "Screenshot of the Buildkite SSO Session Duration Configuration" %>
 
+## SSO session IP address pinning
+
+> 📘
+> Session IP Address Pinning is an Enterprise only feature.
+
+You can configure the SSO Session IP Address Pinning to require re-authentication when user IP changes.
+
+To set the Session IP Address Pinning you can either use the [GraphQL API](/docs/apis/graphql/graphql-cookbook#update-the-sso-provider-session-ip-address-pinning) or complete the following steps via the settings interface.
+
+* Select Provider
+* Under Session IP Address Pinning section
+  Click Update Session IP Address Pinning
+* Check Session IP Address Pinning checkbox
+* Click Save Session IP Address Pinning
+
 ## Frequently asked questions
 
 ### Can some people in the organization use SSO and others not?


### PR DESCRIPTION
This PR adds docs for SSO Session IP Address Pinning feature.

`/docs/integrations/sso#sso-session-ip-address-pinning`:

![CleanShot 2023-03-27 at 14 38 57@2x](https://user-images.githubusercontent.com/1000669/227860320-098e57fd-84b5-4744-9801-30a401423069.png)

The `GraphQL API` link goes to following GraphQL cookbook `/docs/apis/graphql/graphql-cookbook#update-the-sso-provider-session-ip-address-pinning`:

![CleanShot 2023-03-27 at 14 34 03@2x](https://user-images.githubusercontent.com/1000669/227859793-870aa53c-7d49-443b-8ea9-66de1b3fbc08.png)

FDN-2327