### PR TITLE
Add missing "#" to notify -> slack -> channels example for step-level Slack notifications

### DIFF
--- a/pages/pipelines/notifications.md
+++ b/pages/pipelines/notifications.md
@@ -294,7 +294,7 @@ steps:
     notify:
       - slack:
           channels:
-            - "general"
+            - "#general"
           message: "This message will ping <@user>!"
 ```
 {: codeblock-file="pipeline.yml"}


### PR DESCRIPTION
If you omit this, you get the following error message when editing pipeline steps:

```
The `slack` notification is invalid: Each channel should be defined as `#channel-name`, `team-name#channel-name`, 'team-name@user-name', '@user-name'` message 
```