### PR TITLE
update sso docs (okta) with extra detail around account provisioning

### DIFF
--- a/pages/integrations/sso/okta.md
+++ b/pages/integrations/sso/okta.md
@@ -43,7 +43,7 @@ Go to your Buildkite application in Okta to set up deprovisioning:
 
 ### Provisioning existing users
 
-Existing Okta users aren't automatically provisioned in Buildkite; you'll need to sync your users in order to deprovision them. Users will have their Buildkite accounts created via [JIT provisioning](/docs/integrations/sso#frequently-asked-questions-do-you-support-jit-provisioning).
+Buildkite creates accounts for existing Okta users with just-in-time user provisioning (JIT provisioning). To deprovision users, you need to sync them.
 
 This can be done one of two ways:
 

--- a/pages/integrations/sso/okta.md
+++ b/pages/integrations/sso/okta.md
@@ -43,7 +43,7 @@ Go to your Buildkite application in Okta to set up deprovisioning:
 
 ### Provisioning existing users
 
-Existing Okta users aren't automatically provisioned in Buildkite; you'll need to sync your users in order to deprovision them.
+Existing Okta users aren't automatically provisioned in Buildkite; you'll need to sync your users in order to deprovision them. Users will have their Buildkite accounts created via [JIT provisioning](/docs/integrations/sso#frequently-asked-questions-do-you-support-jit-provisioning).
 
 This can be done one of two ways:
 


### PR DESCRIPTION
We support JIT provisioning with Okta, so I think it's important that is clarified in our docs (rather than just as an FAQ).

@mbelton-buildkite I'm not sure this is entirely the right spot for this, but I do think it's something we should have written down, so if you have other suggestions for where this information can go, please suggest!