### PR TITLE
Add Pausing Cluster Queues documentation

### DIFF
--- a/pages/agent/clusters.md
+++ b/pages/agent/clusters.md
@@ -53,19 +53,6 @@ To create additional queues:
 1. Enter a key and description.
 1. Select _Create Queue_.
 
-### Pause a queue
-
-Pausing a queue will prevent jobs from being dispatched to agents associated with that queue. This may affect builds targeting the paused queue.
-
-To pause a queue:
-1. Navigate to your cluster’s _Queues_.
-1. Click on the queue you wish to pause.
-1. Click _Edit_.
-1. Under _Queue Management_, click _Pause Queue_.
-1. Enter an optional note in the dialog if needed, and confirm that you wish to pause the queue.
-
-To resume the queue again, click Resume Queue.
-
 ### Connect agents to a cluster
 
 Agents are associated with a cluster through the cluster’s agent tokens.
@@ -102,6 +89,23 @@ To add a maintainer to a cluster:
 1. Navigate to the cluster’s _Maintainers_.
 1. Select a user or team.
 1. Click _Add Maintainer_.
+
+### Pause a queue
+
+You can pause a queue to prevent jobs from being dispatched to agents associated with that queue.
+To pause a queue:
+
+1. Navigate to your cluster’s _Queues_.
+1. Select on the queue you wish to pause.
+1. Select _Edit_.
+1. Under _Queue Management_, select _Pause Queue_.
+1. Enter an optional note in the dialog if needed, and confirm that you wish to pause the queue. The note will be displayed on the queue page, and any affected builds.
+
+Jobs which have _already_ been dispatched to agents in the queue prior to pausing will continue to run. New jobs which target the paused queue will 'wait' until the queue is resumed.
+
+Trigger steps do not rely on agents, so they will run unless they have a dependency that has been halted by the paused queue. The behaviour of the jobs they trigger depends on their configuration. If a triggered job targets the paused queue, it will 'wait' until the queue is resumed. If a triggered job does not target the pasued queue, it will run as usual.
+
+To resume the queue again, select _Resume Queue_. Once resumed, job dispatch to the queue will operate as usual, and any 'waiting' jobs affected by the pause will be picked up.
 
 ### Migrate to clusters
 

--- a/pages/agent/clusters.md
+++ b/pages/agent/clusters.md
@@ -90,7 +90,11 @@ To add a maintainer to a cluster:
 1. Select a user or team.
 1. Click _Add Maintainer_.
 
-### Pause a queue
+### Migrate to clusters
+
+If you migrate all your existing agents over to clusters, make sure to add all your pipelines to the relevant clusters. Otherwise, any builds for those pipelines will never find agents to run them.
+
+## Pause a queue
 
 You can pause a queue to prevent jobs from being dispatched to agents associated with that queue.
 
@@ -109,7 +113,3 @@ Jobs _already_ dispatched to agents in the queue before pausing will continue to
 Trigger steps do not rely on agents, so they will run unless they have dependencies waiting on the paused queue. The behavior of the jobs they trigger depends on their configuration. If a triggered job targets the paused queue, it will wait until the queue is resumed. If a triggered job does not target the paused queue, it will run as usual.
 
 Select _Resume Queue_ to resume a paused queue. Jobs will resume dispatching to the queue as usual, including any jobs waiting to run.
-
-### Migrate to clusters
-
-If you migrate all your existing agents over to clusters, make sure to add all your pipelines to the relevant clusters. Otherwise, any builds for those pipelines will never find agents to run them.

--- a/pages/agent/clusters.md
+++ b/pages/agent/clusters.md
@@ -106,7 +106,7 @@ To pause a queue:
 
 Jobs _already_ dispatched to agents in the queue before pausing will continue to run. New jobs that target the paused queue will wait until the queue is resumed.
 
-Trigger steps do not rely on agents, so they will run unless they have dependencies waiting on the paused queue. The behaviour of the jobs they trigger depends on their configuration. If a triggered job targets the paused queue, it will wait until the queue is resumed. If a triggered job does not target the paused queue, it will run as usual.
+Trigger steps do not rely on agents, so they will run unless they have dependencies waiting on the paused queue. The behavior of the jobs they trigger depends on their configuration. If a triggered job targets the paused queue, it will wait until the queue is resumed. If a triggered job does not target the paused queue, it will run as usual.
 
 Select _Resume Queue_ to resume a paused queue. Jobs will resume dispatching to the queue as usual, including any jobs waiting to run.
 

