### PR TITLE
Add ability to render H3s in Table of Contents

### DIFF
--- a/app/assets/javascripts/toc.js
+++ b/app/assets/javascripts/toc.js
@@ -4,7 +4,7 @@ function initToc() {
   const initCurrentLinkListener = () => {
     const scrollPadding = 125;
     const currentClassName = "Toc__link--current";
-    const tocLinkNodes = document.querySelectorAll(".Toc__link");
+    const tocLinkNodes = document.querySelectorAll(".Toc__link--h2");
     const headingNodes = document.querySelectorAll("h2.Docs__heading");
 
     const getDistanceFromTop = (element) => {

--- a/app/assets/stylesheets/components/_toc.scss
+++ b/app/assets/stylesheets/components/_toc.scss
@@ -86,6 +86,10 @@
     }
   }
 
+  .Toc__list--h3 {
+    font-size: 0.7rem;
+  }
+
   .Toc__list-item {
     list-style-type: none;
     margin-bottom: 2px;

--- a/app/assets/stylesheets/components/_toc.scss
+++ b/app/assets/stylesheets/components/_toc.scss
@@ -86,10 +86,6 @@
     }
   }
 
-  .Toc__list--h3 {
-    font-size: 0.7rem;
-  }
-
   .Toc__list-item {
     list-style-type: none;
     margin-bottom: 2px;
@@ -111,5 +107,10 @@
       background-color: $purple-100;
       color: $purple-600;
     }
+  }
+
+  .Toc__link--h3 {
+    font-size: 0.875rem;
+    padding-left: 16px + 10px;
   }
 }

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -143,7 +143,9 @@ class Page
   def metadata
     defaults = {
       # Default to rendering table of contents
-      "toc": true
+      "toc": true,
+      # Default to H2s being included in the table of contents
+      "toc_include_h3": false
     }
     if file.front_matter
       defaults.merge(file.front_matter.symbolize_keys)

--- a/app/models/page/data_extractor.rb
+++ b/app/models/page/data_extractor.rb
@@ -23,8 +23,17 @@ class Page::DataExtractor
         if node.header_level == 1 && page_name.nil?
           page_name = header
         end
+
         if node.header_level === 2
           sections << {
+            header: header,
+            id: "##{header.to_url}",
+            subsections: []
+          }
+        end
+
+        if node.header_level === 3
+          sections.last[:subsections] << {
             header: header,
             id: "##{header.to_url}",
           }

--- a/app/models/page/data_extractor.rb
+++ b/app/models/page/data_extractor.rb
@@ -32,7 +32,7 @@ class Page::DataExtractor
           }
         end
 
