### PR TITLE
Fix example in retry docs

### DIFF
--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -289,8 +289,9 @@ Conditions on retries can be specified. For example, it's possible to set steps 
     command: "deploy.sh"
     branches: "main"
     retry:
-      manual: false
-      reason: "Deploys shouldn't be retried"
+      manual: 
+        allowed: false
+        reason: "Deploys shouldn't be retried"
 ```
 {: codeblock-file="pipeline.yml"}
 


### PR DESCRIPTION
The current syntax isn't valid, it triggers the error
> `reason` is not a valid property on the retry ruleset. Please check the documentation to get a full list of supported properties.

The updated file matches the correct syntax used lower down on the page.