### PR TITLE
rate limits documentation

### DIFF
--- a/data/nav_graphql.yml
+++ b/data/nav_graphql.yml
@@ -5,6 +5,8 @@
   path: apis/graphql/graphql-tutorial
 - name: Cookbook
   path: apis/graphql/graphql-cookbook
+- name: Limits
+  path: apis/graphql/graphql-resource-limits
 - name: Queries
   children:
   - name: agent

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -1,6 +1,6 @@
 # GraphQL resource limits
 
-To ensure that Buildkite stays stable for everyone, we have set some limits on our GraphQL API. These limits prevent excessive or abusive calls to our servers while still allowing API users to use GraphQL endpoints in a wide range of ways.
+To ensure that Buildkite stays stable for everyone, there are limits on how you can use the GraphQL API. These limits prevent excessive or abusive calls to the servers while still allowing you to use GraphQL endpoints in a wide range of ways.
 
 Our limits are based on the complexity of the query. We calculate complexity based on requested resources of the query and encourage developers to responsibly use techniques for limiting calls, pagination, caching and retrying requests to lower the complexity of the queries.
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -141,7 +141,7 @@ The rate limit status is available in the following response headers of each Gra
 
 `RateLimit-Remaining` — The remaining complexity left within the current time window.  
 `RateLimit-Limit` — The complexity limit for the time window.  
-`RateLimit-Reset` — The number of seconds remaining until a new time window is started and the limits are reset. 
+`RateLimit-Reset` — The number of seconds remaining until a new time window is started and the limits are reset.
 
 ```js
 RateLimit-Remaining: 20
@@ -173,9 +173,9 @@ Designing your client application with best practices in mind is the simplest wa
 
 Consider the following best practices when designing you API usage:
 
-* Optimize the request by only requesting data you require. We recommend using specific queries rather than a single all-purpose query.
-* Always use appropriate `first` or `last` values when requesting connections. Not providing those may default to 500, which can increase the requested complexity exponentially.
-* Use strategies like caching for data you use often that is unlikely to be updated instead of constantly calling APIs.
-* Regulate the rate of your requests for smoother distribution. You can do this using queues or scheduling API calls in appropriate intervals.
-* Use metadata about your API usage, including rate limit status to manage the behavior dynamically.
-* Think of rate limiting while designing your client application. Be mindful of retries, errors, loops, and the frequency of API calls.
+- Optimize the request by only requesting data you require. We recommend using specific queries rather than a single all-purpose query.
+- Always use appropriate `first` or `last` values when requesting connections. Not providing those may default to 500, which can increase the requested complexity exponentially.
+- Use strategies like caching for data you use often that is unlikely to be updated instead of constantly calling APIs.
+- Regulate the rate of your requests for smoother distribution. You can do this using queues or scheduling API calls in appropriate intervals.
+- Use metadata about your API usage, including rate limit status to manage the behavior dynamically.
+- Think of rate limiting while designing your client application. Be mindful of retries, errors, loops, and the frequency of API calls.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -60,7 +60,7 @@ query RecentPipelineSlugs {
 ```
 
 ### Actual complexity
-The actual complexity is based on the results returned after the query execution, since the connection fields can return fewer nodes than requested. Lowering requested complexity usually lowers the actual complexity of queries.
+The actual complexity is based on the results returned after the query execution, since the connection fields can return fewer nodes than requested. Lowering the requested complexity usually lowers the actual complexity of queries.
 
 Taking the same query as above, if the organization has only 10 pipelines, the actual complexity will be around 13.
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -139,7 +139,7 @@ RateLimit-Reset: 120
 
 `RateLimit-Remaining` provides the remaining complexity left within the current time window.  
 `RateLimit-Limit` is the complexity limit for the time window.  
