### PR TITLE
Render toggle for pre-expanded navigation

### DIFF
--- a/app/assets/javascripts/nav.js
+++ b/app/assets/javascripts/nav.js
@@ -55,27 +55,24 @@ function initNav() {
             )
           );
 
-          if (e.target.className.includes("Nav__toggle--on")) {
+          function collapse() {
             e.target.nextSibling.nextSibling.classList.remove(
               "Nav__section--show"
             );
             e.target.classList.remove("Nav__toggle--on");
-          } else {
-            sectionNodes.map((section) =>
-              section.classList.remove("Nav__section--show")
-            );
+          }
+
+          function expand() {
             e.target.nextSibling.nextSibling.classList.add(
               "Nav__section--show"
             );
-            toggleNodes.map((toggle) => {
-              if (
-                parseInt(toggle.getAttribute("data-toggle-nav-level")) ===
-                currentLevel
-              ) {
-                toggle.classList.remove("Nav__toggle--on");
-              }
-            });
             e.target.classList.add("Nav__toggle--on");
+          }
+
+          if (e.target.className.includes("Nav__toggle--on")) {
+            collapse();
+          } else {
+            expand();
           }
 
           if (window.matchMedia("screen and (max-width: 959px)").matches) {

--- a/app/views/application/_nav_link.html.erb
+++ b/app/views/application/_nav_link.html.erb
@@ -3,6 +3,7 @@
     Nav__link
     Nav__link--level#{nav_level}
     #{"Nav__link--type-#{type}" if type}
+    #{start_expanded && "Nav__toggle--on"}
   "
 %>
 
@@ -20,20 +21,13 @@
     <%= new_window && 'target=_blank' %>
   >
     <%= name %>
-    
+
     <% if pill %>
       <span class="Nav__pill pill pill--<%= pill %> pill--small"><%= pill %></span>
     <% end %>
   </a>
-<% elsif start_expanded %>
-  <span class="<%= css_classes_nav_link %> Nav__link--pre-expand-children">
-    <%= name %>
-    <% if pill %>
-      <span class="Nav__pill pill pill--<%= pill %> pill--small"><%= pill %></span>
-    <% end %>
-  </span>
 <% else %>
-  <button 
+  <button
     class="<%= css_classes_nav_link %> <%= type == "dropdown" ? 'Nav__dropdown-toggle' : 'Nav__toggle' %>"
     data-toggle-nav-level="<%= nav_level %>"
   >
@@ -41,5 +35,5 @@
     <% if pill %>
       <span class="Nav__pill pill pill--<%= pill %> pill--small"><%= pill %></span>
     <% end %>
-  </button> 
+  </button>
 <% end %>


### PR DESCRIPTION
This change updates pre-expanded navigation to render the expand/collapse toggle.

To render navigation expanded navigation you can use the following:

```
start_expanded: true
```

| Before | After |
| --- | --- |
| <img width="786" alt="Screenshot 2023-04-17 at 3 39 14 pm" src="https://user-images.githubusercontent.com/656826/232392730-36f5a4ab-3f04-432d-b6b2-c5c858791ec3.png"> | <img width="786" alt="Screenshot 2023-04-17 at 3 39 27 pm" src="https://user-images.githubusercontent.com/656826/232393125-95d03ddd-9792-41ce-8c30-5d47273e7cfc.png"> |