### PR TITLE
Remove partial template routes from sitemap

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -4,15 +4,18 @@ class Page
   HEADING_REGEX = /^[#]{2}\s(.+)$/
 
   class << self
+    # Find all markdown pages in the pages directory (ignoring partials).
     def all
-      Dir.glob("#{Rails.root}/pages/**/*.md").map do |path|
-        Struct.new(:path, :updated_at).new(
-          path
-            .sub("#{Rails.root}/pages/", "/docs/")
-            .sub(/\.md$/, "")
-            .gsub("_", "-"),
-          File.mtime(path)
-        )
+      Dir.glob("#{Rails.root}/pages/**/*.md")
+        .select { |path | !path.to_s.include?("/_") }
+        .map do |path|
+          Struct.new(:path, :updated_at).new(
+            path
+              .sub("#{Rails.root}/pages/", "/docs/")
+              .sub(/\.md$/, "")
+              .gsub("_", "-"),
+            File.mtime(path)
+          )
       end
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Page do
+  describe ".all" do
+    it "ignores partial templates" do
+      allow(File).to receive(:mtime).and_return(Time.now)
+
+      allow(Dir).to receive(:glob).and_return([
+        "docs/agent-api.md",
+        "docs/_apt_configuration.md"
+      ])
+
+      expect(Page.all.size).to eql(1)
+    end
+  end
+
   describe "#beta?" do
     context "when page's path is defined in the BETA_PAGES constant" do
       it "returns true" do


### PR DESCRIPTION
Partial templates (markdown files prefixed with `_`) are not intended to be rendered directly and should not be included in the sitemap.