### PR TITLE
Clarification on pipeline upload order

### DIFF
--- a/pages/pipelines/defining_steps.md
+++ b/pages/pipelines/defining_steps.md
@@ -260,7 +260,11 @@ To use this script, you'd save it to `.buildkite/pipeline.sh` inside your reposi
 .buildkite/pipeline.sh | buildkite-agent pipeline upload
 ```
 
-When the build is running it will execute the script and pipe the output to the `pipeline upload` command. The upload command will insert the steps from the script into the build immediately after the upload step.
+When the build is running it will execute the script and pipe the output to the `pipeline upload` command. The upload command will insert the steps from the script into the build immediately after the upload step, which means that if you execute it more than once in a single step you'll get those uploads steps appearing in reverse order.
+
+>📘
+> To avoid having the steps in a reverse order in the UI, we suggest to upload the steps in the opposite order you expect them (the things you want to run immediately last).
+
 
 In the below `pipeline.yml` example, when the build runs it will execute the `.buildkite/pipeline.sh` script, then the test steps from the script will be added to the build before the wait step and command step. After the test steps have run, the wait and command step will run.
 

--- a/pages/pipelines/defining_steps.md
+++ b/pages/pipelines/defining_steps.md
@@ -260,10 +260,10 @@ To use this script, you'd save it to `.buildkite/pipeline.sh` inside your reposi
 .buildkite/pipeline.sh | buildkite-agent pipeline upload
 ```
 
-When the build is running it will execute the script and pipe the output to the `pipeline upload` command. The upload command will insert the steps from the script into the build immediately after the upload step, which means that if you execute it more than once in a single step you'll get those uploads steps appearing in reverse order.
+When the build runs, it executes the script and pipes the output to the `pipeline upload` command. The upload command then inserts the steps from the script into the build immediately after the upload step.
 
->📘
-> To avoid having the steps in a reverse order in the UI, we suggest to upload the steps in the opposite order you expect them (the things you want to run immediately last).
+>📘 Step ordering
+> Since the upload command inserts steps immediately after the upload step, they appear in reverse order when you upload multiple steps in one command. To avoid the steps appearing in reverse order, we suggest you upload the steps in reverse order (the step you want to run first goes last). That way, they'll be in the expected order when inserted.
 
 
 In the below `pipeline.yml` example, when the build runs it will execute the `.buildkite/pipeline.sh` script, then the test steps from the script will be added to the build before the wait step and command step. After the test steps have run, the wait and command step will run.


### PR DESCRIPTION
When using multiple dynamic pipelines from the same step, these are shown in reverse order in the UI (i.e. steps uploaded in the second call to pipeline upload show up before the first call). This is confusing for some people and there's a workaround if they want to see them in the "expected" order