### PR TITLE
Work around listen gem issue

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,5 +45,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end


### PR DESCRIPTION
There seems to be an issue with the listen gem running on linux/amd64 which prevents the app from running on docker. 

I found a [workaround](https://github.com/evilmartians/terraforming-rails/issues/34#issuecomment-1347442704) which seems fine since we're likely to stop using sprockets (https://github.com/buildkite/docs/pull/2064)