-`RateLimit-Limit` is the number of seconds remaining until a new time window is started and the limits are reset.  
+`RateLimit-Reset` is the number of seconds remaining until a new time window is started and the limits are reset.  
 
 
 ### Response body

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -83,7 +83,7 @@ query RecentPipelineSlugs {
 
 
 ## Rate limits
-Buildkite has implemented two distinct limits to our GraphQL endpoints. These limits play a critical role in ensuring that our platform operates smoothly and efficiently, while also minimising the risk of unnecessary downtime or system failures.
+Buildkite has implemented two distinct limits to our GraphQL endpoints. These limits play a critical role in ensuring that our platform operates smoothly and efficiently, while minimising the risk of unnecessary downtime or system failures.
 
 By enforcing these limits, we can effectively manage and allocate the necessary resources for our GraphQL endpoints.
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -40,6 +40,7 @@ Although these default costs are in place, Buildkite reserves the right to set m
 Buildkite calculates the cost of the query before and after the query execution.
 
 ### Requested complexity
+
 The requested complexity is calculated based on the number of fields and objects requested. Usually, requesting a deeply nested query or excluding pagination details from connections results in high requested complexity.
 
 A simple query like the following would incur more than 500 requested complexity points as the query asks for 503 possible resources.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -33,7 +33,7 @@ A cost is based on what the field returns.
   </tr>
 </table>
 
-Although these default costs are in place, Buildkite also reserves the right to set manual costs to individual fields.
+Although these default costs are in place, Buildkite reserves the right to set manual costs to individual fields.
 
 
 ## Complexity calculation

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -135,7 +135,7 @@ If an organization exceeds the 20,000 point limit, the response will return HTTP
 
 ## Accessing limit details
 
-### HTTP headers
+### Check time based limits
 
 The rate limit status is available in the following response headers of each GraphQL call:
 
@@ -149,7 +149,7 @@ RateLimit-Limit: 20000
 RateLimit-Reset: 120
 ```
 
-### Response body
+### View query complexity
 
 To include the complexity data in responses, use the `Buildkite-Include-Query-Stats` header in GraphQL requests. This returns the complexity data in the response like the following:
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -4,8 +4,8 @@ To ensure that Buildkite stays stable for everyone, we have set some limits on o
 
 Our limits are based on the complexity of the query. We calculate complexity based on requested resources of the query and encourage developers to responsibly use techniques for limiting calls, pagination, caching and retrying requests to lower the complexity of the queries.
 
-
 ## Query complexity
+
 Every field type in the schema has an integer cost assigned to it. The cost of the query is the sum of the cost of each field. Usually, running the query is the best way to know the true cost of the query.
 
 A cost is based on what the field returns.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -108,7 +108,7 @@ If the query exceeds the limit, the response will return HTTP 200 status code wi
 
 ### Time based rate limit
 
-To ensure optimal performance, an organization can use up to 20,000 actual complexity points within a 5 minute period. By allowing a set number of actual complexity points, we provide organizations flexibility to run query of different sizes within a 5 minute window.
+To ensure optimal performance, an organization can use up to 20,000 actual complexity points within a 5 minute period. By allowing a set number of actual complexity points, we provide organizations flexibility to run queries of different sizes within a 5 minute window.
 
 As a best practice, we recommend utilising client size strategies like caching to lower the number of API calls, queues to schedule API calls or proper use of pagination to only request necessary data to manage time based rate limits.
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -135,7 +135,7 @@ If an organization exceeds the 20,000 point limit, the response will return HTTP
 
 ## Accessing limit details
 
-### Check time based limits
+### Check time-based limits
 
 The rate limit status is available in the following response headers of each GraphQL call:
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -171,7 +171,7 @@ To include the complexity data in responses, use the `Buildkite-Include-Query-St
 
 Designing your client application with best practices in mind is the simplest way to avoid throttling errors. For example, you can stagger API requests in a queue and do other processing tasks while waiting for the next queued job to run.
 
-Consider the following best practices when designing you API usage:
+Consider the following best practices when designing your API usage:
 
 - Optimize the request by only requesting data you require. We recommend using specific queries rather than a single all-purpose query.
 - Always use appropriate `first` or `last` values when requesting connections. Not providing those may default to 500, which can increase the requested complexity exponentially.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -132,16 +132,17 @@ If an organization exceeds the 20,000 point limit, the response will return HTTP
 }
 ```
 
-
 ## Accessing limit details
 
 ### Check time-based limits
 
 The rate limit status is available in the following response headers of each GraphQL call:
 
-`RateLimit-Remaining` — The remaining complexity left within the current time window.  
-`RateLimit-Limit` — The complexity limit for the time window.  
-`RateLimit-Reset` — The number of seconds remaining until a new time window is started and the limits are reset.
+- `RateLimit-Remaining` — The remaining complexity left within the current time window.  
+- `RateLimit-Limit` — The complexity limit for the time window.  
+- `RateLimit-Reset` — The number of seconds remaining until a new time window is started and the limits are reset.
+
+For example:
 
 ```js
 RateLimit-Remaining: 20
