### PR TITLE
Fix link to `annotate` subcommand in annotation API doc page

### DIFF
--- a/pages/apis/rest_api/annotations.md
+++ b/pages/apis/rest_api/annotations.md
@@ -3,7 +3,7 @@
 
 ## Annotation data model
 
-An annotation is a snippet of Markdown uploaded by your agent during the execution of a build's job. Annotations are created using the [`buildkite-agent annotate` command](/docs/agent/v3/cli-pipeline) from within a job.
+An annotation is a snippet of Markdown uploaded by your agent during the execution of a build's job. Annotations are created using the [`buildkite-agent annotate` command](/docs/agent/v3/cli-annotate) from within a job.
 
 <table>
 <tbody>


### PR DESCRIPTION
Just ran into this - it points to the [`pipeline` subcommand](https://buildkite.com/docs/agent/v3/cli-pipeline) when it should point to the [`annotate` subcommand](https://buildkite.com/docs/agent/v3/cli-annotate).