--- a/pages/agent/clusters.md
+++ b/pages/agent/clusters.md
@@ -93,19 +93,22 @@ To add a maintainer to a cluster:
 ### Pause a queue
 
 You can pause a queue to prevent jobs from being dispatched to agents associated with that queue.
+
 To pause a queue:
 
 1. Navigate to your cluster’s _Queues_.
-1. Select on the queue you wish to pause.
+1. Select the queue you wish to pause.
 1. Select _Edit_.
 1. Under _Queue Management_, select _Pause Queue_.
-1. Enter an optional note in the dialog if needed, and confirm that you wish to pause the queue. The note will be displayed on the queue page, and any affected builds.
+1. Enter an optional note in the dialog, and confirm that you wish to pause the queue.
 
-Jobs which have _already_ been dispatched to agents in the queue prior to pausing will continue to run. New jobs which target the paused queue will 'wait' until the queue is resumed.
+      You can use the note to explain why you're pausing the queue. The note will display on the queue page and any affected builds.
 
-Trigger steps do not rely on agents, so they will run unless they have a dependency that has been halted by the paused queue. The behaviour of the jobs they trigger depends on their configuration. If a triggered job targets the paused queue, it will 'wait' until the queue is resumed. If a triggered job does not target the paused queue, it will run as usual.
+Jobs _already_ dispatched to agents in the queue before pausing will continue to run. New jobs that target the paused queue will wait until the queue is resumed.
 
-To resume the queue again, select _Resume Queue_. Once resumed, job dispatch to the queue will operate as usual, and any 'waiting' jobs affected by the pause will be picked up.
+Trigger steps do not rely on agents, so they will run unless they have dependencies waiting on the paused queue. The behaviour of the jobs they trigger depends on their configuration. If a triggered job targets the paused queue, it will wait until the queue is resumed. If a triggered job does not target the paused queue, it will run as usual.
+
+Select _Resume Queue_ to resume a paused queue. Jobs will resume dispatching to the queue as usual, including any jobs waiting to run.
 
 ### Migrate to clusters
 

--- a/pages/agent/clusters.md
+++ b/pages/agent/clusters.md
@@ -53,6 +53,19 @@ To create additional queues:
 1. Enter a key and description.
 1. Select _Create Queue_.
 
+### Pause a queue
+
+Pausing a queue will prevent jobs from being dispatched to agents associated with that queue. This may affect builds targeting the paused queue.
+
+To pause a queue:
+1. Navigate to your cluster’s _Queues_.
+1. Click on the queue you wish to pause.
+1. Click _Edit_.
+1. Under _Queue Management_, click _Pause Queue_.
+1. Enter an optional note in the dialog if needed, and confirm that you wish to pause the queue.
+
+To resume the queue again, click Resume Queue.
+
 ### Connect agents to a cluster
 
 Agents are associated with a cluster through the cluster’s agent tokens.

--- a/pages/agent/clusters.md
+++ b/pages/agent/clusters.md
@@ -103,7 +103,7 @@ To pause a queue:
 
 Jobs which have _already_ been dispatched to agents in the queue prior to pausing will continue to run. New jobs which target the paused queue will 'wait' until the queue is resumed.
 
-Trigger steps do not rely on agents, so they will run unless they have a dependency that has been halted by the paused queue. The behaviour of the jobs they trigger depends on their configuration. If a triggered job targets the paused queue, it will 'wait' until the queue is resumed. If a triggered job does not target the pasued queue, it will run as usual.
+Trigger steps do not rely on agents, so they will run unless they have a dependency that has been halted by the paused queue. The behaviour of the jobs they trigger depends on their configuration. If a triggered job targets the paused queue, it will 'wait' until the queue is resumed. If a triggered job does not target the paused queue, it will run as usual.
 
 To resume the queue again, select _Resume Queue_. Once resumed, job dispatch to the queue will operate as usual, and any 'waiting' jobs affected by the pause will be picked up.
 


### PR DESCRIPTION
This PR is to get the ball rolling on the documentation for Pausing Cluster Queues. This is an upcoming feature that allows users to "Pause" a cluster queue. When paused, job dispatch to agents associated with that queue is prevented. When resumed, job dispatch picks up where it left off. At first, pausing queues will be possible via the Buildkite UI and GraphQL API only. We will be adding REST API support for this as part of upcoming Clusters work later on.

For this first draft I've made a 'best guess' at what to include, given the existing structure of the Clusters docs. I'm sure there's lots of room for improvement, so would love feedback on this. 

