### PR TITLE
Add json content type header to all curl examples with json data

### DIFF
--- a/pages/apis/graphql/graphql_tutorial.md
+++ b/pages/apis/graphql/graphql_tutorial.md
@@ -43,6 +43,7 @@ To run the same query using [cURL](https://curl.haxx.se), replace `xxxxxxx` with
 ```sh
 $ curl 'https://graphql.buildkite.com/v1' \
        -H 'Authorization: Bearer xxxxxxx' \
+       -H "Content-Type: application/json" \
        -d '{
          "query": "query { viewer { user { name } } }"
        }'

--- a/pages/apis/graphql_api.md
+++ b/pages/apis/graphql_api.md
@@ -41,6 +41,7 @@ For example, the following `curl` command returns the `name` property of the cur
 ```bash
 curl https://graphql.buildkite.com/v1 \
   -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
   -d '{
     "query": "{ viewer { user { name } } }",
     "variables": "{ }"

--- a/pages/apis/rest_api.md
+++ b/pages/apis/rest_api.md
@@ -35,6 +35,7 @@ Some API requests accept JSON request bodies for specifying data. For example, t
 
 ```
 curl -X POST "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds" \
+  -H "Content-Type: application/json" \
   -d '{
     "key": "value"
   }'

--- a/pages/apis/rest_api/agents.md
+++ b/pages/apis/rest_api/agents.md
@@ -147,6 +147,7 @@ Instruct an agent to stop accepting new build jobs and shut itself down.
 
 ```bash
 curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}/stop" \
+  -H "Content-Type: application/json" \
   -d '{
     "force": true
   }'

--- a/pages/apis/rest_api/builds.md
+++ b/pages/apis/rest_api/builds.md
@@ -299,6 +299,7 @@ Success response: `200 OK`
 
 ```bash
 curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.slug}/builds" \
+  -H "Content-Type: application/json" \
   -d '{
     "commit": "abcd0b72a1e580e90712cdd9eb26d3fb41cd09c8",
     "branch": "master",

--- a/pages/apis/rest_api/jobs.md
+++ b/pages/apis/rest_api/jobs.md
@@ -60,6 +60,7 @@ Unblocks a build's "Block pipeline" job. The job's `unblockable` property indica
 
 ```bash
 curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.slug}/builds/{build.number}/jobs/{job.id}/unblock"  \
+  -H "Content-Type: application/json" \
   -d '{
     "fields": {
       "name": "Liam Neeson",

--- a/pages/apis/rest_api/pipelines.md
+++ b/pages/apis/rest_api/pipelines.md
@@ -169,6 +169,7 @@ make the following POST request, substituting your organization slug instead of 
 
 ```bash
 curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines" \
+  -H "Content-Type: application/json" \
   -d '{
       "name": "My Pipeline X",
       "repository": "git@github.com:acme-inc/my-pipeline.git",
@@ -397,6 +398,7 @@ YAML pipelines are the recommended way to [manage your pipelines](https://buildk
 
 ```bash
 curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines" \
+  -H "Content-Type: application/json" \
   -d '{
     "name": "My Pipeline",
     "repository": "git@github.com:acme-inc/my-pipeline.git",
@@ -684,6 +686,7 @@ To update a pipeline's YAML steps, make a PATCH request to the `pipelines` endpo
 
 ```bash
 curl -X PATCH "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{slug}" \
+  -H "Content-Type: application/json" \
   -d '{
     "repository": "git@github.com:acme-inc/new-repo.git",
     "configuration": "steps:\n  - command: \"new.sh\"\n    agents:\n    - \"myqueue=true\""

--- a/pages/integrations/git.md
+++ b/pages/integrations/git.md
@@ -70,6 +70,7 @@ while read -r _oldrev newrev ref; do
   curl -X POST \
     "https://api.buildkite.com/v2/organizations/$BUILDKITE_ORG_SLUG/pipelines/$BUILDKITE_PIPELINE_SLUG/builds" \
     -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+    -H "Content-Type: application/json" \
     -d "$(printf "$BUILDKITE_PAYLOAD_FORMAT" "$newrev" "$branch" "$message" "$author" "$email")"
 done
 ```

--- a/pages/pipelines/secrets.md
+++ b/pages/pipelines/secrets.md
@@ -124,6 +124,7 @@ steps:
   - command: |
       curl \
         --header "Authorization: token $GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN" \
+        --header "Content-Type: application/json" \
         --request POST \
         --data "{\"ref\": \"$BUILDKITE_COMMIT\"}" \
         https://api.github.com/repos/my-org/my-app/deployments
@@ -155,6 +156,7 @@ steps:
   - command: |
       curl \
         --header "Authorization: token $$GITHUB_MY_APP_DEPLOYMENT_ACCESS_TOKEN" \
+        --header "Content-Type: application/json" \
         --request POST \
         --data "{\"ref\": \"$$BUILDKITE_COMMIT\"}" \
         https://api.github.com/repos/my-org/my-app/deployments


### PR DESCRIPTION
By default curl will set the content type header to application/x-www-form-urlencoded. This PR updates our curl examples to explicitly set the content type header to application/json.