### PR TITLE
Buildkite Build Creator details

### DIFF
--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -97,17 +97,26 @@ variables:
   example: "cdanvers@kree-net.com"
 - name: BUILDKITE_BUILD_CREATOR
   desc: |
-    The name of the user who created the build. May be **[unverified](#unverified-commits)**.
+    The name of the user who created the build. The value differs depending on how the build was created:
+      Buildkite dashboard: Set based on who manually created the build.
+      GitHub webhook: Set from the  **[unverified](#unverified-commits)** HEAD commit.
+      Webhook: Set based on which user is attached to the API Key used. 
   modifiable: false
   example: "Carol Danvers"
 - name: BUILDKITE_BUILD_CREATOR_EMAIL
   desc: |
-    The notification email of the user who created the build.
+    The notification email of the user who created the build. The value differs depending on how the build was created:
+      Buildkite dashboard: Set based on who manually created the build.
+      GitHub webhook: Set from the  **[unverified](#unverified-commits)** HEAD commit.
+      Webhook: Set based on which user is attached to the API Key used. 
   modifiable: false
   example: "cdanvers@kree-net.com"
 - name: BUILDKITE_BUILD_CREATOR_TEAMS
   desc: |
-    A colon separated list of **[unverified](#unverified-commits)** non-private team slugs that the build creator belongs to.
+    A colon separated list of non-private team slugs that the build creator belongs to. The value differs depending on how the build was created:
+      Buildkite dashboard: Set based on who manually created the build.
+      GitHub webhook: Set from the  **[unverified](#unverified-commits)** HEAD commit.
+      Webhook: Set based on which user is attached to the API Key used. 
   modifiable: false
   example: "everyone:platform"
 - name: BUILDKITE_BUILD_ID

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -98,9 +98,10 @@ variables:
 - name: BUILDKITE_BUILD_CREATOR
   desc: |
     The name of the user who created the build. The value differs depending on how the build was created:
-      Buildkite dashboard: Set based on who manually created the build.
-      GitHub webhook: Set from the  **[unverified](#unverified-commits)** HEAD commit.
-      Webhook: Set based on which user is attached to the API Key used. 
+      
+    - **Buildkite dashboard:** Set based on who manually created the build.
+    - **GitHub webhook:** Set from the  **[unverified](#unverified-commits)** HEAD commit.
+    - **Webhook:** Set based on which user is attached to the API Key used.
   modifiable: false
   example: "Carol Danvers"
 - name: BUILDKITE_BUILD_CREATOR_EMAIL

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -116,9 +116,10 @@ variables:
 - name: BUILDKITE_BUILD_CREATOR_TEAMS
   desc: |
     A colon separated list of non-private team slugs that the build creator belongs to. The value differs depending on how the build was created:
-      Buildkite dashboard: Set based on who manually created the build.
-      GitHub webhook: Set from the  **[unverified](#unverified-commits)** HEAD commit.
-      Webhook: Set based on which user is attached to the API Key used. 
+
+    - **Buildkite dashboard:** Set based on who manually created the build.
+    - **GitHub webhook:** Set from the  **[unverified](#unverified-commits)** HEAD commit.
+    - **Webhook:** Set based on which user is attached to the API Key used.
   modifiable: false
   example: "everyone:platform"
 - name: BUILDKITE_BUILD_ID

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -107,9 +107,10 @@ variables:
 - name: BUILDKITE_BUILD_CREATOR_EMAIL
   desc: |
     The notification email of the user who created the build. The value differs depending on how the build was created:
-      Buildkite dashboard: Set based on who manually created the build.
-      GitHub webhook: Set from the  **[unverified](#unverified-commits)** HEAD commit.
-      Webhook: Set based on which user is attached to the API Key used. 
+
+    - **Buildkite dashboard:** Set based on who manually created the build.
+    - **GitHub webhook:** Set from the  **[unverified](#unverified-commits)** HEAD commit.
+    - **Webhook:** Set based on which user is attached to the API Key used.
   modifiable: false
   example: "cdanvers@kree-net.com"
 - name: BUILDKITE_BUILD_CREATOR_TEAMS


### PR DESCRIPTION
The customer is asking why the BUILDKITE_BUILD_AUTHOR is not showing in the UI as the build creator.  Though the information is in [this]( https://buildkite.com/docs/pipelines/conditionals#variable-and-syntax-reference-variables) part of our docs, customers tend to navigate into this [section](https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_BUILD_AUTHOR) for information about the environment variables.

Proposing to add the details here for the above reason and make it easier for customers to search this information.