### PR TITLE
Load nav into memory on app startup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,17 +8,11 @@ class ApplicationController < ActionController::Base
   private
 
   def default_nav
-    @_nav ||= Nav.new(
-      request.path,
-      YAML.load_file(File.join(Rails.root, 'data', 'nav.yml'))
-    )
+    Rails.application.config.default_nav
   end
 
   def graphql_nav
-    @_graphql_nav ||= Nav.new(
-      request.path,
-      YAML.load_file(File.join(Rails.root, 'data', 'nav_graphql.yml'))
-    )
+    Rails.application.config.graphql_nav
   end
 
   # capture some extra data so we can log it with lograge

--- a/app/models/nav.rb
+++ b/app/models/nav.rb
@@ -1,18 +1,20 @@
 class Nav
-  attr_reader :data, :path
+  attr_reader :data
 
-  def initialize(path, data = [])
+  def initialize(data = [])
     @data = data.freeze
-    @path = path
+    route_map
   end
 
-  def current_item_root
-    data.find { |item| item["name"] == current_item[:parents][0] }
+  # Returns the current nav item's root
+  def current_item_root(request)
+    current = current_item(request)
+    data.find { |item| item["name"] == current[:parents][0] }
   end
 
   # Returns the current nav item
-  def current_item
-    item = route_map[path.sub("/docs/", "")]
+  def current_item(request)
+    item = route_map[request.path.sub("/docs/", "")]
     raise ActionController::RoutingError.new("Missing navigation for #{path}") unless item
     item
   end

--- a/app/views/application/_nav.html.erb
+++ b/app/views/application/_nav.html.erb
@@ -2,7 +2,7 @@
   <%=
     render 'nav_children',
     children: @nav.data,
-    current_nav_item: @nav.current_item,
+    current_nav_item: @nav.current_item(request),
     is_dropdown: nil,
     nav_level: 0,
     start_expanded: true,

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -1,8 +1,8 @@
 <nav class="Nav Nav--sidebar">
   <%=
     render 'nav_children',
-    children: @nav.current_item_root["children"],
-    current_nav_item: @nav.current_item,
+    children: @nav.current_item_root(request)["children"],
+    current_nav_item: @nav.current_item(request),
     is_dropdown: nil,
     nav_level: 1,
     start_expanded: true,

--- a/config/initializers/nav.rb
+++ b/config/initializers/nav.rb
@@ -1,0 +1,8 @@
+Rails.application.configure do
+  config.default_nav = Nav.new(
+    YAML.load_file(File.join(Rails.root, 'data', 'nav.yml'))
+  )
+  config.graphql_nav = Nav.new(
+    YAML.load_file(File.join(Rails.root, 'data', 'nav_graphql.yml'))
+  )
+end

--- a/spec/models/nav_spec.rb
+++ b/spec/models/nav_spec.rb
@@ -4,15 +4,13 @@ RSpec.describe Nav do
   let(:data) { YAML.load_file("#{Rails.root}/data/nav.yml") }
   let(:nav) { Nav.new(data) }
 
-  describe '#nav_tree' do
+  describe '#current_item' do
     it 'returns the nav data' do
-      expect(nav.data).to eq([])
-    end
-  end
-
-  describe '#route_map' do
-    it 'returns a hash of routes' do
-      expect(nav.route_map).to eq({})
+      request = double('request', path: '/docs/tutorials/getting-started')
+      expect(nav.current_item(request)).to eq({
+        parents: ["Pipelines"],
+        path: "tutorials/getting-started",
+      })
     end
   end
 end

--- a/spec/models/nav_spec.rb
+++ b/spec/models/nav_spec.rb
@@ -1,11 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe Nav do
-  let(:data) { YAML.load_file("#{Rails.root}/data/nav.yml") }
+  let(:data) do
+    [
+      {
+          name: "Pipelines",
+          path: "pipelines",
+          children: [
+            {
+              name: "Getting Started",
+              path: "tutorials/getting-started",
+            }.stringify_keys
+          ]
+        }.stringify_keys
+      ]
+  end
+
   let(:nav) { Nav.new(data) }
 
+  describe "#route_map" do
+    it "returns a hash of routes, indexed by path" do
+      expect(nav.route_map).to eq({
+        "tutorials/getting-started" => {
+          path: "tutorials/getting-started",
+          parents: ["Pipelines"]
+        }
+      })
+    end
+  end
+
+
+  describe '#current_item_root' do
+    it 'returns a nav tree' do
+      request = double('request', path: '/docs/tutorials/getting-started')
+      expect(nav.current_item_root(request)).to eq(data[0])
+    end
+  end
+
   describe '#current_item' do
-    it 'returns the nav data' do
+    it 'returns a nav item' do
       request = double('request', path: '/docs/tutorials/getting-started')
       expect(nav.current_item(request)).to eq({
         parents: ["Pipelines"],


### PR DESCRIPTION
The navigation data is loaded from YAML and transformed into a structured for fast lookup when highlighting the active path. This data never changes so we can do this once on app startup. 