### PR TITLE
Add placeholder preview URL comment

### DIFF
--- a/.buildkite/pipeline.preview.yml
+++ b/.buildkite/pipeline.preview.yml
@@ -1,4 +1,19 @@
 steps:
+  - label: "Prepare preview"
+    command: bin/prepare-preview
+    plugins:
+      - docker-compose#v4.12.0:
+          run: agent
+          config: docker-compose.yml
+          mount-checkout: true
+          mount-buildkite-agent: true
+          env:
+            - GH_TOKEN
+            - NETLIFY_AUTH_TOKEN
+            - NETLIFY_SITE_ID
+            - BUILDKITE_BRANCH
+            - BUILDKITE_BUILD_URL
+
   - label: "Deploy preview"
     command: bin/deploy-preview
     plugins:

--- a/.buildkite/pipeline.preview.yml
+++ b/.buildkite/pipeline.preview.yml
@@ -1,18 +1,6 @@
 steps:
   - label: "Prepare preview"
     command: bin/prepare-preview
-    plugins:
-      - docker-compose#v4.12.0:
-          run: agent
-          config: docker-compose.yml
-          mount-checkout: true
-          mount-buildkite-agent: true
-          env:
-            - GH_TOKEN
-            - NETLIFY_AUTH_TOKEN
-            - NETLIFY_SITE_ID
-            - BUILDKITE_BRANCH
-            - BUILDKITE_BUILD_URL
 
   - label: "Deploy preview"
     command: bin/deploy-preview

--- a/bin/deploy-preview
+++ b/bin/deploy-preview
@@ -1,20 +1,10 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 set -eu
 
-# Find pull request number for the current branch (e.g. 123).
-#
-# If no PR is found this should exit with a non-zero status code.
-#
-# Why not `$BUILDKITE_PULL_REQUEST`? That env variable is only set
-# for builds triggered via Github and it's possible previews are
-# manually triggered via the API or Buildkite Dashboard.
-#
-PULL_REQUEST_NUMBER=$(gh api \
-  -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  /repos/buildkite/docs/pulls \
-  -X GET -f head="buildkite:$BUILDKITE_BRANCH" | jq ".[0].number")
+. bin/utils.sh
+
+PULL_REQUEST_NUMBER=$(get_branch_pull_request_number $BUILDKITE_BRANCH)
 
 if [ -z "$PULL_REQUEST_NUMBER" ]; then
   echo "No pull request found for branch $BUILDKITE_BRANCH"
@@ -27,29 +17,8 @@ staticgen generate
 # Copy images into build directory
 mkdir -p build/docs/assets && cp -r public/docs/assets build/docs
 
-echo "--- :netlify: Deploying to Netlify"
-PREVIEW_URL=$(./node_modules/.bin/netlify deploy --auth $NETLIFY_AUTH_TOKEN --site $NETLIFY_SITE_ID --alias $PULL_REQUEST_NUMBER --dir build --json true | jq -r .deploy_url)
+echo "+++ :netlify: Deploying to Netlify"
+node_modules/.bin/netlify deploy --auth $NETLIFY_AUTH_TOKEN --site $NETLIFY_SITE_ID --alias $PULL_REQUEST_NUMBER --dir build
 
-msg="Preview URL: $PREVIEW_URL"
-
-echo "--- :buildkite: Annotating build"
-buildkite-agent annotate --style "success" --context "netlify/preview-url" "$msg"
-
-# Find comment on pull request
-comment_id=$(gh api \
-  -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  /repos/buildkite/docs/issues/$PULL_REQUEST_NUMBER/comments \
-  | jq --arg msg "$msg" '.[] | select(.body==$msg) | .id')
-
-
-# Post comment if not found
-if [ -z "$comment_id" ]; then
-  echo "--- :github: Commenting on GitHub pull request"
-  gh api \
-    --method POST \
-    -H "Accept: application/vnd.github+json" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    /repos/buildkite/docs/issues/$PULL_REQUEST_NUMBER/comments \
-    -f body="$msg"
-  fi
+echo "--- :buildkite: Update annotation state"
+buildkite-agent annotate --style "success" --context "netlify/preview-url"

--- a/bin/prepare-preview
+++ b/bin/prepare-preview
@@ -26,15 +26,23 @@ cat << EOF > build/index.html
 </html>
 EOF
 
-echo "--- :netlify: Deploying to Netlify"
-netlify deploy --auth $NETLIFY_AUTH_TOKEN --site $NETLIFY_SITE_ID --alias $PULL_REQUEST_NUMBER --dir build --json true | tee netlify-deploy.json
+zip -r build.zip build
 
-PREVIEW_URL=$(cat netlify-deploy.json | jq -r '.deploy_url')
+echo "--- :netlify: Deploying placeholder site Netlify"
+curl -H "Content-Type: application/zip" \
+     -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+     --data-binary "@build.zip" \
+     https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys\?deploy-preview\=true\&branch\=$PULL_REQUEST_NUMBER > netlify-deploy.json
+
+
+PREVIEW_URL=$(cat netlify-deploy.json | jq -r '.deploy_ssl_url')
 PREVIEW_MESSAGE="Preview URL: $PREVIEW_URL"
 
 echo "--- :buildkite: Annotating build"
 buildkite-agent annotate --style "info" --context "netlify/preview-url" "$PREVIEW_MESSAGE"
 
