### PR TITLE
PIE-1675 Analytics rest api suite#show docs 

### DIFF
--- a/app/models/beta_pages.rb
+++ b/app/models/beta_pages.rb
@@ -6,6 +6,7 @@ class BetaPages
       'test-analytics/android-collectors',
       'test-analytics/dotnet-collectors',
       'apis/rest-api/analytics/flaky-tests',
+      'apis/rest-api/analytics/suites',
       'agent/clusters',
       'apis/rest-api/clusters'
     ]

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -408,6 +408,9 @@
             - name: "Flaky tests"
               pill: "beta"
               path: "apis/rest-api/analytics/flaky-tests"
+            - name: "Suites"
+              pill: "beta"
+              path: "apis/rest-api/analytics/suites"
     - name: "GraphQL"
       children: []
     - name: "Webhooks"

--- a/pages/apis/rest_api/analytics/suites.md
+++ b/pages/apis/rest_api/analytics/suites.md
@@ -1,0 +1,22 @@
+# Suites API
+## Get a suite
+
+```bash
+curl "https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{suite.slug}"
+```
+
+```json
+
+  {
+    "slug":"my_suite_slug",
+    "name":"My suite name",
+    "url":"https://api.buildkite.com/v2/analytics/organizations/my_great_org/suites/my_suite_slug",
+    "web_url":"https://buildkite.com/organizations/my_great_org/analytics/suites/my_suite_slug",
+    "default_branch":"main"
+  }
+
+```
+
+Required scope: `read_suites`
+
+Success response: `200 OK`

--- a/pages/apis/rest_api/analytics/suites.md
+++ b/pages/apis/rest_api/analytics/suites.md
@@ -1,4 +1,5 @@
 # Suites API
+
 ## Get a suite
 
 ```bash


### PR DESCRIPTION
### Description
Add information about analytics Suite#show API endpoint

**Linear:** https://linear.app/buildkite/issue/PIE-1675/rest-api-endpoints-documentation-suiteshow
<img width="562" alt="Screenshot 2023-06-01 at 2 39 45 pm" src="https://github.com/buildkite/docs/assets/47379003/58bdca3c-8b54-4d5b-8e96-a39ff9babaa2">

The endpoint is currently behind a feature flag. I'm not sure if I can also hide the link to this doc page behind a feature flag, or hold off releasing this PR until the endpoint is publicly released. 
