### PR TITLE
Remove light grey border from search kbd widget

### DIFF
--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -30,14 +30,13 @@
 .Search__kbd {
   background: $base-0;
   border-radius: $rounded;
-  border: 1px solid map-get($color-aliases, "border");
   box-shadow: $box-shadow-depth-100;
   color: map-get($color-aliases, "text-lightest");
   display: none;
   font-size: 14px;
   font-weight: bold;
   line-height: map-get($line-heights, "tightest");
-  margin-top: -10px;
+  margin-top: -9px;
   padding: 2px 10px;
   position: absolute;
   right: 12px;


### PR DESCRIPTION
Just a small suggestion to adjust the optical appearance of the `/` keyboard affordance in the search bar 🙂

<img width="724" alt="change" src="https://github.com/buildkite/docs/assets/677025/36279c4b-a769-41b9-9f16-e72fec78675e">
