### PR TITLE
Update BUILDKITE_MESSAGE empty scenario

### DIFF
--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -269,7 +269,7 @@ variables:
     - false
 - name: BUILDKITE_MESSAGE
   desc: |
-    The message associated with the build, usually the commit message.
+    The message associated with the build, usually the commit message. This value can be blank if message is not set when builds manually triggered using Buildkite web interface.
   modifiable: false
   example: "Added a great new feature"
 - name: BUILDKITE_ORGANIZATION_SLUG

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -269,7 +269,7 @@ variables:
     - false
 - name: BUILDKITE_MESSAGE
   desc: |
-    The message associated with the build, usually the commit message. This value can be blank if message is not set when builds manually triggered using Buildkite web interface.
+    The message associated with the build, usually the commit message. The value is empty when a message is not set. For example, when a user triggers a build from the Buildkite dashboard without entering a message, the variable returns an empty value.
   modifiable: false
   example: "Added a great new feature"
 - name: BUILDKITE_ORGANIZATION_SLUG


### PR DESCRIPTION
This PR updates the explanation of environment variable BUILDKITE_MESSAGE where it can be empty of build is triggered from UI and user does not set the message in the build dialog box