### PR TITLE
Update cli_step.md

### DIFF
--- a/pages/agent/v3/cli_step.md
+++ b/pages/agent/v3/cli_step.md
@@ -9,6 +9,7 @@ Use this command in your build scripts to update an attribute of a step.
 
 <%= render 'agent/v3/help/step_update' %>
 
+label update works on a step level and not on the job level, it would not be possible to update each job in a step 
 ## Getting a step
 
 Use this command in your build scripts to get the value of a particular attribute from a step.


### PR DESCRIPTION
Customers have recently wanted to be be able update each job label individually and it is not possible. Because the Buildkite-agent does the label update on a step level