### PR TITLE
Update dev docs for installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ or use [`rbenv`](https://github.com/rbenv/rbenv) to automatically select the cor
    For non-containerized development, run:
 
    ```bash
-   # Install the dependencies
-   bundle
+   # Install dependencies
+   bin/setup
 
    # Start the app
    foreman start

--- a/bin/setup
+++ b/bin/setup
@@ -18,7 +18,7 @@ chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  system 'bin/yarn'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'


### PR DESCRIPTION
Now that docs uses Vite for assets we need to install node deps (via yarn) as part of setup. 

cc / @123sarahj123