### PR TITLE
Cache responses in Cloudfront

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
-  helper_method :probably_authenticated?
-
   def route_not_found
     render file: Rails.root.join("public","404.html"), layout: false, status: 404
   end
@@ -19,12 +17,5 @@ class ApplicationController < ActionController::Base
     payload[:request_id] = request.headers.fetch("X-Amzn-Trace-Id", request.request_id)
     payload[:remote_ip] = request.remote_ip
     payload[:user_agent] = request.user_agent
-  end
-
-
-  # When you login to Buildkite, we set this cookie as an indicator for other
-  # services that the user *may* be logged in.
-  def probably_authenticated?
-    request.cookie_jar[:bk_logged_in] == "true"
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,12 +3,15 @@ class PagesController < ApplicationController
   layout :layout_by_path
 
   def index
-    @nav = default_nav
+    expires_in 5.minutes, public: true, must_revalidate: true
 
+    @nav = default_nav
     render :index, layout: "homepage"
   end
 
   def show
+    expires_in 5.minutes, public: true, must_revalidate: true
+
     @nav = default_nav
     @page = Page.new(view_context, params[:path])
 
@@ -20,6 +23,7 @@ class PagesController < ApplicationController
     unless @page.is_canonical?
       redirect_to "/docs/#{@page.canonical_url}", status: :moved_permanently
     end
+
 
     # Otherwise, render the page (the default)
   end