-        if node.header_level === 3
+        if node.header_level === 3 && !sections.empty?
           sections.last[:subsections] << {
             header: header,
             id: "##{header.to_url}",

--- a/app/models/page/data_extractor.rb
+++ b/app/models/page/data_extractor.rb
@@ -27,7 +27,7 @@ class Page::DataExtractor
         if node.header_level === 2
           sections << {
             header: header,
-            id: "##{header.to_url}",
+            id: "#{header.to_url}",
             subsections: []
           }
         end
@@ -35,7 +35,7 @@ class Page::DataExtractor
         if node.header_level === 3 && !sections.empty?
           sections.last[:subsections] << {
             header: header,
-            id: "##{header.to_url}",
+            id: "#{header.to_url}",
           }
         end
       when :paragraph, :code_block

--- a/app/views/application/_toc.html.erb
+++ b/app/views/application/_toc.html.erb
@@ -1,0 +1,29 @@
+  <% if @page.metadata[:toc] %>
+    <nav class="Toc">
+      <button class="Toc__toggle">
+        <h2 class="Toc__title">On this page</h2>
+      </button>
+      <ul class="Toc__list Toc__list--is-collapsed">
+        <% @page.sections.each do |section| %>
+          <li class="Toc__list-item">
+            <a class="Toc__link Toc__link--h2" href="<%= section[:id] %>">
+              <%= section[:header] %>
+            </a>
+
+            <% if section[:subsections].count && @page.metadata[:toc_include_h3] %>
+              <ul class="Toc__list">
+                <% section[:subsections].each do |subsection| %>
+                  <li class="Toc__list-item">
+                    <a class="Toc__link Toc__link--h3" href="<%= subsection[:id] %>">
+                      <%= subsection[:header] %>
+                    </a>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+
+          </li>
+        <% end %>
+      </ul>
+    </nav>
+  <% end %>

--- a/app/views/application/_toc.html.erb
+++ b/app/views/application/_toc.html.erb
@@ -6,7 +6,7 @@
       <ul class="Toc__list Toc__list--is-collapsed">
         <% @page.sections.each do |section| %>
           <li class="Toc__list-item">
-            <a class="Toc__link Toc__link--h2" href="<%= section[:id] %>">
+            <a class="Toc__link Toc__link--h2" href="#<%= section[:id] %>">
               <%= section[:header] %>
             </a>
 
@@ -14,7 +14,7 @@
               <ul class="Toc__list">
                 <% section[:subsections].each do |subsection| %>
                   <li class="Toc__list-item">
-                    <a class="Toc__link Toc__link--h3" href="<%= subsection[:id] %>">
+                    <a class="Toc__link Toc__link--h3" href="#<%= "#{section[:id]}-#{subsection[:id]}" %>">
                       <%= subsection[:header] %>
                     </a>
                   </li>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -15,6 +15,19 @@
             <a class="Toc__link" href="<%= section[:id] %>">
               <%= section[:header] %>
             </a>
+
+            <% if section[:subsections].count && @page.metadata[:h3s] %>
+              <ul class="Toc__list--h3">
+                <% section[:subsections].each do |subsection| %>
+                  <li class="Toc__list-item">
+                    <a class="Toc__link" href="<%= section[:id] %>">
+                      <%= subsection[:header] %>
+                    </a>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+
           </li>
         <% end %>
       </ul>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -4,33 +4,5 @@
 <%= @page.body %>
 
 <%= content_for :toc do %>
-  <% if @page.metadata[:toc] %>
-    <nav class="Toc">
-      <button class="Toc__toggle">
-        <h2 class="Toc__title">On this page</h2>
-      </button>
-      <ul class="Toc__list Toc__list--is-collapsed">
-        <% @page.sections.each do |section| %>
-          <li class="Toc__list-item">
-            <a class="Toc__link" href="<%= section[:id] %>">
-              <%= section[:header] %>
-            </a>
-
-            <% if section[:subsections].count && @page.metadata[:h3s] %>
-              <ul class="Toc__list--h3">
-                <% section[:subsections].each do |subsection| %>
-                  <li class="Toc__list-item">
-                    <a class="Toc__link" href="<%= section[:id] %>">
-                      <%= subsection[:header] %>
-                    </a>
-                  </li>
-                <% end %>
-              </ul>
-            <% end %>
-
-          </li>
-        <% end %>
-      </ul>
-    </nav>
-  <% end %>
+  <%= render 'toc' %>
 <% end %>

--- a/spec/models/page/data_extractor_spec.rb
+++ b/spec/models/page/data_extractor_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe Page::DataExtractor do
 
         More text goes here!
 
+        ### Meow
+
+        Sub section text
+
         ## Here's another!
 
         Yet more text goes in this section
@@ -57,8 +61,14 @@ RSpec.describe Page::DataExtractor do
         "attributes" => [],
         "name" => "Page title",
         "sections" => [
-          { id: "#heres-a-second-heading", header: "Here's a second heading"},
-          { id: "#heres-another", header: "Here's another!" },
+          {
+            id: "#heres-a-second-heading",
+            header: "Here's a second heading",
+            subsections: [
+              { id: "#meow", header: "Meow" },
+            ]
+          },
+          { id: "#heres-another", header: "Here's another!", subsections: [] },
         ],
         "shortDescription" => "Some description",
         "textContent" => <<~MD.strip

--- a/spec/models/page/data_extractor_spec.rb
+++ b/spec/models/page/data_extractor_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe Page::DataExtractor do
       })
     end
 
+    it "ignores h3s outside of sections" do
+      md = <<~MD
+        ### Meow
+
+        Sub section text
+      MD
+
+      expect(Page::DataExtractor.extract(md)).to include({
+        "sections" => []
+      })
+    end
+
     it "extracts sections from secondary headings" do
       md = <<~MD
         # Page title

--- a/spec/models/page/data_extractor_spec.rb
+++ b/spec/models/page/data_extractor_spec.rb
@@ -74,13 +74,13 @@ RSpec.describe Page::DataExtractor do
         "name" => "Page title",
         "sections" => [
           {
-            id: "#heres-a-second-heading",
+            id: "heres-a-second-heading",
             header: "Here's a second heading",
             subsections: [
-              { id: "#meow", header: "Meow" },
+              { id: "meow", header: "Meow" },
             ]
           },
-          { id: "#heres-another", header: "Here's another!", subsections: [] },
+          { id: "heres-another", header: "Here's another!", subsections: [] },
         ],
         "shortDescription" => "Some description",
         "textContent" => <<~MD.strip


### PR DESCRIPTION
Extract H3s from page content and optionally render them into the table of contents for pages that opt-in.

e.g. example.md

```markdown
---
h3s: true
---
```

I've used `h3s: true` as the configuration attribute but totally open to something more descriptive. Perhaps `toc_depth` or something along those lines? 

I've also left the styling wide open, perhaps @olyism has some feels on this one.

<img width="1112" alt="Screenshot 2023-04-17 at 4 30 07 pm" src="https://user-images.githubusercontent.com/656826/232402972-39f0787b-e4d7-437e-837b-181122179f9b.png">

