### PR TITLE
DOCS-561 Add URL Query Param auth method for rest API

### DIFF
--- a/pages/apis/rest_api.md
+++ b/pages/apis/rest_api.md
@@ -49,10 +49,18 @@ You can authenticate with the Buildkite API using access tokens.
 
 API access tokens allow to call the API without using your username and password. They can be created on your <a href="<%= url_helpers.user_access_tokens_url %>" rel="nofollow">API access tokens</a> page, limited to individual organizations and permissions, and revoked at any time from the web interface [or the REST API](/docs/apis/rest-api/access-token#revoke-the-current-token).
 
-To authenticate using a token, set the <code>Authorization</code> HTTP header to the word <code>Bearer</code>, followed by a space, followed by the access token. For example:
+Authentication can be done with both HTTP headers and as a query parameter in a HTTP request.
+
+To authenticate using a header token, set the <code>Authorization</code> HTTP header to the word <code>Bearer</code>, followed by a space, followed by the access token. For example:
 
 ```bash
 curl -H "Authorization: Bearer $TOKEN" https://api.buildkite.com/v2/user
+```
+
+To authenticate using query paramters add `access_token=$TOKEN` to your query URL. For example:
+
+```bash
+curl "https://api.buildkite.com/v2/user?access_token=$TOKEN"
 ```
 
 >🚧 Basic authentication

--- a/pages/apis/rest_api.md
+++ b/pages/apis/rest_api.md
@@ -57,7 +57,7 @@ To authenticate using a header token, set the <code>Authorization</code> HTTP he
 curl -H "Authorization: Bearer $TOKEN" https://api.buildkite.com/v2/user
 ```
 
-To authenticate using query paramters add `access_token=$TOKEN` to your query URL. For example:
+To authenticate using query parameters add `access_token=$TOKEN` to your query URL. For example:
 
 ```bash
 curl "https://api.buildkite.com/v2/user?access_token=$TOKEN"

--- a/pages/apis/rest_api.md
+++ b/pages/apis/rest_api.md
@@ -47,17 +47,17 @@ The data encoding is assumed to be `application/json`. Unless explicitly stated 
 
 You can authenticate with the Buildkite API using access tokens.
 
-API access tokens allow to call the API without using your username and password. They can be created on your <a href="<%= url_helpers.user_access_tokens_url %>" rel="nofollow">API access tokens</a> page, limited to individual organizations and permissions, and revoked at any time from the web interface [or the REST API](/docs/apis/rest-api/access-token#revoke-the-current-token).
+API access tokens allow you to call the API without using your username and password. They can be created on your <a href="<%= url_helpers.user_access_tokens_url %>" rel="nofollow">API access tokens</a> page, limited to individual organizations and permissions, and revoked at any time from the web interface [or the REST API](/docs/apis/rest-api/access-token#revoke-the-current-token).
 
-Authentication can be done with both HTTP headers and as a query parameter in a HTTP request.
+You can include the access token in a request using either an HTTP header or a query parameter.
 
-To authenticate using a header token, set the <code>Authorization</code> HTTP header to the word <code>Bearer</code>, followed by a space, followed by the access token. For example:
+To authenticate using a header token, set the <code>Authorization</code> HTTP header to the word <code>Bearer</code>, followed by a space, and then the access token. For example:
 
 ```bash
 curl -H "Authorization: Bearer $TOKEN" https://api.buildkite.com/v2/user
 ```
 
-To authenticate using query parameters add `access_token=$TOKEN` to your query URL. For example:
+To authenticate using a query parameter, add `access_token=$TOKEN` to your query URL. For example:
 
 ```bash
 curl "https://api.buildkite.com/v2/user?access_token=$TOKEN"


### PR DESCRIPTION
Add a missing ability to the documentation about authentication using the Rest API.

Clarifies that auth tokens can be used as a query parameter by going `...?access_token=$TOKEN`.

Please check I'm using language properly.

https://linear.app/buildkite/issue/DOC-561/document-auth-in-query-parameter