### PR TITLE
PDP-699 updating documentation for trigger steps to include soft_fail attribute

### DIFF
--- a/pages/pipelines/trigger_step.md
+++ b/pages/pipelines/trigger_step.md
@@ -172,6 +172,39 @@ _Optional_ `build` _attributes:_
 ```
 {: codeblock-file="pipeline.yml"}
 
+## Soft fail attributes
+
+_Optional Attributes_
+
+<table>
+  <tr>
+    <td><code>exit_status</code></td>
+    <td>
+      Allow specified non-zero exit statuses not to fail the build.
+      <br>
+      <em>Example:</em> <code>"*"</code><br>
+      <em>Example:</em> <code>1</code><br>
+      <em>Example:</em> <code>true</code>
+    </td>
+  </tr>
+</table>
+
+```yml
+- trigger:
+    label: "I don't want to fail my triggering build"
+    command: "tests.sh"
+    soft_fail:
+      - exit_status: 1
+```
+{: codeblock-file="pipeline.yml"}
+
+```yml
+- trigger:
+    label: "I don't want to fail my triggering build"
+    command: "tests.sh"
+    soft_fail: true
+```
+{: codeblock-file="pipeline.yml"}
 ## Environment variables
 
 You can use [environment variable substitution](/docs/agent/v3/cli-pipeline#environment-variable-substitution) to set attribute values:
@@ -246,37 +279,4 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-## Soft fail attributes
-
-_Optional Attributes_
-
-<table>
-  <tr>
-    <td><code>exit_status</code></td>
-    <td>
-      Allow specified non-zero exit statuses not to fail the build.
-      <br>
-      <em>Example:</em> <code>"*"</code><br>
-      <em>Example:</em> <code>1</code><br>
-      <em>Example:</em> <code>true</code>
-    </td>
-  </tr>
-</table>
-
-```yml
-- trigger:
-    label: "I don't want to fail my triggering build"
-    command: "tests.sh"
-    soft_fail:
-      - exit_status: 1
-```
-{: codeblock-file="pipeline.yml"}
-
-```yml
-- trigger:
-    label: "I don't want to fail my triggering build"
-    command: "tests.sh"
-    soft_fail: true
-```
-{: codeblock-file="pipeline.yml"}
 

--- a/pages/pipelines/trigger_step.md
+++ b/pages/pipelines/trigger_step.md
@@ -190,7 +190,7 @@ _Optional Attributes_
 </table>
 
 ```yml
-- trigger:
+- trigger: "some-tests"
     label: "I don't want to fail my triggering build"
     command: "tests.sh"
     soft_fail:
@@ -199,7 +199,7 @@ _Optional Attributes_
 {: codeblock-file="pipeline.yml"}
 
 ```yml
-- trigger:
+- trigger: "some-tests"
     label: "I don't want to fail my triggering build"
     command: "tests.sh"
     soft_fail: true

--- a/pages/pipelines/trigger_step.md
+++ b/pages/pipelines/trigger_step.md
@@ -245,3 +245,38 @@ steps:
 
 ```
 {: codeblock-file="pipeline.yml"}
+
+## Soft fail attributes
+
+_Optional Attributes_
+
+<table>
+  <tr>
+    <td><code>exit_status</code></td>
+    <td>
+      Allow specified non-zero exit statuses not to fail the build.
+      <br>
+      <em>Example:</em> <code>"*"</code><br>
+      <em>Example:</em> <code>1</code>
+      <em>Example:</em> <code>true</code>
+    </td>
+  </tr>
+</table>
+
+```yml
+- trigger:
+    label: "I don't want to fail my triggering build"
+    command: "tests.sh"
+    soft_fail:
+      - exit_status: 1
+```
+{: codeblock-file="pipeline.yml"}
+
+```yml
+- trigger:
+    label: "I don't want to fail my triggering build"
+    command: "tests.sh"
+    soft_fail: true
+```
+{: codeblock-file="pipeline.yml"}
+

--- a/pages/pipelines/trigger_step.md
+++ b/pages/pipelines/trigger_step.md
@@ -257,7 +257,7 @@ _Optional Attributes_
       Allow specified non-zero exit statuses not to fail the build.
       <br>
       <em>Example:</em> <code>"*"</code><br>
-      <em>Example:</em> <code>1</code>
+      <em>Example:</em> <code>1</code><br>
       <em>Example:</em> <code>true</code>
     </td>
   </tr>

--- a/pages/pipelines/trigger_step.md
+++ b/pages/pipelines/trigger_step.md
@@ -109,6 +109,16 @@ _Optional attributes:_
       <em>Example:</em> <code>"My reason"</code>
     </td>
   </tr>
+  <tr>
+    <td><code>soft_fail</code></td>
+    <td>
+      Allow specified non-zero exit statuses not to fail the build.
+      Can be either an array of allowed soft failure exit statuses or <code>true</code> to make all exit statuses soft-fail.<br>
+      <em>Example:</em> <code>true</code><br>
+      <em>Example:</em><br>
+      <code>- exit_status: 1</code><br>
+    </td>
+  </tr>
 </table>
 
 _Optional_ `build` _attributes:_

--- a/pages/pipelines/trigger_step.md
+++ b/pages/pipelines/trigger_step.md
@@ -205,6 +205,7 @@ _Optional Attributes_
     soft_fail: true
 ```
 {: codeblock-file="pipeline.yml"}
+
 ## Environment variables
 
 You can use [environment variable substitution](/docs/agent/v3/cli-pipeline#environment-variable-substitution) to set attribute values:

--- a/pages/pipelines/trigger_step.md
+++ b/pages/pipelines/trigger_step.md
@@ -279,5 +279,3 @@ steps:
 
 ```
 {: codeblock-file="pipeline.yml"}
-
-


### PR DESCRIPTION
/docs/pipelines/trigger-step

Adding soft_fail attribute to trigger step (soft_fail is already existing for [command step](https://buildkite.com/docs/pipelines/command-step))

![image](https://user-images.githubusercontent.com/78014112/228387398-52d59c55-f9fe-4b94-a904-95ad663cbdfb.png)


![image](https://user-images.githubusercontent.com/78014112/228389073-4d3ada6d-44e8-4002-886d-88943e3a0434.png)

