### PR TITLE
Added note about the agent release in which `BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH` is introduced

### DIFF
--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -234,7 +234,7 @@ attributes:
   default_value: "false"
   required: false
   desc: |
-      Force checking out a fresh clone of plugins every build. By default, if the organization, repository, and version tag of a plugin specified in a step match a plugin that is already on the agent, the agent uses that local version. Forcing fresh checkout is especially useful during plugin development. Introduced in [v3.37](https://github.com/buildkite/agent/releases/tag/v3.37.0).
+      Force checking out a fresh clone of plugins every build. By default, if the organization, repository, and version tag of a plugin specified in a step match a plugin that is already on the agent, the agent uses that local version. Forcing fresh checkout is especially useful during plugin development. Available from [v3.37](https://github.com/buildkite/agent/releases/tag/v3.37.0).
 - name: priority
   env_var: BUILDKITE_AGENT_PRIORITY
   default_value: "null"

--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -234,7 +234,7 @@ attributes:
   default_value: "false"
   required: false
   desc: |
-      Force checking out a fresh clone of plugins every build. By default, if the organization, repository, and version tag of a plugin specified in a step match a plugin that is already on the agent, the agent uses that local version. Forcing fresh checkout is especially useful during plugin development.
+      Force checking out a fresh clone of plugins every build. By default, if the organization, repository, and version tag of a plugin specified in a step match a plugin that is already on the agent, the agent uses that local version. Forcing fresh checkout is especially useful during plugin development. Introduced in [v3.37](https://github.com/buildkite/agent/releases/tag/v3.37.0).
 - name: priority
   env_var: BUILDKITE_AGENT_PRIORITY
   default_value: "null"

--- a/pages/plugins/writing.md
+++ b/pages/plugins/writing.md
@@ -238,7 +238,7 @@ Next, add a `README.md` file to introduce the plugin to the world:
 
 When developing plugins, it is useful to have a quick feedback loop between making a change in your plugin code, and seeing the effects in a Buildkite pipeline. Let's say you're developing your feature on `my-org/plugin#dev-branch`. *By default*, if a Buildkite agent sees that it needs the plugin `my-org/plugin#dev-branch`, and it already has a checkout matching that, it will *not* pull any changes from the Git repository. But if you *do* want to see changes reflected immediately, set [`plugins-always-clone-fresh`](/docs/agent/v3/configuration#plugins-always-clone-fresh) to `true`.
 
-One way to try this is to add the following step to the Buildkite pipeline where you're testing your plugin.  Configuring `BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH` on only one step means that other plugins, which are unlikely to be changing in the meantime, won't get unnecessarily cloned on every step invocation. This needs agent version v3.37.0 or above as configuration `BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH` is introduced in that release.
+One way to try this is to add the following step to the Buildkite pipeline where you're testing your plugin.  Configuring `BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH` on only one step means that other plugins, which are unlikely to be changing in the meantime, won't get unnecessarily cloned on every step invocation. You need agent version v3.37.0 or above to use `BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH`.
 
 ```yml
 steps:

--- a/pages/plugins/writing.md
+++ b/pages/plugins/writing.md
@@ -238,7 +238,7 @@ Next, add a `README.md` file to introduce the plugin to the world:
 
 When developing plugins, it is useful to have a quick feedback loop between making a change in your plugin code, and seeing the effects in a Buildkite pipeline. Let's say you're developing your feature on `my-org/plugin#dev-branch`. *By default*, if a Buildkite agent sees that it needs the plugin `my-org/plugin#dev-branch`, and it already has a checkout matching that, it will *not* pull any changes from the Git repository. But if you *do* want to see changes reflected immediately, set [`plugins-always-clone-fresh`](/docs/agent/v3/configuration#plugins-always-clone-fresh) to `true`.
 
-One way to try this is to add the following step to the Buildkite pipeline where you're testing your plugin.  Configuring `BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH` on only one step means that other plugins, which are unlikely to be changing in the meantime, won't get unnecessarily cloned on every step invocation.
+One way to try this is to add the following step to the Buildkite pipeline where you're testing your plugin.  Configuring `BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH` on only one step means that other plugins, which are unlikely to be changing in the meantime, won't get unnecessarily cloned on every step invocation. This needs agent version v3.37.0 or above as configuration `BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH` is introduced in that release.
 
 ```yml
 steps:


### PR DESCRIPTION
We had a user who was trying to use `BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH` but it did not work as this feature was introduced in agent release v3.37.0 or above. This PR updates the pages to include a note that mentions release this configuration is introduced.