### PR TITLE
Add beta lozenge to clusters

### DIFF
--- a/app/models/beta_pages.rb
+++ b/app/models/beta_pages.rb
@@ -5,7 +5,8 @@ class BetaPages
       'test-analytics/swift-collectors',
       'test-analytics/android-collectors',
       'test-analytics/dotnet-collectors',
-      'apis/rest-api/analytics/flaky-tests'
+      'apis/rest-api/analytics/flaky-tests',
+      'agent/clusters'
     ]
   end
 end

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -53,6 +53,7 @@
           path: "agent/v3"
         - name: "Clusters"
           path: "agent/clusters"
+          pill: "beta"
         - name: "Installation"
           path: "agent/v3/installation"
         - name: "Upgrading"


### PR DESCRIPTION
I noticed that we forgot to label this as a beta feature:

![Screenshot 2023-03-30 at 10 44 24 am](https://user-images.githubusercontent.com/119824349/228692125-52fbbbe0-eba2-4689-af27-91b8942594be.png)

**Live preview:** [Clusters](https://bk-docs-pr-1989.onrender.com/docs/agent/clusters)