### PR TITLE
💄 Design styling fixes for Docs Week Q2

### DIFF
--- a/app/assets/stylesheets/base/_text_content.scss
+++ b/app/assets/stylesheets/base/_text_content.scss
@@ -15,6 +15,12 @@
   @include margin($margin);
 }
 
+@mixin code-bg {
+  background-color: $gray-300;
+  border-radius: $border-rounded;
+  padding: 0.185em 0.375em;
+}
+
 h1 {
   @include heading(3);
 }
@@ -143,16 +149,53 @@ h6 {
     &:hover {
       color: map-get($color-aliases, "text-link-hover");
     }
+
+    &:has(code) {
+      text-decoration: none;
+    }
   }
 
   code {
     font-family: "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono",
       Courier, monospace;
+
+    a {
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
   pre code {
     font-size: #{(16/18)}em;
     line-height: map-get($line-heights, "default");
   }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  a {
+    &:not([class]) {
+      > code {
+        @include code-bg;
+      }
+    }
+  }
+
+  li,
+  dt,
+  td,
+  th {
+    > code {
+      @include code-bg;
+    }
+  }
+
   em {
     font-style: italic;
   }
@@ -177,16 +220,6 @@ h6 {
   }
   iframe {
     border: 1px solid #ddd;
-  }
-  li,
-  p,
-  dt,
-  td,
-  th,
-  a {
-    > code {
-      font-size: 0.875rem;
-    }
   }
   table {
     font-size: 0.875rem;

--- a/app/assets/stylesheets/base/_text_content.scss
+++ b/app/assets/stylesheets/base/_text_content.scss
@@ -158,6 +158,7 @@ h6 {
   code {
     font-family: "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono",
       Courier, monospace;
+    font-size: $font-size-code;
 
     a {
       text-decoration: none;
@@ -166,10 +167,6 @@ h6 {
         text-decoration: underline;
       }
     }
-  }
-  pre code {
-    font-size: #{(16/18)}em;
-    line-height: map-get($line-heights, "default");
   }
 
   h1,
@@ -202,20 +199,30 @@ h6 {
   strong {
     font-weight: 600;
   }
+
+  .highlight {
+    font-size: 1rem;
+  }
+
   pre {
     word-break: break-all;
     word-wrap: break-word;
     border: 1px solid #ddd;
     padding: 0.8em 1em;
     border-radius: 5px;
-    font-size: #{(15/18)}rem;
     line-height: map-get($line-heights, "default");
     min-width: 0;
     white-space: pre-wrap;
+
     &.overflow-scroll {
       overflow: auto;
       word-break: normal;
       word-wrap: normal;
+    }
+
+    code {
+      font-size: $font-size-code;
+      line-height: map-get($line-heights, "default");
     }
   }
   iframe {

--- a/app/assets/stylesheets/base/_text_content.scss
+++ b/app/assets/stylesheets/base/_text_content.scss
@@ -143,6 +143,7 @@ h6 {
 
   a {
     color: map-get($color-aliases, "text-link");
+    text-underline-offset: 0.1em;
     transition: color $transition-speed;
     will-change: color;
 

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -62,8 +62,8 @@ $slate-900: #151921;
 $color-aliases: (
   "text-base": $charcoal-700,
   "text-lightest": $charcoal-400,
-  "text-link": $olive-700,
-  "text-link-hover": $olive-800,
+  "text-link": $purple-600,
+  "text-link-hover": $purple-700,
   "text-display": $slate-900,
   "text-body": $charcoal-400,
   "button-primary": $olive-700,

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -85,6 +85,7 @@ $color-aliases: (
 $font-size-base: 16px;
 $font-size-template: 0.9375rem;
 $font-size-body: 1.125rem;
+$font-size-code: 0.875em;
 $font-family-system: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
   "Helvetica Neue", Helvetica, sans-serif;
 $font-family-display: "Aeonik", $font-family-system;

--- a/app/assets/stylesheets/components/_copy_to_clipboard_button.scss
+++ b/app/assets/stylesheets/components/_copy_to_clipboard_button.scss
@@ -4,14 +4,14 @@
 
   transition: opacity 0.05s linear;
   font-family: $font-family-display;
-  font-size: 14px;
+  font-size: $font-size-template;
   font-weight: 400;
 
   opacity: 0;
   position: absolute;
   gap: 0.4em;
-  right: 0.4em;
-  top: 0.4em;
+  right: 0.45em;
+  top: 0.45em;
   padding: 0.4em;
   cursor: pointer;
 

--- a/app/assets/stylesheets/pages/_docs.scss
+++ b/app/assets/stylesheets/pages/_docs.scss
@@ -200,8 +200,8 @@ $color-green: rgb(3, 165, 98);
 }
 
 a.Docs__example-repo {
-  align-items: top;
   border: 1px solid #ccc;
+  color: map-get($color-aliases, "text-base");
   display: flex;
   padding: 15px;
   text-decoration: none;

--- a/pages/tutorials/getting_started.md
+++ b/pages/tutorials/getting_started.md
@@ -25,7 +25,9 @@ Choose a sample pipeline to use as your first pipeline:
 
     <a class="inline-block" href="https://buildkite.com/new?template=https://github.com/buildkite/bash-example" target="_blank" rel="nofollow"><img src="https://buildkite.com/button.svg" alt="Add Bash Example to Buildkite" class="no-decoration" width="160" height="30"></a>
 
+    <!-- vale off -->
     [powershell-example test repository](https://github.com/buildkite/powershell-example)
+    <!-- vale on -->
 
     <a class="inline-block" href="https://buildkite.com/new?template=https://github.com/buildkite/powershell-example" target="_blank" rel="nofollow"><img src="https://buildkite.com/button.svg" alt="Add PowerShell Example to Buildkite" class="no-decoration" width="160" height="30"></a>
 

--- a/pages/tutorials/getting_started.md
+++ b/pages/tutorials/getting_started.md
@@ -25,7 +25,7 @@ Choose a sample pipeline to use as your first pipeline:
 
     <a class="inline-block" href="https://buildkite.com/new?template=https://github.com/buildkite/bash-example" target="_blank" rel="nofollow"><img src="https://buildkite.com/button.svg" alt="Add Bash Example to Buildkite" class="no-decoration" width="160" height="30"></a>
 
-    [`powershell-example` test repository](https://github.com/buildkite/powershell-example)
+    [powershell-example test repository](https://github.com/buildkite/powershell-example)
 
     <a class="inline-block" href="https://buildkite.com/new?template=https://github.com/buildkite/powershell-example" target="_blank" rel="nofollow"><img src="https://buildkite.com/button.svg" alt="Add PowerShell Example to Buildkite" class="no-decoration" width="160" height="30"></a>
 


### PR DESCRIPTION
I'm packaging numerous styling tweaks planned for Docs Week into one PR. The changes are:

- Code styling improvements:
  - DOC-519: Make inline code more visually distinct
  - DOC-578: Fix headings with monospaced font
- DOC-602: Match internal link style with .com site and app (use purple)
- DOC-603: Fix copy button style (position alignment)

Manually tested in macOS Webkit and Windows Edge.

## Screenshots

### DOC-519: Make inline code more visually distinct

#### Before

<img width="954" alt="Screen Shot 2023-04-18 at 10 25 10 AM" src="https://user-images.githubusercontent.com/7202667/232638176-8ebe6b30-8e09-4bdf-9169-09e36ec0e655.png">

<img width="957" alt="Screen Shot 2023-04-18 at 10 25 24 AM" src="https://user-images.githubusercontent.com/7202667/232638200-e05411c7-7158-4096-8b6e-98f091874aae.png">

#### After

<img width="952" alt="Screen Shot 2023-04-18 at 10 25 40 AM" src="https://user-images.githubusercontent.com/7202667/232638225-10fc2d70-3db9-4293-aae4-67cb06e104a5.png">

<img width="963" alt="Screen Shot 2023-04-18 at 10 25 52 AM" src="https://user-images.githubusercontent.com/7202667/232638246-6b78505c-5384-4907-bfd8-de95131a43df.png">

### DOC-578: Fix headings with monospaced font

#### Before

<img width="480" alt="Screen Shot 2023-04-18 at 10 27 01 AM" src="https://user-images.githubusercontent.com/7202667/232638347-01fccfc7-e74b-4c19-8976-7ee48ffaf37c.png">

#### After

<img width="546" alt="Screen Shot 2023-04-18 at 10 27 19 AM" src="https://user-images.githubusercontent.com/7202667/232638369-33d01f30-6897-4616-bec4-0ca71761c183.png">

### DOC-602: Match internal link style with .com site and app (use purple)

#### Before

<img width="948" alt="Screen Shot 2023-04-18 at 10 27 49 AM" src="https://user-images.githubusercontent.com/7202667/232638422-d97c9730-c23f-436b-9b2b-b3de547cb21b.png">

#### After

<img width="945" alt="Screen Shot 2023-04-18 at 10 28 03 AM" src="https://user-images.githubusercontent.com/7202667/232638454-c0766f21-54ef-4add-897d-03ce29023d72.png">

### DOC-603: Fix copy button style (position alignment)

#### Before

<img width="936" alt="Screen Shot 2023-04-18 at 10 28 57 AM" src="https://user-images.githubusercontent.com/7202667/232638555-d2eba340-7fd0-476b-b4a1-e040ebba2c82.png">

#### After

<img width="932" alt="Screen Shot 2023-04-18 at 10 29 11 AM" src="https://user-images.githubusercontent.com/7202667/232638588-81a17b2b-5e24-4991-a045-3e3dc1e73b33.png">
