### PR TITLE
Update api parity docs and update graphQL cookbook

### DIFF
--- a/pages/apis/api_differences.md
+++ b/pages/apis/api_differences.md
@@ -24,6 +24,7 @@ On this page, we've collected the known limitation where some API features are o
 * <%= pill "BUILDS", "builds" %> [Get all environment variables set on a build](/docs/apis/graphql/graphql-cookbook#builds-get-all-environment-variables-set-on-a-build).
 * <%= pill "BUILDS", "builds" %> [Increase the next build number](/docs/apis/graphql/graphql-cookbook#builds-increase-the-next-build-number).
 * <%= pill "BUILDS", "builds" %> [Get build info by ID] (/docs/apis/graphql/graphql-cookbook#builds-get-build-info-by-id).
+* <%= pill "BUILDS", "builds" %> [Get detailed retry info for jobs in a build](/docs/apis/graphq/graphql-cookbook#builds-get-job-retry-info-for-a-build)
 * <%= pill "JOBS", "jobs" %> [Get all jobs in a given queue for a given timeframe](/docs/apis/graphql/graphql-cookbook#jobs-get-all-jobs-in-a-given-queue-for-a-given-timeframe).
 * <%= pill "JOBS", "jobs" %> [Get all jobs in a particular concurrency group](/docs/apis/graphql/graphql-cookbook#jobs-get-all-jobs-in-a-particular-concurrency-group).
 * <%= pill "JOBS", "jobs" %> list job events.

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -152,6 +152,29 @@ query GetBuilds {
 }
 ```
 
+### Get job retry info for a build
+
+Get the retry info for jobs in a given build, jobs retried [automatically](/docs/pipelines/command-step#retry-attributes) will return `nil` for `retriedBy`.
+
+```graphql
+query GetJobRetryInfo {
+  build(slug:"organization-slug/pipeline-slug/build-number") {
+    jobs(first: 10, state:FINISHED) {
+      edges {
+        node {
+          ... on JobTypeCommand {
+            retriedBy{
+              name
+            }
+            retryType
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### Get all environment variables set on a build
 
 Retrieve all of a job's environment variables for a given build. This is the equivalent of what you see in the _Environment_ tab of each build.


### PR DESCRIPTION
We have the ability to query detailed retry info for jobs on a given build with only the GraphQL api, so this will update the api differences page, as well as add a query that shows how to do this as an example.