### PR TITLE
Deprecate read_flaky_tests scope in favour of read_suites

### DIFF
--- a/pages/apis/managing_api_tokens.md
+++ b/pages/apis/managing_api_tokens.md
@@ -28,6 +28,10 @@ REST API scopes are very granular, you can select some or all of the following:
 * Read Pipelines `read_pipelines` - Permission to list and retrieve details of pipelines
 * Write Pipelines `write_pipelines` - Permission to create, update and delete pipelines
 * Read User `read_user` - Permission to retrieve basic details of the user
+* Read Suites `read_suites` - Permission to list and retrieve details of suites; including runs,
+  tests, executions, etc.
+* Read Flaky Tests `read_flaky_tests` - Deprecated. Use `read_suites` instead. Permission to list
+  flaky tests.
 
 When creating API access tokens, you can also restrict which network address are allowed to use them, using [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
 

--- a/pages/apis/rest_api/analytics/flaky_tests.md
+++ b/pages/apis/rest_api/analytics/flaky_tests.md
@@ -25,6 +25,6 @@ curl "https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{su
 ]
 ```
 
-Required scope: `read_flaky_tests`
+Required scope: `read_suites`
 
 Success response: `200 OK`


### PR DESCRIPTION
This is the first step in removing read_flaky_tests. Next steps will include migrating existing tokens and updating terraform providers etc. At some point we aim to remove it from the docs completely.

![image](https://github.com/buildkite/docs/assets/543166/e7ddd423-6d3b-4c76-a003-14061074ff81)

https://linear.app/buildkite/issue/PIE-1800/demote-flaky-tests-scope-and-promote-read-suites-scope