### PR TITLE
Pattern for promoted experiments

### DIFF
--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -91,7 +91,7 @@ attributes:
   experimental: false
   required: false
   desc: |
-      Flags to pass to the `git clone` command when used for mirroring. Refer to [Git mirrors](/docs/agent/v3#promoted-experiments-git-mirrors) for more information on this feature.
+      Flags to pass to the `git clone` command when used for mirroring. Refer to [Git mirrors](/docs/agent/v3#promoted-experiments-git-mirrors) for more information on this feature. Introduced in [v3.47.0](https://github.com/buildkite/agent/releases/tag/v3.47.0).
       _Example:_ `-v --mirror`.
 - name: git-fetch-flags
   env_var: BUILDKITE_GIT_FETCH_FLAGS
@@ -106,14 +106,14 @@ attributes:
   required: false
   experimental: false
   desc: |
-      Seconds to lock a git mirror during clone. Should exceed your longest checkout. Refer to [Git mirrors](/docs/agent/v3#promoted-experiments-git-mirrors) for more information on this feature.
+      Seconds to lock a git mirror during clone. Should exceed your longest checkout. Refer to [Git mirrors](/docs/agent/v3#promoted-experiments-git-mirrors) for more information on this feature. Introduced in [v3.47.0](https://github.com/buildkite/agent/releases/tag/v3.47.0).
 - name: git-mirrors-path
   env_var: BUILDKITE_GIT_MIRRORS_PATH
   default_value: "none"
   required: false
   experimental: false
   desc: |
-      Path to where mirrors of git repositories are stored. Refer to [Git mirrors](/docs/agent/v3#promoted-experiments-git-mirrors) for more information on this feature.
+      Path to where mirrors of git repositories are stored. Refer to [Git mirrors](/docs/agent/v3#promoted-experiments-git-mirrors) for more information on this feature. Introduced in [v3.47.0](https://github.com/buildkite/agent/releases/tag/v3.47.0).
       _Example:_ `/tmp/buildkite-git-mirrors`
 - name: health-check-addr
   env_var: BUILDKITE_AGENT_HEALTH_CHECK_ADDR

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -379,7 +379,7 @@ variables:
   example: "git@github.com:acme-inc/my-project.git"
 - name: BUILDKITE_REPO_MIRROR
   desc: |
-    The path to the shared git mirror.
+    The path to the shared git mirror. Introduced in [v3.47.0](https://github.com/buildkite/agent/releases/tag/v3.47.0).
   modifiable: false
   example: "/tmp/buildkite-git-mirrors"
 - name: BUILDKITE_RETRY_COUNT

--- a/pages/agent/v3.md
+++ b/pages/agent/v3.md
@@ -83,12 +83,6 @@ If an experiment doesn't exist, no error will be raised.
 >🚧
 > Please note that there is every chance we will remove or change these experiments, so using them should be at your own risk and without the expectation that they will work in future!
 
-### Redacted variables
-
-The Buildkite agent can redact strings that match the value of environment variables whose names match common patterns for passwords and other secure information before the build log is uploaded to Buildkite.
-
-See [redacted-vars](/docs/pipelines/managing-log-output#redacted-environment-variables) for more information.
-
 ### Normalised upload paths
 
 Artifacts uploaded by `buildkite-agent artifact upload` will be uploaded using URI/Unix-style paths, even on Windows. This makes sure that artifacts uploaded from Windows agents are stored in a URI-compatible URL.
@@ -153,15 +147,25 @@ The API is exposed using a Unix Domain Socket. Unlike the `job-api`, the path to
 
 ## Promoted experiments
 
-We've recently promoted some experiments into full features.
+The following features started as experiments before being promoted to fully supported features.
+
+### Flock file locks
+
+Changes the file lock implementation from `github.com/nightlyone/lockfile` to `github.com/gofrs/flock` to address an issue where file locks are never released by agents that don't shut down cleanly. The new file locks are implemented at the kernel level, and are aware of when their parent process dies.
+
+Promoted in [v3.48.0](https://github.com/buildkite/agent/releases/tag/v3.48.0). It's the default behavior, so there's no configuration required to use it. Because the old and new lock systems do not interact, we *strongly* recommend not running different versions of the agent on the same host.
+
+### ANSI timestamps
+
+Outputs inline ANSI timestamps for each line of log output which enables toggle-able timestamps in the Buildkite UI.
+
+Promoted in [v3.48.0](https://github.com/buildkite/agent/releases/tag/v3.48.0). It's the default behavior, so there's no configuration required to use it. If you want to turn it off, pass the `--no-ansi-timestamps` flag.
 
 ### Git mirrors
 
 Maintain a single bare git mirror for each repository on a host that is shared amongst multiple agents and pipelines. Checkouts reference the git mirror using `git clone --reference`, as do submodules.
 
->🎓 Promoted experiment
->
-> Git mirrors became a full feature in Agent v3.47.0. It can be used by setting the `--git-mirrors-path` flag.
+Promoted in [v3.47.0](https://github.com/buildkite/agent/releases/tag/v3.47.0). You can use it by setting the `--git-mirrors-path` flag.
 
 See the following agent configuration options for more information:
 
@@ -169,22 +173,13 @@ See the following agent configuration options for more information:
 - [git-mirrors-lock-timeout](/docs/agent/v3/configuration#git-mirrors-lock-timeout)
 - [git-mirrors-path](/docs/agent/v3/configuration#git-mirrors-path)
 
-### Flock file locks
+### Redacted variables
 
-Changes the file lock implementation from `github.com/nightlyone/lockfile` to `github.com/gofrs/flock` to address an issue where file locks are never released by agents that don't shut down cleanly. The new file locks are implemented at the kernel level, and are aware of when their parent process dies.
+The Buildkite agent can redact strings that match the value of environment variables whose names match common patterns for passwords and other secure information before the build log is uploaded to Buildkite.
 
->🎓 Promoted experiment
->
-> Flock file locks became a default feature in Agent v3.48.0. There is no configuration required to use it; it is just on. Because the old and new lock systems do not interact, we *strongly* recommend not running different versions of the agent on the same host.
+Promoted in [v3.31.0](https://github.com/buildkite/agent/releases/tag/v3.31.0).
 
-### ANSI timestamps
-
-Outputs inline ANSI timestamps for each line of log output which enables toggle-able timestamps in the Buildkite UI.
-
->🎓 Promoted experiment
->
-> ANSI timestamps became a default feature in Agent v3.48.0. There is no configuration required to use it. If you want to turn it off, pass the `--no-ansi-timestamps` flag.
-
+See [redacted-vars](/docs/pipelines/managing-log-output#redacted-environment-variables) for more information.
 
 ## Customizing with hooks
 


### PR DESCRIPTION
This change suggest a pattern for handling agent experiments that have been promoted:

- Note version it became a full feature in the configuration reference.
- List them in a new section on the agent overview, newest first.

I'd like to come back to this in the future, but think it solves the immediate need from #2196. What do you think?