### PR TITLE
Make "local" an official BUILDKITE_SOURCE

### DIFF
--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -435,6 +435,7 @@ variables:
     - ui
     - trigger_job
     - schedule
+    - local
 - name: BUILDKITE_SSH_KEYSCAN
   desc: |
     The opposite of the value of the `no-ssh-keyscan` [agent configuration option](/docs/agent/v3/configuration).


### PR DESCRIPTION
## Problem
In my plugins and pipelines, I want to be able to augment the behavior if the step is running via a `bk local run` command. An example of this would be a "docker push" plugin, which might look like

```yaml
steps:
  - command: docker pull alpine
    plugins:
      - example/docker:
          push_local_image: alpine
```

When executing via the actual agents, this would take the local alpine image, get some credentials, and push the image to the company's registry.

However, having a plugin like this now makes it so that this step _cannot_ be run in a `bk local run` context. As far as I can tell from the docs, there is no way for the plugin to augment its behavior to make it acceptable to run locally, and it's common to make it so users _can't_ just push from their laptops.

## Solution

This PR updates the possible values for `BUILDKITE_SOURCE` to highlight that "local" is possible in the context of running via `bk local run`. This makes the [current state of affairs](https://github.com/buildkite/cli/blob/cdcc5fa4b6e209f5ffa79469dad04938d6eed0cd/local/server.go#L369) official, and presumably "supported," by y'all. This would allow me to feel more comfortable encoding some

```sh
if [[ "$BUILDKITE_SOURCE" == "local" ]]; then DRY_RUN=true; fi
```

in all my plugins.

That's a lot of words for a very small change, but I figure it might have some impact on y'all's flexibility moving forward since it's **effectively an API change proposed as a doc change** 🙈.

## Caveats
* I may have just missed somewhere in the docs that describes either a different environment variable, **or a better way to check if we're running locally**
* I imagine the `local` value _might_ have been chosen arbitrarily by @lox when he was first setting up the `bk local run` command? 
* We could encode this into [`BUILDKITE_PIPELINE_PROVIDER`](https://github.com/buildkite/cli/blob/cdcc5fa4b6e209f5ffa79469dad04938d6eed0cd/local/server.go#LL390C4-L390C31) instead of `BUILDKITE_SOURCE` to get the same effect, not sure what the meaning of the difference between the two env vars should be in this context