### PR TITLE
Add metrics-datadog-distributions documentation

### DIFF
--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -154,6 +154,16 @@ attributes:
   required: false
   desc: |
         The DogStatsD instance to send metrics to using UDP.
+- name: metrics-datadog-distributions
+  env_var: BUILDKITE_METRICS_DATADOG_DISTRIBUTIONS
+  default_value: "false"
+  requires: false
+  desc: |
+      Use Datadog Distributions for Timing metrics. By default, we submit metrics via standard gauges. This will unfortunately cause issues if you have multiple agents running,
+      as components like buildkite.jobs.duration.success.median becomes a roll up of the median execution time _from each agent_. As each agent is likely only running a single job
+      at a time, this causes all time related histogram metrics (avg, max, median, 95percentile) from a given agent to be the same value.
+      Distributions, however, aggregate the metrics server side at Datadog, thus the median and 95percentile is calculated given the set of builds executing across all agents.
+      Learn more about [Datadog Distributions](Use Datadog Distributions for Timing metrics)
 - name: name
   env_var: BUILDKITE_AGENT_NAME
   default_value: "%hostname-%spawn"

--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -159,7 +159,7 @@ attributes:
   default_value: "false"
   requires: false
   desc: |
-      Use [Datadog Distributions](https://docs.datadoghq.com/metrics/types/?tab=distribution#metric-types) for timing metrics. This advisable when running multiple agents. Otherwise, metrics from multiple agents may be rolled up and appear to have the same value.
+      Use [Datadog Distributions](https://docs.datadoghq.com/metrics/types/?tab=distribution#metric-types) for timing metrics. This is advisable when running multiple agents. Otherwise, metrics from multiple agents may be rolled up and appear to have the same value.
 - name: name
   env_var: BUILDKITE_AGENT_NAME
   default_value: "%hostname-%spawn"

--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -163,7 +163,7 @@ attributes:
       as components like buildkite.jobs.duration.success.median becomes a roll up of the median execution time _from each agent_. As each agent is likely only running a single job
       at a time, this causes all time related histogram metrics (avg, max, median, 95percentile) from a given agent to be the same value.
       Distributions, however, aggregate the metrics server side at Datadog, thus the median and 95percentile is calculated given the set of builds executing across all agents.
-      Learn more about [Datadog Distributions](Use Datadog Distributions for Timing metrics)
+      Learn more about [Datadog Distributions](https://docs.datadoghq.com/metrics/types/?tab=distribution#metric-types)
 - name: name
   env_var: BUILDKITE_AGENT_NAME
   default_value: "%hostname-%spawn"

--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -157,7 +157,7 @@ attributes:
 - name: metrics-datadog-distributions
   env_var: BUILDKITE_METRICS_DATADOG_DISTRIBUTIONS
   default_value: "false"
-  requires: false
+  required: false
   desc: |
       Use [Datadog Distributions](https://docs.datadoghq.com/metrics/types/?tab=distribution#metric-types) for timing metrics. This is advisable when running multiple agents. Otherwise, metrics from multiple agents may be rolled up and appear to have the same value.
 - name: name

--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -159,11 +159,7 @@ attributes:
   default_value: "false"
   requires: false
   desc: |
-      Use Datadog Distributions for Timing metrics. By default, we submit metrics via standard gauges. This will unfortunately cause issues if you have multiple agents running,
-      as components like buildkite.jobs.duration.success.median becomes a roll up of the median execution time _from each agent_. As each agent is likely only running a single job
-      at a time, this causes all time related histogram metrics (avg, max, median, 95percentile) from a given agent to be the same value.
-      Distributions, however, aggregate the metrics server side at Datadog, thus the median and 95percentile is calculated given the set of builds executing across all agents.
-      Learn more about [Datadog Distributions](https://docs.datadoghq.com/metrics/types/?tab=distribution#metric-types)
+      Use [Datadog Distributions](https://docs.datadoghq.com/metrics/types/?tab=distribution#metric-types) for timing metrics. This advisable when running multiple agents. Otherwise, metrics from multiple agents may be rolled up and appear to have the same value.
 - name: name
   env_var: BUILDKITE_AGENT_NAME
   default_value: "%hostname-%spawn"


### PR DESCRIPTION
This adds documentation for metrics-datadog-distributions, which was added in https://github.com/buildkite/agent/pull/1433.

Please note that I don't actually know how to test this at all -- do I get a rendered version of the site in the PR?