### PR TITLE
Pipeline's UUID and info added to graphql cookbook

### DIFF
--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -82,6 +82,48 @@ query RecentPipelineSlugs {
 }
 ```
 
+### Get a pipeline's UUID
+
+Get a pipeline's UUID by searching for it in the API. Search term can match a pipeline slug.
+
+_Note: Pipeline slugs are modifiable and can change_
+
+```graphql
+query GetPipelineUUID {
+  organization(slug: "organization-slug") {
+    pipelines(first: 50, search: "part of slug") {
+      edges {
+        node {
+          slug
+          uuid
+        }
+      }
+    }
+  }
+}
+```
+
+### Get a pipeline's information
+
+You can get specific pipeline information for each of your pipeline. You can retrieve information for each build, jobs, and any other information listed on [this](https://buildkite.com/docs/apis/graphql/schemas/object/pipeline) page.
+
+```graphql
+query GetPipelineInfo {
+  pipeline(uuid: "pipeline-uuid") {
+    slug
+    uuid
+    builds(first:50){
+      edges {
+        node {
+          state
+          message
+        }
+      }
+    }
+  }
+}
+```
+
 ### Get pipeline metrics
 
 The _Pipelines_ page in Buildkite shows speed, reliability, and builds per week, for each pipeline. You can also access this information through the API.

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -105,7 +105,7 @@ query GetPipelineUUID {
 
 ### Get a pipeline's information
 
-You can get specific pipeline information for each of your pipeline. You can retrieve information for each build, jobs, and any other information listed on [this](https://buildkite.com/docs/apis/graphql/schemas/object/pipeline) page.
+You can get more specific pipeline information for each of your pipelines. You can retrieve information for each build, jobs, and any other information listed on [this](https://buildkite.com/docs/apis/graphql/schemas/object/pipeline) page.
 
 ```graphql
 query GetPipelineInfo {


### PR DESCRIPTION
Adds to the GraphQL cookbook the ability to retrieve a pipeline's UUID and use that UUID inorder to get in depth info about that pipeline.

Reference HelpScout Ticket: https://secure.helpscout.net/conversation/2280173033/53169/