### PR TITLE
Correct the recipe for concurrency group filter

### DIFF
--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -361,7 +361,7 @@ To see which jobs are waiting for a concurrency group in case the secret URL fai
 ```
 query getConcurrency {
   organization(slug: "{org}") {
-    jobs(first:100,concurrency:{"name"}, type:[COMMAND], state:[LIMITED]) {
+    jobs(first:100,concurrency:{group: "name"}, type:[COMMAND], state:[LIMITED]) {
       edges {
         node {
           ... on JobTypeCommand {


### PR DESCRIPTION
The "input" of the `concurrency` doesn't take an unnamed string as an argument, it must be defined as `group`.