### PR TITLE
Add data retention

### DIFF
--- a/pages/test_analytics.md
+++ b/pages/test_analytics.md
@@ -38,8 +38,8 @@ Test Analytics helps you track and analyze the steps in that pipeline that invol
 
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
->📘 Data Retention
-> The upload data sent to Test Analytics is stored in S3 and deleted after six months.
+>📘 Data retention
+> The data uploaded to Test Analytics is stored in S3 and deleted after six months.
 
 ----
 

--- a/pages/test_analytics.md
+++ b/pages/test_analytics.md
@@ -38,6 +38,9 @@ Test Analytics helps you track and analyze the steps in that pipeline that invol
 
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
+>📘 Data Retention
+> The upload data sent to Test Analytics is stored in S3 and deleted after six months.
+
 ----
 
 <%= tiles "test_analytics_features" %>


### PR DESCRIPTION
The TA page needs a lot of updates, but something quick we can add, and customers asked, is about the details of the data retention, which is currently of 6 months.