### PR TITLE
Fix bug in pre-bootstrap example in securing.md

### DIFF
--- a/pages/agent/v3/securing.md
+++ b/pages/agent/v3/securing.md
@@ -83,7 +83,7 @@ set -euo pipefail
 
 for line in "$(grep "^BUILDKITE_REPO=" "${BUILDKITE_ENV_FILE}")"
 do
-  repo="$(echo "${line}" | cut -d= -f2)"
+  repo="$(echo "${line}" | cut -d= -f2 | sed -e 's/^"//' -e 's/"$//')"
   if [ "${repo}" != "git@server:repo.git" ]
   then
     echo "Repository not allowed: ${repo}"
@@ -93,7 +93,7 @@ done
 
 for line in "$(grep "^BUILDKITE_COMMAND=" "${BUILDKITE_ENV_FILE}")"
 do
-  command="$(echo "${line}" | cut -d= -f2)"
+  command="$(echo "${line}" | cut -d= -f2 | sed -e 's/^"//' -e 's/"$//')"
   if [ "${command}" != "some-script.sh" ]
   then
     echo "Command not allowed: ${command}"


### PR DESCRIPTION
When I tried to use the example syntax for the `pre-bootstrap` script, it failed because it didn't strip the leading and trailing quotes when extracting the value of a Buildkite env var from `BUILDKITE_ENV_FILE`. Adding the appropriate `sed` call made my script work.