+echo "--- :github: Finding existing comment on GitHub"
 if [ -z "$(find_github_comment $PULL_REQUEST_NUMBER "$PREVIEW_MESSAGE")" ]; then
+  echo "--- :github: Posting comment on GitHub"
   post_github_comment $PULL_REQUEST_NUMBER "$PREVIEW_MESSAGE"
 fi

--- a/bin/prepare-preview
+++ b/bin/prepare-preview
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -eu
+
+. bin/utils.sh
+
+PULL_REQUEST_NUMBER=$(get_branch_pull_request_number $BUILDKITE_BRANCH)
+
+if [ -z "$PULL_REQUEST_NUMBER" ]; then
+  echo "No pull request found for branch $BUILDKITE_BRANCH"
+  exit 1
+fi
+
+# Create placeholder site whilst we build the real thing.
+mkdir build
+cat << EOF > build/index.html
+<!DOCTYPE html>
+  <html>
+    <head>
+      <meta http-equiv="refresh" content="30">
+    </head>
+    <body>
+      <p>Building preview...</p>
+      Follow progress here: <a href="$BUILDKITE_BUILD_URL">$BUILDKITE_BUILD_URL</a>
+    </body>
+</html>
+EOF
+
+echo "--- :netlify: Deploying to Netlify"
+netlify deploy --auth $NETLIFY_AUTH_TOKEN --site $NETLIFY_SITE_ID --alias $PULL_REQUEST_NUMBER --dir build --json true | tee netlify-deploy.json
+
+PREVIEW_URL=$(cat netlify-deploy.json | jq -r '.deploy_url')
+PREVIEW_MESSAGE="Preview URL: $PREVIEW_URL"
+
+echo "--- :buildkite: Annotating build"
+buildkite-agent annotate --style "info" --context "netlify/preview-url" "$PREVIEW_MESSAGE"
+
+if [ -z "$(find_github_comment $PULL_REQUEST_NUMBER "$PREVIEW_MESSAGE")" ]; then
+  post_github_comment $PULL_REQUEST_NUMBER "$PREVIEW_MESSAGE"
+fi

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Find pull request number for a given branch.
+#
+# Why not `$BUILDKITE_PULL_REQUEST`? That env variable is only set
+# for builds triggered via Github and it's possible previews are
+# manually triggered via the API or Buildkite Dashboard.
+#
+function get_branch_pull_request_number() {
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    /repos/buildkite/docs/pulls \
+    -X GET -f head="buildkite:$1" | jq ".[0].number | select (.!=null)"
+}
+
+function find_github_comment() {
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    /repos/buildkite/docs/issues/$1/comments \
+    | jq --arg msg "$2" '.[] | select(.body==$msg)'
+}
+
+function post_github_comment() {
+  gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    /repos/buildkite/docs/issues/$1/comments \
+    -f body="$2"
+}

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -7,26 +7,29 @@
 # manually triggered via the API or Buildkite Dashboard.
 #
 function get_branch_pull_request_number() {
-  gh api \
+  curl -L \
     -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GH_TOKEN" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    /repos/buildkite/docs/pulls \
-    -X GET -f head="buildkite:$1" | jq ".[0].number | select (.!=null)"
+    https://api.github.com/repos/buildkite/docs/pulls\?head=buildkite\:$1 \
+    | jq ".[0].number | select (.!=null)"
 }
 
 function find_github_comment() {
-  gh api \
+  curl -L \
     -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GH_TOKEN" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    /repos/buildkite/docs/issues/$1/comments \
+    https://api.github.com/repos/buildkite/docs/issues/$1/comments \
     | jq --arg msg "$2" '.[] | select(.body==$msg)'
 }
 
 function post_github_comment() {
-  gh api \
-    --method POST \
+  curl -L \
+    -X POST \
     -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GH_TOKEN" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    /repos/buildkite/docs/issues/$1/comments \
-    -f body="$2"
+    --data "{\"body\":\"$2\"}" \
+    https://api.github.com/repos/buildkite/docs/issues/$1/comments
 }


### PR DESCRIPTION
Post placeholder site and Github comment to let users know something is happening. 

#### Highlights:

1. Deploy a lightweight placeholder site to get a preview URL (it might even be worth making this nice one day)
2. Avoid dependencies and interact with REST APIs so that we can post a Github ASAP, rather than waiting for docker images to build which takes aaaaaaages.

Seems to work alright...
<img width="1180" alt="Screenshot 2023-06-08 at 1 12 41 pm" src="https://github.com/buildkite/docs/assets/656826/3a73ef1c-a792-4e9a-95bb-693070ac07b3">

Placeholder site:
<img width="598" alt="Screenshot 2023-06-08 at 1 15 11 pm" src="https://github.com/buildkite/docs/assets/656826/0f34a3aa-953f-4f16-ad1e-ab6648aeee43">


It's worth noting that I'm blowing away the preview website on every deployment. I think that's probably fine but if not then I'm sure could also do some extra checks using some Netlify APIs. 
