### PR TITLE
IAM policies on Secret Manager on single Elastic CI Stack note 

### DIFF
--- a/pages/agent/v3/aws/secrets_manager.md
+++ b/pages/agent/v3/aws/secrets_manager.md
@@ -46,6 +46,9 @@ To ensure your Elastic CI Stack for AWS has access to the secret:
 }
 ```
 
+>📘 Single instance Elastic CI Stacks
+> If you have set `minSize` and `maxSize` parameters equal to 1 in your [Elastic CI Stack parameters](/docs/agent/v3/elastic-ci-aws/parameters), you will only need to set the `IAMRole` to your Secret Manager secret's resource policy as above. The  `AutoscalingLambdaExecutionRole` IAM role and corresponding autoscaling resources are not created in this Elastic CI Stack setup.
+
 ## Multi-region replication
 
 It is also possible to replicate your Buildkite Agent token to multiple regions


### PR DESCRIPTION
This change:

- Adds a note underneath the main page within the `docs/pages/agent/v3/aws/secrets_manager.md` page (Storing agent tokens) to clarify the need for only one IAM role to be set in a corresponding secret's policy. 
- Came out from community forum [discussion](https://forum.buildkite.community/t/buildkite-elastic-stack-minsuccessfulinstancespercent/2931/6) and testing (Autoscaling Lambda/components not made in the single case)