### PR TITLE
add reference to auto creating webhooks

### DIFF
--- a/pages/pipelines/create_your_own.md
+++ b/pages/pipelines/create_your_own.md
@@ -66,6 +66,7 @@ To create a new pipeline:
  _New Pipeline_.
 
     If you're prompted to connect your repositories, we recommend completing that first, but you can always connect them later from the settings.
+    After you have connected your repositories, you'll be able to select them from the dropdown, and enable automatic webhook creation.
 
 1. Enter the details you want for the pipeline. You can always change these later in the pipeline settings.
 1. Select _Create Pipeline_.


### PR DESCRIPTION
If you have connected Buildkite to your Github account, you'll be able to select your git repositories from a dropdown when creating a pipeline, as well as check a box that allows Buildkite to automatically create webhooks on the repo for you.