### PR TITLE
Fix broken image styles

### DIFF
--- a/app/assets/stylesheets/base/_article.scss
+++ b/app/assets/stylesheets/base/_article.scss
@@ -265,14 +265,6 @@
     margin-top: 0;
   }
 
-  img:not(.emoji):not(.TileItem__image),
-  svg {
-    border: 1px solid #eee;
-    border-radius: 5px;
-    box-sizing: border-box;
-    padding: 5px;
-  }
-
   details {
     background-color: map-get($color-aliases, "panel-background");
     display: inline-block;
@@ -344,12 +336,6 @@
     }
   }
 
-  img.no-decoration,
-  .responsive-image-container.no-decoration {
-    padding: 0;
-    border: none;
-    margin: 0;
-  }
   img.emoji {
     padding: 0;
     border: none;
@@ -363,13 +349,11 @@
   thead th {
     font-weight: 600;
   }
-  .image,
+
   img {
     max-width: 100%;
   }
-  .responsive-image-container {
-    margin: 0.5rem 0 2rem 0;
-  }
+
   li .responsive-image-container {
     margin: 0.5rem 0 0 0;
   }

--- a/app/assets/stylesheets/utilities/_responsive_image_container.scss
+++ b/app/assets/stylesheets/utilities/_responsive_image_container.scss
@@ -1,5 +1,13 @@
 .responsive-image-container {
   max-width: 100%;
+  border: 1px solid #eee;
+  border-radius: 5px;
+  box-sizing: border-box;
+  padding: 5px;
+
+  // FIXME: spacing should be handled by the parent element
+  margin: 0.5rem 0 2rem 0;
+
   img {
     height: auto;
     max-width: 100%;

--- a/app/assets/stylesheets/utilities/_responsive_image_container.scss
+++ b/app/assets/stylesheets/utilities/_responsive_image_container.scss
@@ -13,3 +13,9 @@
     max-width: 100%;
   }
 }
+
+.no-decoration {
+  padding: 0;
+  border: none;
+  margin: 0;
+}

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -73,10 +73,14 @@ class Page
 
     def responsive_image_tag(image, width, height, image_tag_options={}, &block)
       max_width = image_tag_options.delete(:max_width)
-      container = content_tag :div, image_tag(image, image_tag_options), class: ["responsive-image-container", image_tag_options[:class]]
+
+      img_class = image_tag_options.delete(:class).try(:split, " ") || []
+      img_class << "responsive-image-container"
+
+      container = content_tag :div, image_tag(image, image_tag_options), class: img_class
 
       if max_width
-        content_tag :div, container, style: "max-width: #{max_width}px", class: image_tag_options[:class]
+        content_tag :div, container, style: "max-width: #{max_width}px"
       else
         container
       end

--- a/pages/tutorials/getting_started.md
+++ b/pages/tutorials/getting_started.md
@@ -26,7 +26,9 @@ Choose a sample pipeline to use as your first pipeline:
     <a class="inline-block" href="https://buildkite.com/new?template=https://github.com/buildkite/bash-example" target="_blank" rel="nofollow"><img src="https://buildkite.com/button.svg" alt="Add Bash Example to Buildkite" class="no-decoration" width="160" height="30"></a>
 
     <!-- vale off -->
+
     [powershell-example test repository](https://github.com/buildkite/powershell-example)
+
     <!-- vale on -->
 
     <a class="inline-block" href="https://buildkite.com/new?template=https://github.com/buildkite/powershell-example" target="_blank" rel="nofollow"><img src="https://buildkite.com/button.svg" alt="Add PowerShell Example to Buildkite" class="no-decoration" width="160" height="30"></a>


### PR DESCRIPTION
I noted we're rendering some `<!-- vale` comments and applying some global image styles to the [getting started page](https://buildkite.com/docs/tutorials/getting-started).

This PR does some housekeeping to remove the need to opt-out of certain image styles hopefully preventing images from breaking in the future.

Before:
<img width="634" alt="Screenshot 2023-04-27 at 10 41 13 am" src="https://user-images.githubusercontent.com/656826/234731301-4daa6da9-4d9e-4ed5-819b-5f21869925d0.png">

After:
<img width="634" alt="Screenshot 2023-04-27 at 10 41 26 am" src="https://user-images.githubusercontent.com/656826/234731312-642399a1-e942-4e96-ad9a-acf8288a054d.png">
