### PR TITLE
Add an example for force clean checkout at step level

### DIFF
--- a/pages/agent/v3/securing.md
+++ b/pages/agent/v3/securing.md
@@ -158,6 +158,7 @@ steps:
   env:
     BUILDKITE_CLEAN_CHECKOUT: true
 ```
+
 In logs for this step, you will find log group "Cleaning pipeline checkout".
 
 ## Running the Agent behind a proxy

--- a/pages/agent/v3/securing.md
+++ b/pages/agent/v3/securing.md
@@ -153,7 +153,7 @@ By default, Buildkite will reuse (after cleaning) a previous checkout. This may 
 
 ```yaml
 steps:
-- label: ":github: Clean Checkout"
+- label: "Clean Checkout"
   command: echo "clean checkout"
   env:
     BUILDKITE_CLEAN_CHECKOUT: true

--- a/pages/agent/v3/securing.md
+++ b/pages/agent/v3/securing.md
@@ -149,7 +149,7 @@ exit 1
 
 ## Forcing clean checkouts
 
-By default Buildkite will reuse (after cleaning) a previous checkout. This may not be safe if building commits from untrusted sources (for example, 3rd party pull requests). To force a clean checkout every time, set `BUILDKITE_CLEAN_CHECKOUT=true` in the environment. Here is an example to force a clean checkout at step level:
+By default, Buildkite will reuse (after cleaning) a previous checkout. This may be unsafe if building commits from untrusted sources (for example, third-party pull requests). To force a clean checkout every time, set BUILDKITE_CLEAN_CHECKOUT=true in the environment. The following example shows how to enforce a clean checkout at the step level:
 
 ```yaml
 steps:

--- a/pages/agent/v3/securing.md
+++ b/pages/agent/v3/securing.md
@@ -159,7 +159,7 @@ steps:
     BUILDKITE_CLEAN_CHECKOUT: true
 ```
 
-In logs for this step, you will find log group "Cleaning pipeline checkout".
+In the logs for this step, you will find a log group called "Cleaning pipeline checkout."
 
 ## Running the Agent behind a proxy
 

--- a/pages/agent/v3/securing.md
+++ b/pages/agent/v3/securing.md
@@ -149,7 +149,7 @@ exit 1
 
 ## Forcing clean checkouts
 
-By default, Buildkite will reuse (after cleaning) a previous checkout. This may be unsafe if building commits from untrusted sources (for example, third-party pull requests). To force a clean checkout every time, set BUILDKITE_CLEAN_CHECKOUT=true in the environment. The following example shows how to enforce a clean checkout at the step level:
+By default, Buildkite will reuse (after cleaning) a previous checkout. This may be unsafe if building commits from untrusted sources (for example, third-party pull requests). To force a clean checkout every time, set `BUILDKITE_CLEAN_CHECKOUT=true` in the environment. The following example shows how to enforce a clean checkout at the step level:
 
 ```yaml
 steps:

--- a/pages/agent/v3/securing.md
+++ b/pages/agent/v3/securing.md
@@ -149,7 +149,16 @@ exit 1
 
 ## Forcing clean checkouts
 
-By default Buildkite will reuse (after cleaning) a previous checkout. This may not be safe if building commits from untrusted sources (for example, 3rd party pull requests). To force a clean checkout every time, set `BUILDKITE_CLEAN_CHECKOUT=true` in the environment.
+By default Buildkite will reuse (after cleaning) a previous checkout. This may not be safe if building commits from untrusted sources (for example, 3rd party pull requests). To force a clean checkout every time, set `BUILDKITE_CLEAN_CHECKOUT=true` in the environment. Here is an example to force a clean checkout at step level:
+
+```yaml
+steps:
+- label: ":github: Clean Checkout"
+  command: echo "clean checkout"
+  env:
+    BUILDKITE_CLEAN_CHECKOUT: true
+```
+In logs for this step, you will find log group "Cleaning pipeline checkout".
 
 ## Running the Agent behind a proxy
 


### PR DESCRIPTION
Currently in docs there is no example on how to use environment variable BUILDKITE_CLEAN_CHECKOUT to set force clean checkout so adding one through this example and also information on how to confirm from logs if clean checkout happened.