### PR TITLE
[PIE-1819] Documentation for Analytics REST API Suites#update and Suite#destroy

### DIFF
--- a/pages/apis/rest_api/analytics/suites.md
+++ b/pages/apis/rest_api/analytics/suites.md
@@ -97,3 +97,39 @@ Optional [request body properties](/docs/api#request-body-properties):
 Required scope: `write_suites`
 
 Success response: `201 Created`
+
+## Update a suite
+
+```bash
+curl -X PUT \
+  https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{suite.slug} \
+  -d '{
+    "name": "Jasmine",
+    "default_branch": "main"
+  }'
+```
+
+```json
+{
+  "id": "3e979a94-a479-4a6e-ab8d-8b6607ffb62c",
+  "slug": "jasmine",
+  "name": "Jasmine",
+  "url": "https://api.buildkite.com/v2/analytics/organizations/my_great_org/suites/jasmine",
+  "web_url": "https://buildkite.com/organizations/my_great_org/analytics/suites/jasmine",
+  "default_branch": "main"
+}
+```
+
+Optional [request body properties](/docs/api#request-body-properties):
+
+<table class="responsive-table">
+<tbody>
+  <tr><th><code>name</code></th><td>Name of the new suite.<br><em>Example:</em> <code>"Jasmine"</code>.</td></tr>
+  <tr><th><code>default_branch</code></th><td>Your test suite will default to showing trends for this default branch, but collect data for all test runs.<br><em>Example:</em> <code>"main"</code> or <code>"master"</code>.</td></tr>
+</tbody>
+</table>
+
+
+Required scope: `write_suites`
+
+Success response: `200 OK`

--- a/pages/apis/rest_api/analytics/suites.md
+++ b/pages/apis/rest_api/analytics/suites.md
@@ -133,3 +133,14 @@ Optional [request body properties](/docs/api#request-body-properties):
 Required scope: `write_suites`
 
 Success response: `200 OK`
+
+## Delete a suite
+
+```bash
+curl -X DELETE \
+  https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{suite.slug} \
+```
+
+Required scope: `write_clusters`
+
+Success response: `204 No Content`

--- a/pages/apis/rest_api/analytics/suites.md
+++ b/pages/apis/rest_api/analytics/suites.md
@@ -101,7 +101,7 @@ Success response: `201 Created`
 ## Update a suite
 
 ```bash
-curl -X PUT \
+curl -X PATCH \
   https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{suite.slug} \
   -d '{
     "name": "Jasmine",
@@ -124,7 +124,7 @@ Optional [request body properties](/docs/api#request-body-properties):
 
 <table class="responsive-table">
 <tbody>
-  <tr><th><code>name</code></th><td>Name of the new suite.<br><em>Example:</em> <code>"Jasmine"</code>.</td></tr>
+  <tr><th><code>name</code></th><td>Name of the suite.<br><em>Example:</em> <code>"Jasmine"</code>.</td></tr>
   <tr><th><code>default_branch</code></th><td>Your test suite will default to showing trends for this default branch, but collect data for all test runs.<br><em>Example:</em> <code>"main"</code> or <code>"master"</code>.</td></tr>
 </tbody>
 </table>
@@ -138,9 +138,9 @@ Success response: `200 OK`
 
 ```bash
 curl -X DELETE \
-  https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{suite.slug} \
+  https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{suite.slug}
 ```
 
-Required scope: `write_clusters`
+Required scope: `write_suites`
 
 Success response: `204 No Content`


### PR DESCRIPTION
Add documentation about test analytics Suites#update and Suite#destroy API endpoints

Suites#update:
<img width="747" alt="Screenshot 2023-06-26 at 4 35 20 pm" src="https://github.com/buildkite/docs/assets/47379003/7bb94cec-3c2a-41fe-b34d-74e27c776dbb">
Suite#destroy:

<img width="753" alt="Screenshot 2023-06-26 at 4 38 34 pm" src="https://github.com/buildkite/docs/assets/47379003/05794f5c-485f-4204-9d89-87c8a221053f">



