### PR TITLE
PIE-1719 Test analytics rest api runs#index docs

### DIFF
--- a/pages/apis/rest_api/analytics/runs.md
+++ b/pages/apis/rest_api/analytics/runs.md
@@ -13,7 +13,7 @@ curl "https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{su
   {
     "id": "64374307-12ab-4b13-a3f3-6a408f644ea2",
     "branch": "main",
-    "commit_sha": "e32432c045439c95b5af2cb472b4d8be2207685d",
+    "commit_sha": "1c3214fcceb2c14579a2c3c50cd78f1442fd8936",
     "url": "https://api.buildkite.com/v2/analytics/organizations/my_great_org/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2",
     "web_url":"https://buildkite.com/organizations/my_great_org/analytics/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2"
   }
@@ -34,7 +34,7 @@ curl "https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{su
 {
   "id": "64374307-12ab-4b13-a3f3-6a408f644ea2",
   "branch": "main",
-  "commit_sha": "e32432c045439c95b5af2cb472b4d8be2207685d",
+  "commit_sha": "1c3214fcceb2c14579a2c3c50cd78f1442fd8936",
   "url": "https://api.buildkite.com/v2/analytics/organizations/my_great_org/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2",
   "web_url":"https://buildkite.com/organizations/my_great_org/analytics/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2"
 }

--- a/pages/apis/rest_api/analytics/runs.md
+++ b/pages/apis/rest_api/analytics/runs.md
@@ -1,5 +1,29 @@
 # Runs API
 
+## List all runs
+
+Returns a [paginated list](<%= paginated_resource_docs_url %>) of runs in a test suite.
+
+```bash
+curl "https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{suite.slug}/runs"
+```
+
+```json
+[
+  {
+    "id": "64374307-12ab-4b13-a3f3-6a408f644ea2",
+    "branch": "main",
+    "commit_sha": "e32432c045439c95b5af2cb472b4d8be2207685d",
+    "url": "https://api.buildkite.com/v2/analytics/organizations/my_great_org/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2",
+    "web_url":"https://buildkite.com/organizations/my_great_org/analytics/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2"
+  }
+]
+```
+
+Required scope: `read_suites`
+
+Success response: `200 OK`
+
 ## Get a run
 
 ```bash


### PR DESCRIPTION
**Description**
Add documentation about test analytics runs#index API endpoint

Linear https://linear.app/buildkite/issue/PIE-1719/rest-api-endpoints-documentation-runindex
<img width="1670" alt="Screenshot 2023-06-14 at 11 16 08 am" src="https://github.com/buildkite/docs/assets/47379003/b87dc42f-62e5-43d3-b8bb-6c1ba7e55b4b">

This branch will be merged into a long living branch [pie-1713-release-ta-rest-api-documentation](https://github.com/buildkite/docs/tree/pie-1713-release-ta-rest-api-documentation) as the endpoint is behind a feature flag. 
