### PR TITLE
Add link to cluster queues documentation from agents queues

### DIFF
--- a/pages/agent/v3/queues.md
+++ b/pages/agent/v3/queues.md
@@ -24,7 +24,7 @@ buildkite-agent start --tags "queue=building,queue=testing"
 <%= image "agent-queues.png", width: 1182/2, height: 160/2, alt: "Screenshot of an agent's tags showing both building and testing queues" %>
 
 >🚧 Configuring Cluster Queues
->If you have [Clusters](/docs/agent/clusters) enabled, and are configuring your agent with a _Cluster Queue_, you will need to ensure the cluster queue has been explicitly created first. See [setting up Cluster Queues](/docs/agent/clusters#set-up-a-cluster-set-up-queues) to learn more.
+>If you have [Clusters](/docs/agent/clusters) enabled and are configuring your agent with a _Cluster Queue_, you need to create the cluster queue first. See [Set up a Cluster Queue](/docs/agent/clusters#set-up-a-cluster-set-up-queues) for more information.
 
 ## Targeting a queue
 

--- a/pages/agent/v3/queues.md
+++ b/pages/agent/v3/queues.md
@@ -23,6 +23,9 @@ buildkite-agent start --tags "queue=building,queue=testing"
 
 <%= image "agent-queues.png", width: 1182/2, height: 160/2, alt: "Screenshot of an agent's tags showing both building and testing queues" %>
 
+>🚧 Configuring Cluster Queues
+>If you have [Clusters](/docs/agent/clusters) enabled, and are configuring your agent with a _Cluster Queue_, you will need to ensure the cluster queue has been explicitly created first. See [setting up Cluster Queues](/docs/agent/clusters#set-up-a-cluster-set-up-queues) to learn more.
+
 ## Targeting a queue
 
 Target specific queues using the `agents` attribute on your pipeline steps.

--- a/pages/agent/v3/queues.md
+++ b/pages/agent/v3/queues.md
@@ -24,7 +24,7 @@ buildkite-agent start --tags "queue=building,queue=testing"
 <%= image "agent-queues.png", width: 1182/2, height: 160/2, alt: "Screenshot of an agent's tags showing both building and testing queues" %>
 
 >🚧 Configuring Cluster Queues
->If you have [Clusters](/docs/agent/clusters) enabled and are configuring your agent with a _Cluster Queue_, you need to create the cluster queue first. See [Set up a Cluster Queue](/docs/agent/clusters#set-up-a-cluster-set-up-queues) for more information.
+>If you have [Clusters](/docs/agent/clusters) enabled and are configuring your agent with a _cluster queue_, you need to create the cluster queue first. See [Set up a cluster queue](/docs/agent/clusters#set-up-a-cluster-set-up-queues) for more information.
 
 ## Targeting a queue
 

--- a/pages/agent/v3/queues.md
+++ b/pages/agent/v3/queues.md
@@ -23,7 +23,7 @@ buildkite-agent start --tags "queue=building,queue=testing"
 
 <%= image "agent-queues.png", width: 1182/2, height: 160/2, alt: "Screenshot of an agent's tags showing both building and testing queues" %>
 
->🚧 Configuring Cluster Queues
+>🚧 Configuring cluster queues
 >If you have [Clusters](/docs/agent/clusters) enabled and are configuring your agent with a _cluster queue_, you need to create the cluster queue first. See [Set up a cluster queue](/docs/agent/clusters#set-up-a-cluster-set-up-queues) for more information.
 
 ## Targeting a queue


### PR DESCRIPTION
Responds to [EDGE-882](https://linear.app/buildkite/issue/EDGE-882/update-queue-docs-to-point-to-cluster-queues) 
- Adds a link to point the user to cluster queue setup from the agent queues page, and lets them know that for cluster queues they'll need to explicitly create the queue first for it to work. 