### PR TITLE
🐛 Only the `h1` need beta tag

### DIFF
--- a/app/assets/stylesheets/pages/_docs.scss
+++ b/app/assets/stylesheets/pages/_docs.scss
@@ -205,9 +205,8 @@ html {
 }
 
 body.beta {
-  .Page {
-    h1,
-    .Docs__heading {
+  .Article {
+    > h1:first-of-type {
       display: inline;
       position: relative;
 
@@ -215,9 +214,9 @@ body.beta {
         @include pill;
         @include pill-style(beta);
         @include pill-small;
-        left: 5px;
+        left: 1em;
         position: relative;
-        top: -5px;
+        top: -1em;
       }
     }
   }


### PR DESCRIPTION
A small frontend PR to fix the overuse of 'beta' tags on Docs article pages.

- Current behavior: when I set a page to beta, all headings on that page gets the 'beta' tag appended.
- Expected behavior: the beta tag is only needed on the nav item and the first heading for the user to become aware that it's beta 

## Screenshots

### Current behavior

![Screen Shot 2023-05-02 at 4 22 57 PM](https://user-images.githubusercontent.com/7202667/235593711-b38c87a2-7be4-474d-9cfb-44661f61b467.png)

### After the fix

![Screen Shot 2023-05-02 at 4 25 43 PM](https://user-images.githubusercontent.com/7202667/235594122-e32f493d-a31c-4e9c-9971-86203704369d.png)

## Notes on the change

### Pages fixed by this change

This fix resolves the problem for the Clusters page and five Test Analytics pages (beta collectors and flaky test API).

### Potential future improvements

This is fixed with a small styling change. However, it'd be worth to change how tags like 'beta' and 'deprecated' are handled throughout Docs, because currently it involves double-handling specifying it in `nav.yml` and `beta_pages.rb`.

Furthermore, the 'deprecated' tag is handled differently and defined only in `nav.yml` and it doesn't get appended to deprecated feature pages.
