### PR TITLE
Update buildkite-test_collector from 1.5.0 to 2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,9 +31,8 @@ GEM
     bugsnag (6.21.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
-    buildkite-test_collector (1.5.0)
+    buildkite-test_collector (2.3.1)
       activesupport (>= 4.2)
-      websocket (~> 1.2)
     byebug (11.1.3)
     capybara (3.35.3)
       addressable


### PR DESCRIPTION
v1 has been deprecated

From https://github.com/buildkite/test-collector-ruby/
> DEPRECATION NOTICE Versions prior to 2.1.x are unsupported and will not work after mid-2023. Please upgrade to the latest version.
