### PR TITLE
add section in GHE docs about configuring multiple GHE integrations

### DIFF
--- a/pages/integrations/github_enterprise.md
+++ b/pages/integrations/github_enterprise.md
@@ -67,7 +67,7 @@ Buildkite will recognize that it's hosted on your GitHub Enterprise Server, and 
 
 ## Transferring ownership
 
-If you need to leave your current GitHub Enterprise Organization, you need to transfer the OAuth ownership first. Without this, the remaining members of your Buildkite team who are using that GitHub Enterprise Organization for OAth won't be able to log in.
+If you need to leave your current GitHub Enterprise Organization, you need to transfer the OAuth ownership first. Without this, the remaining members of your Buildkite team who are using that GitHub Enterprise Organization for OAuth won't be able to log in.
 
 To correctly transfer the OAuth ownership over your GitHub Enterprise Organization, see GitHub's official documentation for [Transferring ownership of an OAuth App](https://docs.github.com/en/developers/apps/managing-oauth-apps/transferring-ownership-of-an-oauth-app) and [Maintaining ownership continuity for your organization](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/maintaining-ownership-continuity-for-your-organization).
 
@@ -121,6 +121,10 @@ http {
   }
 }
 ```
+
+## Multiple GitHub Enterprise integrations
+
+It is possible to configure multiple GitHub Enterprise integrations with your Buildkite organization, however, because of the nature of the OAuth installation, each integration *must* be configured by a different user, who has Admin permissions in both Buildkite and GitHub
 
 ## Using one repository in multiple pipelines and organizations
 


### PR DESCRIPTION
There are some caveats to be aware of when configuring multiple GHE integrations on a single Buildkite organization, so we should make that known to people trying to do this.