@@ -173,7 +174,7 @@ Designing your client application with best practices in mind is the simplest wa
 
 Consider the following best practices when designing your API usage:
 
-- Optimize the request by only requesting data you require. We recommend using specific queries rather than a single all-purpose query.
+- Optimize the request by only requesting the data you require. We recommend using specific queries rather than a single all-purpose query.
 - Always use appropriate `first` or `last` values when requesting connections. Not providing those may default to 500, which can increase the requested complexity exponentially.
 - Use strategies like caching for data you use often that is unlikely to be updated instead of constantly calling APIs.
 - Regulate the rate of your requests for smoother distribution. You can do this using queues or scheduling API calls in appropriate intervals.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -133,7 +133,7 @@ We provide rate limit status on response headers of each GraphQL call. We have 3
 
 ```js
 RateLimit-Remaining: 20
-RateLimit-Limit: 10000
+RateLimit-Limit: 20000
 RateLimit-Reset: 120
 ```
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -35,7 +35,6 @@ A cost is based on what the field returns using the following values.
 
 Although these default costs are in place, Buildkite reserves the right to set manual costs to individual fields.
 
-
 ## Complexity calculation
 
 Buildkite calculates the cost of the query before and after the query execution.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -110,7 +110,7 @@ If the query exceeds the limit, the response will return HTTP 200 status code wi
 
 To ensure optimal performance, an organization can use up to 20,000 actual complexity points within a 5 minute period. By allowing a set number of actual complexity points, we provide organizations flexibility to run queries of different sizes within a 5 minute window.
 
