### PR TITLE
Update `inline_link` method example to work with encoded URLs

### DIFF
--- a/pages/pipelines/links_and_images_in_log_output.md
+++ b/pages/pipelines/links_and_images_in_log_output.md
@@ -16,7 +16,7 @@ function inline_link {
   LINK=$(printf "url='%s'" "$1")
 
   if [ $# -gt 1 ]; then
-    LINK=$(printf "$LINK;content='%s'" "$2")
+    LINK=$(printf "%s;content='%s'" "$LINK" "$2")
   fi
 
   printf '\033]1339;%s\a\n' "$LINK"


### PR DESCRIPTION
## Summary

Before this documentation change, the `inline_link` method:
- Generated a link for a decoded URL
- Generated a link for a decoded URL and a custom label
- Generated a link for an encoded URL
- Could not generate a link for an encoded URL and a custom label

This documentation change allows the `inline_link` example function to generate links for encoded URLs and custom labels correctly.

## A more technical summary

When using the current example function:
```sh
inline_link "https://buildkite.com/"
# url='https://buildkite.com/'

inline_link "https://buildkite.com/%20"
# url='https://buildkite.com/%20'

inline_link "https://buildkite.com/" "test"
# url='https://buildkite.com/';content='test'

inline_link "https://buildkite.com/%20" "test"
# inline_link:printf:4: %20': invalid directive
# url='https://buildkite.com/
```

When using the new example function:
```sh
inline_link "https://buildkite.com/"
# url='https://buildkite.com/'

inline_link "https://buildkite.com/%20"
# url='https://buildkite.com/%20'

inline_link "https://buildkite.com/" "test"
# url='https://buildkite.com/';content='test'

inline_link "https://buildkite.com/%20" "test"
# url='https://buildkite.com/%20';content='test'
```

Because `printf` wasn't substituting the value of `$LINK`, it was trying to interpret the `%` symbol in `%20` as a directive (similar to the `%s` directive).
