### PR TITLE
fix missing quotation mark in HTTP example

### DIFF
--- a/pages/test_analytics/importing_json.md
+++ b/pages/test_analytics/importing_json.md
@@ -352,7 +352,7 @@ Detail objects contains additional information about the span.
   "detail": {
     method: "POST",
     url: "https://example.com",
-    lib: "curl
+    lib: "curl"
   }
 }
 ```


### PR DESCRIPTION
When troubleshooting, I noticed we missed a double quotation mark in our HTTP example in the docs. This commit adds the missing double quotation mark.