### PR TITLE
Add note about substitution of user with build creator env variable v…

### DIFF
--- a/pages/pipelines/notifications.md
+++ b/pages/pipelines/notifications.md
@@ -299,6 +299,9 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
+>🚧
+> We cannot substitute `user` with the build creator environment variable value
+
 ### Conditional Slack notifications
 
 You can also add [conditionals](/docs/pipelines/notifications#conditional-notifications) to restrict the events on which notifications are sent:


### PR DESCRIPTION

This PR adds a note that we cannot substitute user with value of build creator env variable as that variable interpolation is not possible