### PR TITLE
Additional info on using WAIT with BLOCK

### DIFF
--- a/pages/pipelines/_block_wait.md
+++ b/pages/pipelines/_block_wait.md
@@ -30,3 +30,17 @@ steps:
   - block: "unblock me"
 ```
 {: codeblock-file="pipeline.yml"}
+
+Alternatively, it is possible to use a wait step with a block step if conditionals are used. In these cases, the wait step must come before the block step:
+
+```yml
+steps:
+  - command: ".buildkite/steps/yarn"
+  - wait:
+    if: build.source == "schedule"
+  - block: "Deploy changes?"
+    if: build.branch == pipeline.default_branch && build.source != "schedule"
+  - command: ".buildkite/scripts/deploy"
+    if: build.branch == pipeline.default_branch
+```
+{: codeblock-file="pipeline.yml"}


### PR DESCRIPTION
It is possible to use a `wait` with a `block`, but conditionals need to be used and the `wait` must come before the `block` in order to ensure it's not considered part of the blocked steps.

This makes sense where scheduled pipelines deploy some infrastructure, but when a human makes a change we want that deploy to be verified.
