### PR TITLE
Get all builds for pipeline graphql

### DIFF
--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -174,7 +174,7 @@ query GetEnvVarsBuild {
 }
 ```
 
-### Get all builds for a given pipeline
+### Get all builds for a pipeline
 
 Retrieve all of the builds for a given pipeline. This will print out a list of builds that are run on the given pipeline and return the id, number, and url of each build.
 ```graphql

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -176,7 +176,8 @@ query GetEnvVarsBuild {
 
 ### Get all builds for a pipeline
 
-Retrieve all of the builds for a given pipeline. This will print out a list of builds that are run on the given pipeline and return the id, number, and url of each build.
+Retrieve all of the builds for a given pipeline, including each build's ID, number, and URL.
+
 ```graphql
 query GetBuilds {
   pipeline(slug: "organization-slug/pipeline-slug") {

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -179,7 +179,7 @@ query GetEnvVarsBuild {
 Retrieve all of the builds for a given pipeline. This will print out a list of builds that are run on the given pipeline and return the id, number, and url of each build.
 ```graphql
 query GetBuilds {
-  pipeline(slug: "<pipeline-slug>") {
+  pipeline(slug: "organization-slug/pipeline-slug") {
     builds(first: 10) {
       edges {
         node {

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -174,6 +174,25 @@ query GetEnvVarsBuild {
 }
 ```
 
+### Get all builds for a given pipeline
+
+Retrieve all of the builds for a given pipeline. This will print out a list of builds that are run on the given pipeline and return the id, number, and url of each build.
+```graphql
+query GetBuilds {
+  pipeline(slug: "<pipeline-slug>") {
+    builds(first: 10) {
+      edges {
+        node {
+          id
+          number
+          url
+        }
+      }
+    }
+  }
+}
+```
+
 ### Get the creation date of the most recent build in every pipeline
 
 Get the creation date of the most recent build in every pipeline. Use pagination to handle large responses. Buildkite sorts builds by newest first.


### PR DESCRIPTION
This will add a GraphQL query to the cookbook that will query for all builds on a pipeline