### PR TITLE
update matrix limits to correct values

### DIFF
--- a/pages/pipelines/build_matrix.md
+++ b/pages/pipelines/build_matrix.md
@@ -137,7 +137,7 @@ To remove a combination from the matrix, add it to the `adjustments` key and set
 
 ## Matrix limits
 
-Each build matrix has a limit of 10 dimensions, 10 elements in each dimension and a total of 10 adjustments.
+Each build matrix has a limit of 6 dimensions, 20 elements in each dimension and a total of 12 adjustments.
 
 ## Grouping matrix elements
 


### PR DESCRIPTION
This update adjusts the section in our docs that relates to matrix limits. The current limits have changed and our documentation still provides the old values. This update will bring the limits in line with the code base.