### PR TITLE
Document write_suites scope

### DIFF
--- a/pages/apis/managing_api_tokens.md
+++ b/pages/apis/managing_api_tokens.md
@@ -28,10 +28,11 @@ REST API scopes are very granular, you can select some or all of the following:
 * Read Pipelines `read_pipelines` - Permission to list and retrieve details of pipelines
 * Write Pipelines `write_pipelines` - Permission to create, update and delete pipelines
 * Read User `read_user` - Permission to retrieve basic details of the user
-* Read Suites `read_suites` - Permission to list and retrieve details of suites; including runs,
+* Read Suites `read_suites` - Permission to list and retrieve details of test suites; including runs,
   tests, executions, etc.
+* Write Suites `write_suites` - Permission to create, update and delete test suites
 * Read Flaky Tests `read_flaky_tests` - Deprecated. Use `read_suites` instead. Permission to list
-  flaky tests.
+  flaky tests
 
 When creating API access tokens, you can also restrict which network address are allowed to use them, using [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
 


### PR DESCRIPTION
I forgot to add this in 9b6accd6a09af7121e42ff10b0236c3ebc36fe7e. Technically we don't have the ability to update or delete suites via the api at present. However, it's coming very soon. I think it's important to include because any tokens with the write_suites scope will soon have the ability to update and delete them.