### PR TITLE
s/Golang/Go/ because the latter is its name

### DIFF
--- a/data/nav.yml
+++ b/data/nav.yml
@@ -343,7 +343,7 @@
           pill: "beta"
         - name: "Python"
           path: "test-analytics/python-collectors"
-        - name: "Golang"
+        - name: "Go"
           path: "test-analytics/golang-collectors"
         - name: ".NET"
           path: "test-analytics/dotnet-collectors"

--- a/data/tiles.yml
+++ b/data/tiles.yml
@@ -25,7 +25,7 @@ test_analytics_guides:
         url: "/docs/test-analytics/android-collectors"
       - text: "Python"
         url: "/docs/test-analytics/python-collectors"
-      - text: "Golang"
+      - text: "Go"
         url: "/docs/test-analytics/golang-collectors"
       - text: ".NET"
         url: "/docs/test-analytics/dotnet-collectors"

--- a/pages/agent/v2/upgrading_to_v3.md
+++ b/pages/agent/v2/upgrading_to_v3.md
@@ -37,7 +37,7 @@ Changed:
 * Agent meta-data has been renamed to "tags"
 * Much better Windows support, including .BAT hooks support
 * Checkout clean no longer ignores files in `.gitignore`
-* The bootstrap (run as a sub-process for every job) has moved from a [shell script](https://github.com/buildkite/agent/blob/2-6-stable/templates/bootstrap.sh) to [`buildkite-agent bootstrap`](/docs/agent/v3/cli-bootstrap). This means it's written in golang and cross-platform.
+* The bootstrap (run as a sub-process for every job) has moved from a [shell script](https://github.com/buildkite/agent/blob/2-6-stable/templates/bootstrap.sh) to [`buildkite-agent bootstrap`](/docs/agent/v3/cli-bootstrap). This means it's written in Go and cross-platform.
 
 Deprecated:
 

--- a/pages/pipelines/example_pipelines.md
+++ b/pages/pipelines/example_pipelines.md
@@ -110,8 +110,8 @@ A list of repositories containing example [pipelines](/docs/pipelines).
 <a class="Docs__example-repo" href="https://github.com/buildkite/golang-example">
  <span class="icon">:golang:</span>
   <span class="detail">
-    <strong>Golang</strong>
-     <span class="description">An example of testing a Golang project</span>
+    <strong>Go</strong>
+     <span class="description">An example of testing a Go project</span>
     <span class="repo">github.com/buildkite/golang-example</span>
   </span>
 </a>
@@ -119,8 +119,8 @@ A list of repositories containing example [pipelines](/docs/pipelines).
 <a class="Docs__example-repo" href="https://github.com/buildkite/golang-docker-example">
  <span class="icon">:golang:</span>
   <span class="detail">
-    <strong>Golang - Docker</strong>
-     <span class="description">An example of testing a Golang project w/ Docker</span>
+    <strong>Go - Docker</strong>
+     <span class="description">An example of testing a Go project w/ Docker</span>
     <span class="repo">github.com/buildkite/golang-docker-example</span>
   </span>
 </a>

--- a/pages/pipelines/managing_log_output.md
+++ b/pages/pipelines/managing_log_output.md
@@ -1,6 +1,6 @@
 # Managing log output
 
-Buildkite uses our open-source [terminal Golang library](https://github.com/buildkite/terminal) to provide you with the best possible terminal rendering experience for your build logs, including ANSI terminal emulation to ensure spinners, progress bars, colors and emojis are rendered beautifully.
+Buildkite uses our open-source [terminal-to-html](https://github.com/buildkite/terminal-to-html) tool to provide you with the best possible terminal rendering experience for your build logs, including ANSI terminal emulation to ensure spinners, progress bars, colors and emojis are rendered beautifully.
 
 
 ## Collapsing output

--- a/pages/test_analytics.md
+++ b/pages/test_analytics.md
@@ -27,7 +27,7 @@ Test Analytics helps you track and analyze the steps in that pipeline that invol
   <%= button ":swift: Swift", "/docs/test-analytics/swift-collectors" %>
   <%= button ":android: Android", "/docs/test-analytics/android-collectors" %>
   <%= button ":pytest: pytest", "/docs/test-analytics/python-collectors" %>
-  <%= button ":golang: Golang", "/docs/test-analytics/golang-collectors" %>
+  <%= button ":golang: Go", "/docs/test-analytics/golang-collectors" %>
   <%= button ":junit: JUnit", "/docs/test-analytics/importing-junit-xml" %>
   <%= button ":dotnet: .NET", "/docs/test-analytics/dotnet-collectors" %>
   <%= button ":elixir: Elixir", "/docs/test-analytics/elixir-collectors" %>

--- a/pages/test_analytics/golang_collectors.md
+++ b/pages/test_analytics/golang_collectors.md
@@ -2,9 +2,9 @@
 toc: false
 ---
 
-# Configuring Golang with Test Analytics
+# Configuring Go with Test Analytics
 
-To use Test Analytics with your Go language projects use [gotestsum](https://github.com/gotestyourself/gotestsum) to generate JUnit XML files, then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) to Test Analytics.
+To use Test Analytics with your [Go](https://go.dev/) language projects use [gotestsum](https://github.com/gotestyourself/gotestsum) to generate JUnit XML files, then [upload the JUnit XML files](/docs/test-analytics/importing-junit-xml) to Test Analytics.
 
 1. Install [gotestsum](https://github.com/gotestyourself/gotestsum):
 

--- a/pages/test_analytics/ruby_collectors.md
+++ b/pages/test_analytics/ruby_collectors.md
@@ -1,6 +1,6 @@
 # Ruby collectors
 
-To use Test Analytics with your Ruby projects use the :github: [`test-collectors-ruby`](https://github.com/buildkite/test-collector-ruby) gem with RSpec or minitest.
+To use Test Analytics with your [Ruby](https://www.ruby-lang.org/) projects use the :github: [`test-collectors-ruby`](https://github.com/buildkite/test-collector-ruby) gem with RSpec or minitest.
 
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 

--- a/pages/test_analytics/rust_collectors.md
+++ b/pages/test_analytics/rust_collectors.md
@@ -4,7 +4,7 @@ toc: false
 
 # Rust collector
 
-To use Test Analytics with your Rust projects use the :github: [`test-collector-rust`](https://github.com/buildkite/test-collector-rust) package with `cargo test`.
+To use Test Analytics with your [Rust](https://www.rust-lang.org/) projects use the :github: [`test-collector-rust`](https://github.com/buildkite/test-collector-rust) package with `cargo test`.
 
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 

--- a/vale/styles/Buildkite/h1-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h1-h6_sentence_case.yml
@@ -67,7 +67,7 @@ exceptions:
   - GitLab
   - GitLab Community
   - GitLab Enterprise
-  - Golang
+  - Go
   - Google Chrome
   - Google Cloud
   - Google Cloud Functions

--- a/vale/styles/vocab.txt
+++ b/vale/styles/vocab.txt
@@ -110,7 +110,6 @@ gcloud
 gif
 githooks
 globbing
-golang
 gotestsum
 Graviton
 gz


### PR DESCRIPTION
Replace “Golang” with “Go” in prose and headings, so that we're using the correct name of the language.

I've also linked “Go” to its official https://go.dev/ site in one place in case that helps clarity now that we're not saying “the Go language” or “Golang”, and done the same for a couple of other languages (Rust, Ruby) but not all, so maybe that's silly, but I figure it's somewhat helpful to disambiguate e.g. Go from https://en.wikipedia.org/wiki/Go_(game) and Rust from https://en.wikipedia.org/wiki/Rust_(video_game) and Ruby from https://en.wikipedia.org/wiki/Ruby_character 🤷‍♂️

Anyway… back to Go:

> **Is the language called Go or Golang?**
>
> The language is called Go. The "golang" moniker arose because the web site was originally golang.org. (There was no .dev domain then.) Many use the golang name, though, and it is handy as a label. For instance, the Twitter tag for the language is "#golang". The language's name is just plain Go, regardless.

-- https://go.dev/doc/faq#go_or_golang