--- a/app/views/application/_algolia.html.erb
+++ b/app/views/application/_algolia.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_tag nonce: true do %>
+<%= javascript_tag do %>
   /* This api key is intentionally public */
   docsearch({
     apiKey: '<%= algolia_api_key %>',

--- a/app/views/application/_analytics.html.erb
+++ b/app/views/application/_analytics.html.erb
@@ -1,5 +1,5 @@
 
-<%= javascript_tag nonce: true do %>
+<%= javascript_tag do %>
 var getFirstSource = function() {
   const firstSourceCookie = '_first_lead_source',
         firstReferrerCookie = '_first_referrer',
@@ -76,7 +76,7 @@ var getFirstSource = function() {
 <% end %>
 
 
-<%= javascript_tag nonce: true do %>
+<%= javascript_tag do %>
    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="<%= ENV['SEGMENT_TRACKING_ID'] %>";;analytics.SNIPPET_VERSION="4.15.3";
     analytics.load("<%= ENV['SEGMENT_TRACKING_ID'] %>");
     analytics.page({

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -45,9 +45,9 @@
 <% unless hide_feedback %>
   <% emojicom_campaign_id = Rails.env.production? ? '7O7Rc8JaykqXiCmaqe1C' : 'YeriBgQjRQmOU3br2W1g' %>
   <!-- Start emojicom.io widget -->
-  <%= javascript_tag nonce: true do %>
+  <%= javascript_tag do %>
     window.emojicom_widget = { campaign: "<%= emojicom_campaign_id %>" };
   <% end %>
-  <%= javascript_include_tag 'https://cdn.emojicom.io/embed/widget.js', async: true, nonce: true %>
+  <%= javascript_include_tag 'https://cdn.emojicom.io/embed/widget.js', async: true %>
   <!-- End emojicom.io widget -->
 <% end %>

--- a/app/views/application/_global_links.html.erb
+++ b/app/views/application/_global_links.html.erb
@@ -12,16 +12,10 @@
       </ul>
     </div>
   </li>
-  <% if probably_authenticated? %>
-    <li class="GlobalLinks__call-to-action">
-      <%= link_to "Dashboard", dashboard_path, class: "Button Button--purple Button--small" %>
-    </li>
-  <% else %>
-    <li>
-      <%= link_to "Login", "https://buildkite.com/login", class: "Button Button--link Button--small" %>
-    </li>
-    <li class="GlobalLinks__call-to-action">
-      <%= link_to "Sign up for free", "https://buildkite.com/signup", class: "Button Button--purple Button--small" %>
-    </li>
-  <% end %>
+  <li>
+    <%= link_to "Login", "https://buildkite.com/login", class: "Button Button--secondary Button--small" %>
+  </li>
+  <li class="GlobalLinks__call-to-action">
+    <%= link_to "Sign up", "https://buildkite.com/signup", class: "Button Button--purple Button--small" %>
+  </li>
 </ul>

--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -10,9 +10,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <%= stylesheet_link_tag "docsearch", "application", media: "all" %>
 
-<%= javascript_include_tag "docsearch", nonce: true %>
-
-<%= csp_meta_tag %>
+<%= javascript_include_tag "docsearch" %>
 
 <meta name="referrer" content="origin-when-cross-origin" />
 

--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -35,7 +35,7 @@
 <meta property="og:site_name" content="Buildkite" />
 <meta property="og:locale" content="en_US" />
 
-<%= render 'analytics', application: 'docs', title: "Docs / #{content_for(:page_title)}", logged_in: probably_authenticated? %>
+<%= render 'analytics' %>
 
 <% if ENV.fetch("ROBOTS_NO_INDEX") { "false" } == "true" %>
   <meta name="robots" content="noindex, nofollow">

--- a/app/views/application/_helpscout.html.erb
+++ b/app/views/application/_helpscout.html.erb
@@ -1,2 +1,4 @@
-!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
-window.Beacon('init', "<%= ENV.fetch('HELPSCOUT_BEACON_ID', "1d032e87-e8df-4c7f-a423-a6825b9752a2")%>");
+<%= javascript_tag do -%>
+  !function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
+  window.Beacon('init', "<%= ENV.fetch('HELPSCOUT_BEACON_ID', "1d032e87-e8df-4c7f-a423-a6825b9752a2")%>");
+<% end %>

--- a/app/views/application/_helpscout.html.erb
+++ b/app/views/application/_helpscout.html.erb
@@ -1,4 +1,2 @@
-<%= javascript_tag nonce: true do -%>
-  !function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
-  window.Beacon('init', "<%= ENV.fetch('HELPSCOUT_BEACON_ID', "1d032e87-e8df-4c7f-a423-a6825b9752a2")%>");
-<% end %>
+!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
+window.Beacon('init', "<%= ENV.fetch('HELPSCOUT_BEACON_ID', "1d032e87-e8df-4c7f-a423-a6825b9752a2")%>");

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -32,6 +32,7 @@ Rails.application.config.content_security_policy do |policy|
 
   policy.script_src(
     :self,
+    :unsafe_inline,
     "https://www.googletagmanager.com/",
     "https://cdn.segment.com/",
     "https://cdn.emojicom.io/",
@@ -68,9 +69,6 @@ Rails.application.config.content_security_policy do |policy|
   # Specify URI for violation reports
   policy.report_uri "/_csp-violation-reports"
 end
-
-# We use nonce for inline scripts
-Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:


### PR DESCRIPTION
Cloudfront CDN now sits between the client and our application which means we can start thinking about caching HTTP responses for a snappier user experience.

This PR does a few things to enable HTTP caching. 

- **Render Login + Signup for all users regardless of them having a session.** This one might be contentious! By removing the `probably_authenticated` check we can serve up the same cached response for all HTTP requests. A user can still access their dashboard by clicking either of those links once they're logged in. 
- **Set `Cache-Control` headers**:
  - `public` – this one lets Cloudfront it's allowed to cache it
  - `max-age` - whilst testing cache content for a maximum of 5 minutes
  - `must-revalidated` - check origin server (our app) to see if content is still fresh using etag
- **Remove Rails CSP `nonce` generation**  😬 
  - this change removes nonce generation which was causing the Etag header to regenerate for every request - effectively preventing a page from being cached. 
  - Since our CSP isn't currently being enforced this is pretty harmless but it would be nice to property lock down our CSP. 
  - We should come back around on this once we fix up our CSP for `inline-eval` (see https://github.com/buildkite/docs/pull/681) . 