### PR TITLE
Wrap long inline-code blocks

### DIFF
--- a/app/assets/stylesheets/base/_article.scss
+++ b/app/assets/stylesheets/base/_article.scss
@@ -102,6 +102,7 @@
     font-family: "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono",
       Courier, monospace;
     font-size: $font-size-code;
+    overflow-wrap: anywhere;
 
     a {
       text-decoration: none;


### PR DESCRIPTION
Similar to https://github.com/buildkite/docs/pull/2073 this fixes long code snippets from overflowing content. 