### PR TITLE
[PDP-211] Add signal and signal_reason to the default value for automatic retries

### DIFF
--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -331,6 +331,7 @@ _Optional Attributes_
         <li><code>"*"</code></li>
         <li><code>none</code></li>
         <li><code>cancel</code></li>
+        <li><code>agent_stop</code></li>
       </ul>
     </td>
   </tr>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -229,6 +229,8 @@ _At least one of the following attributes is required:_
       Whether to allow a job to retry automatically. This field accepts a boolean value, individual retry conditions, or a list of multiple different retry conditions.<br> If set to <code>true</code>, the retry conditions are set to the default value.<br>
       <em>Default value:</em><br>
       <code>exit_status: "*"</code><br>
+      <code>signal: "*"</code><br>
+      <code>signal_reason: "*"</code><br>
       <code>limit: 2</code><br>
       <em>Example:</em> <code>true</code>
     </td>


### PR DESCRIPTION
- Adds `signal` and `signal_reason` defaults
- Adds `agent_stop` as an example value for `signal_reason`, so that I can point to it in the changelog (it's commonly used for handling instance spot termination)

Extends https://github.com/buildkite/docs/pull/1883