### PR TITLE
Add documentation on tests#show Test Analytics REST API endpoint

### DIFF
--- a/app/models/beta_pages.rb
+++ b/app/models/beta_pages.rb
@@ -7,6 +7,7 @@ class BetaPages
       'test-analytics/dotnet-collectors',
       'apis/rest-api/analytics/flaky-tests',
       'apis/rest-api/analytics/suites',
+      'apis/rest-api/analytics/tests',
       'agent/clusters',
       'apis/rest-api/clusters'
     ]

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -411,6 +411,9 @@
             - name: "Suites"
               pill: "beta"
               path: "apis/rest-api/analytics/suites"
+            - name: "Tests"
+              pill: "beta"
+              path: "apis/rest-api/analytics/tests"
     - name: "GraphQL"
       children: []
     - name: "Webhooks"

--- a/pages/apis/rest_api/analytics/tests.md
+++ b/pages/apis/rest_api/analytics/tests.md
@@ -1,0 +1,23 @@
+# Tests API
+
+## Get a test
+
+```bash
+curl "https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{suite.slug}/tests/{test.id}"
+```
+
+```json
+{
+  "id": "01867216-8478-7fde-a55a-0300f88bb49b",
+  "url": "https://api.buildkite.com/v2/analytics/organizations/my_great_org/suites/my_suite_name/tests/01867216-8478-7fde-a55a-0300f88bb49b",
+  "web_url": "https://buildkite.com/organizations/my_great_org/analytics/suites/my_suite_name/tests/01867216-8478-7fde-a55a-0300f88bb49b",
+  "scope": "User#email",
+  "name": "is correctly formatted",
+  "location": "./spec/models/user_spec.rb:42",
+  "file_name": "./spec/models/user_spec.rb",
+}
+```
+
+Required scope: `read_suites`
+
+Success response: `200 OK`


### PR DESCRIPTION
### Description

Add documentation on a new Test Analytics REST API endpoint which displays
basic information about a test (beta).

### Context

PIE-1710
https://linear.app/buildkite/issue/PIE-1710/rest-api-endpoints-documentation-testshow

### Release

This PR merges into a long-living branch/PR [pie-1713-release-ta-rest-api-documentation](https://github.com/buildkite/docs/tree/pie-1713-release-ta-rest-api-documentation), https://github.com/buildkite/docs/pull/2189

That PR will be released when we are ready to publish the new pages.