### PR TITLE
Only deploy previews for pull requests (not branches)

### DIFF
--- a/.buildkite/pipeline.preview.yml
+++ b/.buildkite/pipeline.preview.yml
@@ -1,6 +1,7 @@
 steps:
   - label: "Deploy preview"
     command: bin/deploy-preview
+    if: build.env('BUILDKITE_PULL_REQUEST') != 'false'
     plugins:
       - docker-compose#v3.9.0:
           run: app
@@ -10,5 +11,4 @@ steps:
             - GH_TOKEN
             - NETLIFY_AUTH_TOKEN
             - NETLIFY_SITE_ID
-            - BUILDKITE_BRANCH
             - BUILDKITE_PULL_REQUEST

--- a/bin/deploy-preview
+++ b/bin/deploy-preview
@@ -2,6 +2,11 @@
 
 set -eu
 
+if [ "$BUILDKITE_PULL_REQUEST" eq "false" ]; then
+  echo "Not a pull request, skipping deploy-preview"
+  exit 1
+fi
+
 echo "--- :spider_web: Generating static site"
 staticgen generate
 
@@ -9,30 +14,28 @@ staticgen generate
 mkdir -p build/docs/assets && cp -r public/docs/assets build/docs
 
 echo "--- :netlify: Deploying to Netlify"
-PREVIEW_URL=$(./node_modules/.bin/netlify deploy --auth $NETLIFY_AUTH_TOKEN --site $NETLIFY_SITE_ID --alias $BUILDKITE_BRANCH --dir build --json true | jq -r .deploy_url)
+PREVIEW_URL=$(./node_modules/.bin/netlify deploy --auth $NETLIFY_AUTH_TOKEN --site $NETLIFY_SITE_ID --alias $BUILDKITE_PULL_REQUEST --dir build --json true | jq -r .deploy_url)
 
 msg="Preview URL: $PREVIEW_URL"
 
 echo "--- :buildkite: Annotating build"
 buildkite-agent annotate --style "success" --context "netlify/preview-url" "$msg"
 
-if [ -n "$BUILDKITE_PULL_REQUEST" ]; then
-  # Find comment on pull request
-  comment_id=$(gh api \
+# Find comment on pull request
+comment_id=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  /repos/buildkite/docs/issues/$BUILDKITE_PULL_REQUEST/comments \
+  | jq --arg msg "$msg" '.[] | select(.body==$msg) | .id')
+
+
+# Post comment if not found
+if [ -z "$comment_id" ]; then
+  echo "--- :github: Commenting on GitHub pull request"
+  gh api \
+    --method POST \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     /repos/buildkite/docs/issues/$BUILDKITE_PULL_REQUEST/comments \
-    | jq --arg msg "$msg" '.[] | select(.body==$msg) | .id')
-
-
-  # Post comment if not found
-  if [ -z "$comment_id" ]; then
-    echo "--- :github: Commenting on GitHub pull request"
-    gh api \
-      --method POST \
-      -H "Accept: application/vnd.github+json" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      /repos/buildkite/docs/issues/$BUILDKITE_PULL_REQUEST/comments \
-      -f body="$msg"
-    fi
-fi
+    -f body="$msg"
+  fi


### PR DESCRIPTION
Now that I've better configured the Github triggers I think we should always use the pull request ID in the preview URL.

This change updates the preview script to require a pull request ID.