### PR TITLE
feat: update /member-permissions link to /security in docs site

### DIFF
--- a/pages/apis/managing_api_tokens.md
+++ b/pages/apis/managing_api_tokens.md
@@ -59,7 +59,7 @@ Removing access from a token sends a notification email to the token's owner, wh
 
 ## Limiting API Access by IP address
 
-If you'd like to limit access to your organization by IP address, you can create an allowlist of IP addresses in the [organization's permission settings](https://buildkite.com/organizations/~/member-permissions).
+If you'd like to limit access to your organization by IP address, you can create an allowlist of IP addresses in the [organization's security settings](https://buildkite.com/organizations/~/security).
 
 You can also manage the allowlist with the [`organizationApiIpAllowlistUpdate`](/docs/apis/graphql/schemas/mutation/organizationapiipallowlistupdate) mutation in the GraphQL API.
 

--- a/pages/pipelines/notifications.md
+++ b/pages/pipelines/notifications.md
@@ -113,7 +113,7 @@ You can set notifications:
 * On build status events in the Buildkite UI, by using your Slack Notification Service's 'Build State Filtering' settings.
 * On step status and other non-build events, by extending the Slack Notification Service using the `notify` attribute in your `pipeline.yml`.
 
-Before adding a `notify` attribute to your `pipeline.yml`, ensure an organization admin has set up a [Slack integration](/docs/integrations/slack) for the channel or user that you want to post to. Buildkite customers on the [Enterprise](https://buildkite.com/pricing) plan can also check the ['Manage Notifications Services'](https://buildkite.com/organizations/~/member-permissions) checkbox to create, edit, or delete notification services. For detailed information about setting up a Notification Service, see the [Slack integration page](/docs/integrations/slack).
+Before adding a `notify` attribute to your `pipeline.yml`, ensure an organization admin has set up a [Slack integration](/docs/integrations/slack) for the channel or user that you want to post to. Buildkite customers on the [Enterprise](https://buildkite.com/pricing) plan can also check the ['Manage Notifications Services'](https://buildkite.com/organizations/~/security) checkbox to create, edit, or delete notification services. For detailed information about setting up a Notification Service, see the [Slack integration page](/docs/integrations/slack).
 
 Once a Slack channel has been configured in your organization, add a Slack notification to your pipeline using the `slack` attribute of the `notify` YAML block. Remember that if you rename or modify the Slack channel for which the integration was set up, for example if you change it from public to private, you need to set up a new integration.
 


### PR DESCRIPTION
the member-permissions path is changing in the main app to /security. The content is still the same as the old page, but the path is updated.

Updating the links in docs so we don't break anything 😁

For more context, see this PR: https://github.com/buildkite/buildkite/pull/12278
This Bascamp post with response from Buzz: https://3.basecamp.com/3453178/buckets/11426308/messages/6184949967