### PR TITLE
Bugfix curl command for Suite#create (localhost => com)

### DIFF
--- a/pages/apis/rest_api/analytics/suites.md
+++ b/pages/apis/rest_api/analytics/suites.md
@@ -48,7 +48,7 @@ Success response: `200 OK`
 
 ```bash
 curl -X POST \
-  http://api.buildkite.localhost/v2/analytics/organizations/{org.slug}/suites \
+  http://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites \
   -d '{
     "name": "Jasmine",
     "default_branch": "main",


### PR DESCRIPTION
I just spotted a bug on our docs:

<img width="818" alt="Screenshot 2023-06-20 at 2 40 57 pm" src="https://github.com/buildkite/docs/assets/47379003/6ffc74b4-4821-45ca-9757-bdf5b0f38c59">

I think it should be buildkite.com rather than buildkite.localhost