-As a best practice, we recommend utilising client size strategies like caching to lower the number of API calls, queues to schedule API calls or proper use of pagination to only request necessary data to manage time based rate limits.
+As a best practice, we recommend utilizing client size strategies like caching to lower the number of API calls, queues to schedule API calls or proper use of pagination to only request necessary data to manage time based rate limits.
 
 If an organization exceeds the 20,000 points limit, the response will return HTTP 429 status code with the following error.
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -83,9 +83,9 @@ query RecentPipelineSlugs {
 
 
 ## Rate limits
-Buildkite has implemented two distinct limits to our graphql endpoints. These limits play a critical role in ensuring that our platform operates smoothly and efficiently, while also minimising the risk of unnecessary downtime or system failures.
+Buildkite has implemented two distinct limits to our GraphQL endpoints. These limits play a critical role in ensuring that our platform operates smoothly and efficiently, while also minimising the risk of unnecessary downtime or system failures.
 
-By enforcing these limits, we can effectively manage and allocate the necessary resources for our graphql endpoints.
+By enforcing these limits, we can effectively manage and allocate the necessary resources for our GraphQL endpoints.
 
 ### Single query limit
 
@@ -144,7 +144,7 @@ RateLimit-Reset: 120
 
 ### Response body
 
-You can include the header  `Buildkite-Include-Query-Stats` to the graphql request, which will return the complexity data along with the graphql response.
+You can include the header  `Buildkite-Include-Query-Stats` to the GraphQL request, which will return the complexity data along with the GraphQL response.
 
 ```json
 {
@@ -162,13 +162,13 @@ You can include the header  `Buildkite-Include-Query-Stats` to the graphql reque
 
 ## Best practices to avoid rate limit errors
 
-Designing your client application with best practices in mind is the best way to avoid throttling errors. For example, you can stagger API requests in a queue and do other processing tasks while waiting for the next queued job to run. 
+Designing your client application with best practices in mind is the best way to avoid throttling errors. For example, you can stagger API requests in a queue and do other processing tasks while waiting for the next queued job to run.  
 
 Consider the following best practices when designing the app:
 
 * Optimize the request by only requesting data your app requires. We recommend using specific queries rather than a single all-purpose queries.
 * Always use appropriate `first` or `last` values when requesting connections. Not providing those may default to up to 500 which can increase the requested complexity exponentially.
-* Use strategies like caching for data that you use often and are unlikely to be updated instead of calling APIs constantly. 
+* Use strategies like caching for data that you use often and are unlikely to be updated instead of calling APIs constantly.
 * Regulate the rate of your requests for smoother distribution. These can be done by using queues or scheduling API calls in appropriate intervals.
 * Use metadata about your app’s API usage, including rate limit status to manage app’s behaviour dynamically.
 * Think of rate limiting while designing your client application. Be mindful of retries, errors, loops and the frequency of API calls.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -41,7 +41,7 @@ A cost is based on what the field returns using the following values.
   <tbody>
 </table>
 
-Although these default costs are in place, Buildkite reserves the right to set manual costs to individual fields.
+Although these default costs are in place, Buildkite reserves the right to set different costs for specific fields.
 
 ## Complexity calculation
 
@@ -86,11 +86,6 @@ query RecentPipelineSlugs {
   }
 }
 ```
-
-<!-- How to show example -->
-
-
-
 
 ## Rate limits
 Buildkite has implemented two distinct limits to the GraphQL endpoints. These limits play a critical role in ensuring the platform operates smoothly and efficiently, while minimizing the risk of unnecessary downtime or system failures.
@@ -144,16 +139,15 @@ If an organization exceeds the 20,000 point limit, the response will return HTTP
 
 The rate limit status is available in the following response headers of each GraphQL call:
 
+`RateLimit-Remaining` — The remaining complexity left within the current time window.  
+`RateLimit-Limit` — The complexity limit for the time window.  
+`RateLimit-Reset` — The number of seconds remaining until a new time window is started and the limits are reset. 
+
 ```js
 RateLimit-Remaining: 20
 RateLimit-Limit: 20000
 RateLimit-Reset: 120
 ```
-
-`RateLimit-Remaining` provides the remaining complexity left within the current time window.  
-`RateLimit-Limit` is the complexity limit for the time window.  
-`RateLimit-Reset` is the number of seconds remaining until a new time window is started and the limits are reset.  
-
 
 ### Response body
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -171,4 +171,4 @@ Consider the following best practices when designing the app:
 * Use strategies like caching for data that you use often and are unlikely to be updated instead of calling APIs constantly.
 * Regulate the rate of your requests for smoother distribution. These can be done by using queues or scheduling API calls in appropriate intervals.
 * Use metadata about your app’s API usage, including rate limit status to manage app’s behaviour dynamically.
-* Think of rate limiting while designing your client application. Be mindful of retries, errors, loops and the frequency of API calls.
+* Think of rate limiting while designing your client application. Be mindful of retries, errors, loops, and the frequency of API calls.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -112,7 +112,7 @@ To ensure optimal performance, an organization can use up to 20,000 actual compl
 
 As a best practice, we recommend utilising client size strategies like caching to lower the number of API calls, queues to schedule API calls or proper use of pagination to only request necessary data to manage time based rate limits.
 
-If an organisation exceeds the 20,000 points limit, the response will return HTTP 429 status code with the following error.
+If an organization exceeds the 20,000 points limit, the response will return HTTP 429 status code with the following error.
 
 ```json
 {

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -167,7 +167,7 @@ Designing your client application with best practices in mind is the best way to
 Consider the following best practices when designing the app:
 
 * Optimize the request by only requesting data your app requires. We recommend using specific queries rather than a single all-purpose query.
-* Always use appropriate `first` or `last` values when requesting connections. Not providing those may default to up to 500 which can increase the requested complexity exponentially.
+* Always use appropriate `first` or `last` values when requesting connections. Not providing those may default to 500 which can increase the requested complexity exponentially.
 * Use strategies like caching for data that you use often and are unlikely to be updated instead of calling APIs constantly.
 * Regulate the rate of your requests for smoother distribution. These can be done by using queues or scheduling API calls in appropriate intervals.
 * Use metadata about your app’s API usage, including rate limit status to manage app’s behaviour dynamically.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -1,6 +1,6 @@
 # GraphQL resource limits
 
-To make sure that Buildkite stays stable for everyone, we have set some limits on our GraphQL API. These limits prevent excessive or abusive calls to our servers while still allowing API users to use GraphQL endpoints in a wide range of ways.
+To ensure that Buildkite stays stable for everyone, we have set some limits on our GraphQL API. These limits prevent excessive or abusive calls to our servers while still allowing API users to use GraphQL endpoints in a wide range of ways.
 
 Our limits are based on the complexity of the query. We calculate complexity based on requested resources of the query and encourage developers to responsibly use techniques for limiting calls, pagination, caching and retrying requests to lower the complexity of the queries.
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -2,7 +2,7 @@
 
 To make sure that Buildkite stays stable for everyone, we have set some limits on our GraphQL API. These limits prevent excessive or abusive calls to our servers while still allowing API users to use GraphQL endpoints in a wide range of ways.
 
-Our limits are based on the complexity of the query. We calculate complexity based requested resources of the query and encourage developers to responsibly use techniques for limiting calls, pagination, caching and retrying requests to lower the complexity of the queries.
+Our limits are based on the complexity of the query. We calculate complexity based on requested resources of the query and encourage developers to responsibly use techniques for limiting calls, pagination, caching and retrying requests to lower the complexity of the queries.
 
 
 ## Query complexity

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -2,7 +2,7 @@
 
 To ensure that Buildkite stays stable for everyone, there are limits on how you can use the GraphQL API. These limits prevent excessive or abusive calls to the servers while still allowing you to use GraphQL endpoints in a wide range of ways.
 
-Our limits are based on the complexity of the query. We calculate complexity based on requested resources of the query and encourage developers to responsibly use techniques for limiting calls, pagination, caching and retrying requests to lower the complexity of the queries.
+The limits are based on query complexity, which is calculated from the requested resources. We recommend using techniques for limiting calls, pagination, caching, and retrying requests to lower the complexity of queries.
 
 ## Query complexity
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -11,26 +11,34 @@ Every field type in the schema has an integer cost assigned to it. The cost of t
 A cost is based on what the field returns using the following values.
 
 <table>
-  <tr>
-    <td>Scalar</td>
-    <td>0 complexity point</td>
-  </tr>
-  <tr>
-    <td>Enum</td>
-    <td>0 complexity point</td>
-  </tr>
-  <tr>
-    <td>Object</td>
-    <td>1 complexity point</td>
-  </tr>
-  <tr>
-    <td>Interface</td>
-    <td>1 complexity point</td>
-  </tr>
-  <tr>
-    <td>Union</td>
-    <td>1 complexity point</td>
-  </tr>
+  <thead>
+    <tr>
+      <th>Field type</th>
+      <th>Complexity value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Scalar</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <td>Enum</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <td>Object</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>Interface</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>Union</td>
+      <td>1</td>
+    </tr>
+  <tbody>
 </table>
 
 Although these default costs are in place, Buildkite reserves the right to set manual costs to individual fields.
@@ -51,7 +59,7 @@ query RecentPipelineSlugs {
     pipelines(first: 500) {                  # 1 point
       edges {                                # 1 point
         node {                               # 500 points
-          slug                               # 0 point
+          slug                               # 0 points
         }
       }
     }
@@ -60,9 +68,10 @@ query RecentPipelineSlugs {
 ```
 
 ### Actual complexity
+
 The actual complexity is based on the results returned after the query execution, since the connection fields can return fewer nodes than requested. Lowering the requested complexity usually lowers the actual complexity of queries.
 
-Taking the same query as above, if the organization has only 10 pipelines, the actual complexity will be around 13.
+Taking the same query used earlier, if the organization has only 10 pipelines, the actual complexity will be around 13.
 
 ```graphql
 query RecentPipelineSlugs {
@@ -70,7 +79,7 @@ query RecentPipelineSlugs {
     pipelines(first: 500) {                  # 1 point
       edges {                                # 1 point
         node {                               # 10 points
-          slug                               # 0 point
+          slug                               # 0 points
         }
       }
     }
@@ -82,8 +91,9 @@ query RecentPipelineSlugs {
 
 
 
+
 ## Rate limits
-Buildkite has implemented two distinct limits to our GraphQL endpoints. These limits play a critical role in ensuring that our platform operates smoothly and efficiently, while minimising the risk of unnecessary downtime or system failures.
+Buildkite has implemented two distinct limits to the GraphQL endpoints. These limits play a critical role in ensuring the platform operates smoothly and efficiently, while minimizing the risk of unnecessary downtime or system failures.
 
 By enforcing these limits, we can effectively manage and allocate the necessary resources for our GraphQL endpoints.
 
@@ -91,7 +101,7 @@ By enforcing these limits, we can effectively manage and allocate the necessary 
 
 Buildkite's API has a requested complexity limit of 50,000 for each individual query. This limit is enforced prior to query execution. The intention of this limit is to prevent users from requesting an excessive number of resources in a single query.
 
-As a best practice, we recommend breaking up queries into smaller, more manageable chunks and utilizing pagination to navigate through the resulting list, rather than relying on a single large query.
+As a best practice, we recommend breaking up queries into smaller, more manageable chunks and utilizing pagination to navigate through the resulting list rather than relying on a single large query.
 
 If the query exceeds the limit, the response will return HTTP 200 status code with the following error.
 
@@ -105,14 +115,17 @@ If the query exceeds the limit, the response will return HTTP 200 status code wi
 }
 ```
 
+### Time-based rate limit
 
-### Time based rate limit
+To ensure optimal performance, an organization can use up to 20,000 actual complexity points within a 5-minute period. By allowing a set number of actual complexity points, you have the flexibility to run queries of different sizes within a 5-minute window.
 
-To ensure optimal performance, an organization can use up to 20,000 actual complexity points within a 5 minute period. By allowing a set number of actual complexity points, we provide organizations flexibility to run queries of different sizes within a 5 minute window.
+As a best practice, we recommend utilizing client-side strategies like the following to manage time-based rate limits:
 
-As a best practice, we recommend utilizing client size strategies like caching to lower the number of API calls, queues to schedule API calls or proper use of pagination to only request necessary data to manage time based rate limits.
+- Caching to lower the number of API calls.
+- Queues to schedule API calls.
+- Pagination to only request the necessary data.
 
-If an organization exceeds the 20,000 points limit, the response will return HTTP 429 status code with the following error.
+If an organization exceeds the 20,000 point limit, the response will return HTTP 429 status code with the following error.
 
 ```json
 {
@@ -125,11 +138,11 @@ If an organization exceeds the 20,000 points limit, the response will return HTT
 ```
 
 
-## Accessing limits details
+## Accessing limit details
 
 ### HTTP headers
 
-We provide rate limit status on response headers of each GraphQL call. We have 3 rate limit related headers
+The rate limit status is available in the following response headers of each GraphQL call:
 
 ```js
 RateLimit-Remaining: 20
@@ -144,7 +157,7 @@ RateLimit-Reset: 120
 
 ### Response body
 
-You can include the header  `Buildkite-Include-Query-Stats` to the GraphQL request, which will return the complexity data along with the GraphQL response.
+To include the complexity data in responses, use the `Buildkite-Include-Query-Stats` header in GraphQL requests. This returns the complexity data in the response like the following:
 
 ```json
 {
@@ -162,13 +175,13 @@ You can include the header  `Buildkite-Include-Query-Stats` to the GraphQL reque
 
 ## Best practices to avoid rate limit errors
 
-Designing your client application with best practices in mind is the best way to avoid throttling errors. For example, you can stagger API requests in a queue and do other processing tasks while waiting for the next queued job to run.  
+Designing your client application with best practices in mind is the simplest way to avoid throttling errors. For example, you can stagger API requests in a queue and do other processing tasks while waiting for the next queued job to run.
 
-Consider the following best practices when designing the app:
+Consider the following best practices when designing you API usage:
 
-* Optimize the request by only requesting data your app requires. We recommend using specific queries rather than a single all-purpose query.
-* Always use appropriate `first` or `last` values when requesting connections. Not providing those may default to 500 which can increase the requested complexity exponentially.
-* Use strategies like caching for data that you use often and are unlikely to be updated instead of calling APIs constantly.
-* Regulate the rate of your requests for smoother distribution. These can be done by using queues or scheduling API calls in appropriate intervals.
-* Use metadata about your app’s API usage, including rate limit status to manage app’s behaviour dynamically.
+* Optimize the request by only requesting data you require. We recommend using specific queries rather than a single all-purpose query.
+* Always use appropriate `first` or `last` values when requesting connections. Not providing those may default to 500, which can increase the requested complexity exponentially.
+* Use strategies like caching for data you use often that is unlikely to be updated instead of constantly calling APIs.
+* Regulate the rate of your requests for smoother distribution. You can do this using queues or scheduling API calls in appropriate intervals.
+* Use metadata about your API usage, including rate limit status to manage the behavior dynamically.
 * Think of rate limiting while designing your client application. Be mindful of retries, errors, loops, and the frequency of API calls.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -41,7 +41,7 @@ Although these default costs are in place, Buildkite reserves the right to set m
 Buildkite calculates the cost of the query before and after the query execution.
 
 ### Requested complexity
-The requested complexity is based on the number of fields and objects requested. Usually, requesting a deeply nested query or excluding pagination details from connections results in high requested complexity.
+The requested complexity is calculated based on the number of fields and objects requested. Usually, requesting a deeply nested query or excluding pagination details from connections results in high requested complexity.
 
 A simple query like the following would incur more than 500 requested complexity points as the query asks for 503 possible resources.
 

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -8,7 +8,7 @@ The limits are based on query complexity, which is calculated from the requested
 
 Every field type in the schema has an integer cost assigned to it. The cost of the query is the sum of the cost of each field. Usually, running the query is the best way to know the true cost of the query.
 
-A cost is based on what the field returns.
+A cost is based on what the field returns using the following values.
 
 <table>
   <tr>

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -166,7 +166,7 @@ Designing your client application with best practices in mind is the best way to
 
 Consider the following best practices when designing the app:
 
-* Optimize the request by only requesting data your app requires. We recommend using specific queries rather than a single all-purpose queries.
+* Optimize the request by only requesting data your app requires. We recommend using specific queries rather than a single all-purpose query.
 * Always use appropriate `first` or `last` values when requesting connections. Not providing those may default to up to 500 which can increase the requested complexity exponentially.
 * Use strategies like caching for data that you use often and are unlikely to be updated instead of calling APIs constantly.
 * Regulate the rate of your requests for smoother distribution. These can be done by using queues or scheduling API calls in appropriate intervals.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -1,0 +1,174 @@
+# GraphQL resource limits
+
+To make sure that Buildkite stays stable for everyone, we have set some limits on our GraphQL API. These limits prevent excessive or abusive calls to our servers while still allowing API users to use GraphQL endpoints in a wide range of ways.
+
+Our limits are based on the complexity of the query. We calculate complexity based requested resources of the query and encourage developers to responsibly use techniques for limiting calls, pagination, caching and retrying requests to lower the complexity of the queries.
+
+
+## Query complexity
+Every field type in the schema has an integer cost assigned to it. The cost of the query is the sum of the cost of each field. Usually, running the query is the best way to know the true cost of the query.
+
+A cost is based on what the field returns.
+
+<table>
+  <tr>
+    <td>Scalar</td>
+    <td>0 complexity point</td>
+  </tr>
+  <tr>
+    <td>Enum</td>
+    <td>0 complexity point</td>
+  </tr>
+  <tr>
+    <td>Object</td>
+    <td>1 complexity point</td>
+  </tr>
+  <tr>
+    <td>Interface</td>
+    <td>1 complexity point</td>
+  </tr>
+  <tr>
+    <td>Union</td>
+    <td>1 complexity point</td>
+  </tr>
+</table>
+
+Although these default costs are in place, Buildkite also reserves the right to set manual costs to individual fields.
+
+
+## Complexity calculation
+
+Buildkite calculates the cost of the query before and after the query execution.
+
+### Requested complexity
+The requested complexity is based on the number of fields and objects requested. Usually, requesting a deeply nested query or excluding pagination details from connections results in high requested complexity.
+
+A simple query like the following would incur more than 500 requested complexity points as the query asks for 503 possible resources.
+
+```graphql
+query RecentPipelineSlugs {
+  organization(slug: "organization-slug") {  # 1 point
+    pipelines(first: 500) {                  # 1 point
+      edges {                                # 1 point
+        node {                               # 500 points
+          slug                               # 0 point
+        }
+      }
+    }
+  }
+}
+```
+
+### Actual complexity
+The actual complexity is based on the results returned after the query execution, since the connection fields can return fewer nodes than requested. Lowering requested complexity usually lowers the actual complexity of queries.
+
+Taking the same query as above, if the organization has only 10 pipelines, the actual complexity will be around 13.
+
+```graphql
+query RecentPipelineSlugs {
+  organization(slug: "organization-slug") {  # 1 point
+    pipelines(first: 500) {                  # 1 point
+      edges {                                # 1 point
+        node {                               # 10 points
+          slug                               # 0 point
+        }
+      }
+    }
+  }
+}
+```
+
+<!-- How to show example -->
+
+
+
+## Rate limits
+Buildkite has implemented two distinct limits to our graphql endpoints. These limits play a critical role in ensuring that our platform operates smoothly and efficiently, while also minimising the risk of unnecessary downtime or system failures.
+
+By enforcing these limits, we can effectively manage and allocate the necessary resources for our graphql endpoints.
+
+### Single query limit
+
+Buildkite's API has a requested complexity limit of 50,000 for each individual query. This limit is enforced prior to query execution. The intention of this limit is to prevent users from requesting an excessive number of resources in a single query.
+
+As a best practice, we recommend breaking up queries into smaller, more manageable chunks and utilizing pagination to navigate through the resulting list, rather than relying on a single large query.
+
+If the query exceeds the limit, the response will return HTTP 200 status code with the following error.
+
+```json
+{
+  "errors": [
+    {
+      "message": "Query has complexity of 251503, which exceeds max complexity of 50000"
+    }
+  ]
+}
+```
+
+
+### Time based rate limit
+
+To ensure optimal performance, an organization can use up to 20,000 actual complexity points within a 5 minute period. By allowing a set number of actual complexity points, we provide organizations flexibility to run query of different sizes within a 5 minute window.
+
+As a best practice, we recommend utilising client size strategies like caching to lower the number of API calls, queues to schedule API calls or proper use of pagination to only request necessary data to manage time based rate limits.
+
+If an organisation exceeds the 20,000 points limit, the response will return HTTP 429 status code with the following error.
+
+```json
+{
+    "errors": [
+        {
+            "message": "Your organization has exceeded the limit of 20000 complexity points. Please try again in 187 seconds."
+        }
+    ]
+}
+```
+
+
+## Accessing limits details
+
+### HTTP headers
+
+We provide rate limit status on response headers of each GraphQL call. We have 3 rate limit related headers
+
+```js
+RateLimit-Remaining: 20
+RateLimit-Limit: 10000
+RateLimit-Reset: 120
+```
+
+`RateLimit-Remaining` provides the remaining complexity left within the current time window.  
+`RateLimit-Limit` is the complexity limit for the time window.  
+`RateLimit-Limit` is the number of seconds remaining until a new time window is started and the limits are reset.  
+
+
+### Response body
+
+You can include the header  `Buildkite-Include-Query-Stats` to the graphql request, which will return the complexity data along with the graphql response.
+
+```json
+{
+  "data" : {
+    "organization": {
+      "name": "Buildkite"
+    }
+  },
+  "stats" : {
+    "requestedComplexity": 1910,
+    "actualComplexity": 550
+  }
+}
+```
+
+## Best practices to avoid rate limit errors
+
+Designing your client application with best practices in mind is the best way to avoid throttling errors. For example, you can stagger API requests in a queue and do other processing tasks while waiting for the next queued job to run. 
+
+Consider the following best practices when designing the app:
+
+* Optimize the request by only requesting data your app requires. We recommend using specific queries rather than a single all-purpose queries.
+* Always use appropriate `first` or `last` values when requesting connections. Not providing those may default to up to 500 which can increase the requested complexity exponentially.
+* Use strategies like caching for data that you use often and are unlikely to be updated instead of calling APIs constantly. 
+* Regulate the rate of your requests for smoother distribution. These can be done by using queues or scheduling API calls in appropriate intervals.
+* Use metadata about your app’s API usage, including rate limit status to manage app’s behaviour dynamically.
+* Think of rate limiting while designing your client application. Be mindful of retries, errors, loops and the frequency of API calls.

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -134,6 +134,8 @@ If an organization exceeds the 20,000 point limit, the response will return HTTP
 
 ## Accessing limit details
 
+You can access both time-based limits and query complexity information through the API. Accessing limit details will not incur any additional complexity points.
+
 ### Check time-based limits
 
 The rate limit status is available in the following response headers of each GraphQL call:


### PR DESCRIPTION
Public documentation of GraphQL resource limits.

More context:
https://3.basecamp.com/3453178/buckets/1933834/messages/6221093655
https://3.basecamp.com/3453178/buckets/23328660/messages/6161786100#__recording_6176276293


This PR 
* adds a nav item under API > Graphql > Limits
* Adds markdown file with graphql rate limits documentation

