### PR TITLE
Add H3s to the on-page nav by default

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -144,8 +144,8 @@ class Page
     defaults = {
       # Default to rendering table of contents
       "toc": true,
-      # Default to H2s being included in the table of contents
-      "toc_include_h3": false
+      # Default to H3s being included in the table of contents
+      "toc_include_h3": true
     }
     if file.front_matter
       defaults.merge(file.front_matter.symbolize_keys)

--- a/pages/agent/v3/aws.md
+++ b/pages/agent/v3/aws.md
@@ -1,3 +1,7 @@
+---
+toc_include_h3: false
+---
+
 # Running Buildkite Agent on AWS
 
 The Buildkite Agent can be run on AWS using our Elastic CI Stack for AWS

--- a/pages/agent/v3/elastic_ci_aws.md
+++ b/pages/agent/v3/elastic_ci_aws.md
@@ -1,3 +1,7 @@
+---
+toc_include_h3: false
+---
+
 # Elastic CI Stack for AWS
 
 The Buildkite Elastic CI Stack for AWS gives you a private, autoscaling [Buildkite agent](/docs/agent/v3) cluster. Use it to parallelize large test suites across hundreds of nodes, run tests and deployments for Linux or Windows based services and apps, or run AWS ops tasks.

--- a/pages/integrations/sso.md
+++ b/pages/integrations/sso.md
@@ -1,3 +1,7 @@
+---
+toc_include_h3: false
+---
+
 # Single sign-on support
 
 You can use a single sign-on (SSO) provider to protect access to your organization's data in Buildkite. Buildkite supports many different SSO providers, and you can configure multiple SSO providers for a single Buildkite organization.

--- a/pages/integrations/sso/sso_setup_with_graphql.md
+++ b/pages/integrations/sso/sso_setup_with_graphql.md
@@ -1,3 +1,7 @@
+---
+toc_include_h3: false
+---
+
 # Setting up single sign-on with GraphQL
 
 Buildkite's single sign-on (SSO) can be set up by emailing support, or you can set it up manually using our [GraphQL APIs](/docs/apis/graphql-api). This tutorial covers how to set up SSO manually using GraphQL.

--- a/pages/pipelines/notifications.md
+++ b/pages/pipelines/notifications.md
@@ -1,3 +1,7 @@
+---
+toc_include_h3: false
+---
+
 # Triggering notifications
 
 The `notify` attribute allows you to trigger build notifications to different services. You can also choose to conditionally send notifications based on pipeline events like build state.

--- a/pages/pipelines/scheduled_builds.md
+++ b/pages/pipelines/scheduled_builds.md
@@ -1,7 +1,3 @@
----
-toc_include_h3: true
----
-
 # Scheduled builds
 
 Build schedules automatically create builds at specified intervals. For example, you can use scheduled builds to run nightly builds, hourly integration tests, or daily ops tasks.


### PR DESCRIPTION
This change switches the default behavior of the on-page nav to include H3s by default. Almost all pages benefit from showing their H3s. Those that don't have been excluded in this PR.

I've also removed any usage of `toc_include_h3: true` now that it's the default behavior.