### PR TITLE
Proposal: Move Build exports page into Governance section

### DIFF
--- a/data/nav.yml
+++ b/data/nav.yml
@@ -251,8 +251,6 @@
           path: "pipelines/tags"
         - name: "Build retention"
           path: "pipelines/build-retention"
-        - name: "Build exports"
-          path: "pipelines/build-exports"
         - name: "Public pipelines"
           path: "pipelines/public-pipelines"
         - name: "Using build meta-data"
@@ -308,6 +306,8 @@
           path: "pipelines/governance"
         - name: "Pipeline templates"
           path: "pipelines/templates"
+        - name: "Build exports"
+          path: "pipelines/build-exports"
     - name: "Deployments"
       children:
         - name: "Overview"

--- a/pages/pipelines/governance.md
+++ b/pages/pipelines/governance.md
@@ -1,3 +1,16 @@
 # Governance overview
 
-Buildkite cares deeply about making sure enterprise customers have their compliance needs met. These features are aimed to help with the auditing processes in your company be it specific for your industry or wide spread compliance standards like SOC.
+Governance plays a crucial role in CI/CD tools, particularly for anyone operating in regulated industries or handling sensitive data. It encompasses policies, processes, and controls to ensure practices align with the following:
+
+- Industry-specific regulations.
+- Internal policies.
+- Widely recognized compliance standards.
+
+These standards assess the security, availability, processing integrity, confidentiality, and privacy of information systems.
+
+Buildkite understands the importance of meeting compliance and auditing requirements. The following features are tailored to meet your governance needs:
+
+- [Pipeline templates](/docs/pipelines/templates)
+- [Build exports](/docs/pipelines/build-exports)
+
+With these features, you can maintain your compliance and build software with confidence.


### PR DESCRIPTION
Pipeline templates is a new feature in the upcoming release. We're including documentation for it in a new section of the docs called "Governance" in #2255. I thought it would be good to include any existing pages that would fit better in that section and @ozdenyilmaz mentioned that Build exports would be a good candidate.

What do you think?