### PR TITLE
Add webhook + eventbridge docs for new CIDR locked tokens

### DIFF
--- a/data/nav.yml
+++ b/data/nav.yml
@@ -446,6 +446,8 @@
           path: "apis/webhooks/agent-events"
         - name: "Build events"
           path: "apis/webhooks/build-events"
+        - name: "Cluster token events"
+          path: "apis/webhooks/cluster-token-events"
         - name: "Job events"
           path: "apis/webhooks/job-events"
         - name: "Ping events"

--- a/pages/apis/webhooks.md
+++ b/pages/apis/webhooks.md
@@ -14,16 +14,17 @@ You can subscribe to one or more of the following events:
   <tr><th>Event</th><th>Description</th></tr>
 </thead>
 <tbody>
-  <tr><th>ping</th><td>Webhook notification settings have changed</td></tr>
-  <tr><th>build.scheduled</th><td>A build has been scheduled</td></tr>
-  <tr><th>build.running</th><td>A build has started running</td></tr>
-  <tr><th>build.failing</th><td>A build is failing</td></tr>
-  <tr><th>build.finished</th><td>A build has finished</td></tr>
-  <tr><th>job.scheduled</th><td>A job has been scheduled</td></tr>
-  <tr><th>job.started</th><td>A command step job has started running on an agent</td></tr>
-  <tr><th>job.finished</th><td>A job has finished</td></tr>
-  <tr><th>job.activated</th><td>A block step job has been unblocked using the web or API</td></tr>
+  <tr><th><code>ping</code></th><td>Webhook notification settings have changed</td></tr>
+  <tr><th><code>build.scheduled</code></th><td>A build has been scheduled</td></tr>
+  <tr><th><code>build.running</code></th><td>A build has started running</td></tr>
+  <tr><th><code>build.failing</code></th><td>A build is failing</td></tr>
+  <tr><th><code>build.finished</code></th><td>A build has finished</td></tr>
+  <tr><th><code>job.scheduled</code></th><td>A job has been scheduled</td></tr>
+  <tr><th><code>job.started</code></th><td>A command step job has started running on an agent</td></tr>
+  <tr><th><code>job.finished</code></th><td>A job has finished</td></tr>
+  <tr><th><code>job.activated</code></th><td>A block step job has been unblocked using the web or API</td></tr>
   <%= render_markdown partial: 'apis/webhooks/agent_events_table' %>
+  <tr><th><code>cluster_token.registration_blocked</code></th><td>An attempted agent registration has been blocked because the request IP address is not included in the cluster token's <a href="/docs/clusters/manage-clusters#set-up-clusters-restrict-access-for-a-cluster-token-by-ip-address">allowed IP addresses</a></td></tr>
 </tbody>
 </table>
 

--- a/pages/apis/webhooks/_agent_events_table.md
+++ b/pages/apis/webhooks/_agent_events_table.md
@@ -18,3 +18,7 @@
     <th><code>agent.stopped</code></th>
     <td>An agent has stopped. This happens when an agent is instructed to stop from the API. It can be graceful or forceful</td>
   </tr>
+  <tr>
+    <th><code>agent.blocked</code></th>
+    <td>An agent has been blocked. This happens when an agent's IP address is no longer included in the cluster token's <a href="/docs/clusters/manage-clusters#set-up-clusters-restrict-access-for-a-cluster-token-by-ip-address">allowed IP addresses</a></td>
+  </tr>

--- a/pages/apis/webhooks/agent_events.md
+++ b/pages/apis/webhooks/agent_events.md
@@ -4,18 +4,33 @@
 ## Events
 
 <table>
+  <thead>
+    <tr><th>Event</th><th>Description</th></tr>
+  </thead>
 <tbody>
 <%= render_markdown partial: 'apis/webhooks/agent_events_table' %>
 </tbody>
 </table>
 
-## Request body data
+## Common event data
+
+The following properties are sent by all events.
 
 <table>
-<tbody>
-  <tr><th><code>agent</code></th><td>The <a href="/docs/api/agents">Agent</a> this notification relates to</td></tr>
-  <tr><th><code>sender</code></th><td>The user who created the webhook</td></tr>
-</tbody>
+  <thead>
+    <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>agent</code></td>
+      <td><a href="/docs/api/agents">Agent</a></td>
+      <td>The agent this notification relates to</td></tr>
+    <tr>
+      <td><code>sender</code></td>
+      <td>String</td>
+      <td>The user who created the webhook</td>
+    </tr>
+  </tbody>
 </table>
 
 Example request body:
@@ -33,15 +48,35 @@ Example request body:
 }
 ```
 
-### `agent.blocked`
+## Agent blocked event data
+
+The following properties are sent by the `agent.blocked` event.
 
 <table>
-<tbody>
-  <tr><th><code>blocked_ip</code></th><td>The blocked request IP address</td></tr>
-  <tr><th><code>agent</code></th><td>The <a href="/docs/api/agents">Agent</a> this notification relates to</td></tr>
-  <tr><th><code>cluster_token</code></th><td>The <a href="/docs/apis/rest-api/clusters#cluster-tokens">cluster token</a> used in the registration attempt</td></tr>
-  <tr><th><code>sender</code></th><td>The user who created the webhook</td></tr>
-</tbody>
+  <thead>
+    <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>blocked_ip</code></td>
+      <td>String</td>
+      <td>The blocked request IP address</td>
+    </tr>
+    <tr>
+      <td><code>agent</code></td>
+      <td><a href="/docs/api/agents">Agent</a></td>
+      <td>The agent this notification relates to</td>
+    </tr>
+    <tr>
+      <td><code>cluster_token</code></td>
+      <td><a href="/docs/apis/rest-api/clusters#cluster-tokens-token-data-model">Cluster token</a></td>
+      <td>The cluster token used in the registration attempt</td>
+    </tr>
+    <tr>
+      <td><code>sender</code></td>
+      <td>String</td>
+      <td>The user who created the webhook</td></tr>
+  </tbody>
 </table>
 
 Example request body:

--- a/pages/apis/webhooks/agent_events.md
+++ b/pages/apis/webhooks/agent_events.md
@@ -7,9 +7,9 @@
   <thead>
     <tr><th>Event</th><th>Description</th></tr>
   </thead>
-<tbody>
-<%= render_markdown partial: 'apis/webhooks/agent_events_table' %>
-</tbody>
+  <tbody>
+    <%= render_markdown partial: 'apis/webhooks/agent_events_table' %>
+  </tbody>
 </table>
 
 ## Common event data

--- a/pages/apis/webhooks/agent_events.md
+++ b/pages/apis/webhooks/agent_events.md
@@ -32,3 +32,33 @@ Example request body:
   }
 }
 ```
+
+### `agent.blocked`
+
+<table>
+<tbody>
+  <tr><th><code>blocked_ip</code></th><td>The blocked request IP address</td></tr>
+  <tr><th><code>agent</code></th><td>The <a href="/docs/api/agents">Agent</a> this notification relates to</td></tr>
+  <tr><th><code>cluster_token</code></th><td>The <a href="/docs/apis/rest-api/clusters#cluster-tokens">cluster token</a> used in the registration attempt</td></tr>
+  <tr><th><code>sender</code></th><td>The user who created the webhook</td></tr>
+</tbody>
+</table>
+
+Example request body:
+
+```json
+{
+  "event": "agent.blocked",
+  "blocked_ip": "202.188.43.20",
+  "agent": {
+    "...": "..."
+  },
+  "cluster_token": {
+    "...": "..."
+  },
+  "sender": {
+    "id": "8a7693f8-dbae-4783-9137-84090fce9045",
+    "name": "Some Person"
+  }
+}
+```

--- a/pages/apis/webhooks/cluster_token_events.md
+++ b/pages/apis/webhooks/cluster_token_events.md
@@ -1,6 +1,5 @@
 # Cluster token events
 
-
 ## Events
 
 <table>

--- a/pages/apis/webhooks/cluster_token_events.md
+++ b/pages/apis/webhooks/cluster_token_events.md
@@ -3,6 +3,9 @@
 ## Events
 
 <table>
+  <thead>
+    <tr><th>Event</th><th>Description</th></tr>
+  </thead>
 <tbody>
   <tr>
     <th><code>cluster_token.registration_blocked</code></th>
@@ -14,11 +17,26 @@
 ## Request body data
 
 <table>
-<tbody>
-  <tr><th><code>blocked_ip</code></th><td>The IP address of the blocked registration request</td></tr>
-  <tr><th><code>cluster_token</code></th><td>The <a href="/docs/apis/rest-api/clusters#cluster-tokens">cluster token</a> used in the registration attempt</td></tr>
-  <tr><th><code>sender</code></th><td>The user who created the webhook</td></tr>
-</tbody>
+  <thead>
+    <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>blocked_ip</code></td>
+      <td>String</td>
+      <td>The IP address of the blocked registration request</td>
+    </tr>
+    <tr>
+      <td><code>cluster_token</code></td>
+      <td><a href="/docs/apis/rest-api/clusters#cluster-tokens">Cluster token</a></td>
+      <td>The cluster token used in the registration attempt</td>
+    </tr>
+    <tr>
+      <td><code>sender</code></td>
+      <td>String</td>
+      <td>The user who created the webhook</td>
+    </tr>
+  </tbody>
 </table>
 
 Example request body:

--- a/pages/apis/webhooks/cluster_token_events.md
+++ b/pages/apis/webhooks/cluster_token_events.md
@@ -1,0 +1,39 @@
+# Cluster token events
+
+
+## Events
+
+<table>
+<tbody>
+  <tr>
+    <th><code>cluster_token.registration_blocked</code></th>
+    <td>An attempted agent registration has been blocked because the request IP address is not included in the cluster token's <a href="/docs/clusters/manage-clusters#set-up-clusters-restrict-access-for-a-cluster-token-by-ip-address">allowed IP addresses</a></td>
+  </tr>
+</tbody>
+</table>
+
+## Request body data
+
+<table>
+<tbody>
+  <tr><th><code>blocked_ip</code></th><td>The IP address of the blocked registration request</td></tr>
+  <tr><th><code>cluster_token</code></th><td>The <a href="/docs/apis/rest-api/clusters#cluster-tokens">cluster token</a> used in the registration attempt</td></tr>
+  <tr><th><code>sender</code></th><td>The user who created the webhook</td></tr>
+</tbody>
+</table>
+
+Example request body:
+
+```json
+{
+  "event": "cluster_token.registration_blocked",
+  "blocked_ip": "202.188.43.20",
+  "cluster_token": {
+    "...": "..."
+  },
+  "sender": {
+    "id": "8a7693f8-dbae-4783-9137-84090fce9045",
+    "name": "Some Person"
+  }
+}
+```

--- a/pages/clusters/manage_clusters.md
+++ b/pages/clusters/manage_clusters.md
@@ -77,6 +77,8 @@ You can set the _Allowed IP Addresses_ when creating a token, or you can modify 
 
 Modifying the _Allowed IP Addresses_ forcefully disconnects any existing agents with IP addresses outside the updated value. This prevents the completion of any jobs in progress on those agents.
 
+This setting currently does not restrict access to the [Metrics API](/docs/apis/agent-api/metrics) for the given cluster token.
+
 There is a maximum of 24 CIDR blocks per agent token, and IPv6 is currently not supported.
 
 ### Migrate to clusters

--- a/pages/clusters/manage_clusters.md
+++ b/pages/clusters/manage_clusters.md
@@ -77,9 +77,11 @@ You can set the _Allowed IP Addresses_ when creating a token, or you can modify 
 
 Modifying the _Allowed IP Addresses_ forcefully disconnects any existing agents with IP addresses outside the updated value. This prevents the completion of any jobs in progress on those agents.
 
-This setting currently does not restrict access to the [Metrics API](/docs/apis/agent-api/metrics) for the given cluster token.
+Note the following limitations:
 
-There is a maximum of 24 CIDR blocks per agent token, and IPv6 is currently not supported.
+- This setting does not restrict access to the [Metrics API](/docs/apis/agent-api/metrics) for the given cluster token.
+- There is a maximum of 24 CIDR blocks per agent token.
+- IPv6 is currently not supported.
 
 ### Migrate to clusters
 

--- a/pages/clusters/manage_clusters.md
+++ b/pages/clusters/manage_clusters.md
@@ -79,9 +79,9 @@ Modifying the _Allowed IP Addresses_ forcefully disconnects any existing agents 
 
 Note the following limitations:
 
-- This setting does not restrict access to the [Metrics API](/docs/apis/agent-api/metrics) for the given cluster token.
-- There is a maximum of 24 CIDR blocks per agent token.
-- IPv6 is currently not supported.
+* This setting does not restrict access to the [Metrics API](/docs/apis/agent-api/metrics) for the given cluster token.
+* There is a maximum of 24 CIDR blocks per agent token.
+* IPv6 is currently not supported.
 
 ### Migrate to clusters
 

--- a/pages/integrations/amazon_eventbridge.md
+++ b/pages/integrations/amazon_eventbridge.md
@@ -742,8 +742,11 @@ AWS EventBridge has strict limits on the size of the payload as documented in [A
     }
 }
 ```
+<!-- vale off -->
 
 <h3 id="events-cluster-token-registration-blocked">Cluster Token Registration Blocked</h3>
+
+<!-- vale on -->
 
 ```json
 {

--- a/pages/integrations/amazon_eventbridge.md
+++ b/pages/integrations/amazon_eventbridge.md
@@ -25,6 +25,14 @@ Once you've configured an Amazon EventBridge notification service in Buildkite, 
   <tr><th><a href="#events-agent-stopping">Agent Stopping</a></th><td>An agent is stopping. This happens when an agent is instructed to stop from the API. It first transitions to stopping and finishes any current jobs</td></tr>
   <tr><th><a href="#events-agent-stopped">Agent Stopped</a></th><td>An agent has stopped. This happens when an agent is instructed to stop from the API. It can be graceful or forceful</td></tr>
   <tr>
+    <th><a href="#events-agent-blocked">Agent Blocked</a></th>
+    <td>An agent has been blocked. This happens when an agent's IP address is no longer included in the cluster token's <a href="/docs/clusters/manage-clusters#set-up-clusters-restrict-access-for-a-cluster-token-by-ip-address">allowed IP addresses</a></td>
+  </tr>
+  <tr>
+    <th><a href="#events-cluster-token-registration-blocked">Cluster Token Registration Blocked</a></th>
+    <td>An attempted agent registration is blocked because the request IP address is not included in the cluster token's <a href="/docs/clusters/manage-clusters#set-up-clusters-restrict-access-for-a-cluster-token-by-ip-address">allowed IP addresses</a></td>
+  </tr>
+  <tr>
     <th><a href="#audit-event-logged">Audit Event Logged</a></th>
     <td>An audit event has been logged for the organization</td>
   </tr>
@@ -694,6 +702,66 @@ AWS EventBridge has strict limits on the size of the payload as documented in [A
       "description": "Default agent token"
     }
   }
+}
+```
+
+<h3 id="events-agent-blocked">Agent Blocked</h3>
+
+```json
+{
+    "detail-type": "Agent Blocked",
+    "detail": {
+        "version": 1,
+        "blocked_ip": "204.124.80.36",
+        "cluster_token": {
+            "uuid": "c1164b28-bace-436-ac44-4133e1d18ca5",
+            "description": "Default agent token",
+            "allowed_ip_addresses": "202.144.160.0/24",
+        },
+        "agent": {
+            "uuid": "0188f51c-7bc8-4b14-a702-002c485ae2dc",
+            "graphql_id": "QWdlbnQtLSOMTg4ZjUxYy03YmM4LTRiMTQtYTcwMi@ MDJjNDg1YWUyZGM=",
+            "connection_state": "disconnected",
+            "name": "rogue-agent-1",
+            "version": "3.40.0",
+            "token": null,
+            "ip_address": "127.0.0.1",
+            "hostname": "rogue-agent",
+            "pid": "26089",
+            "priority": 0,
+            "meta_data": ["queues=default"],
+            "connected_at": "2023-06-26 00:31:04 UTC",
+            "disconnected_at": "2023-06-26 00:31:18 UTC",
+            "Lost_at": null,
+        },
+        "organization": {
+            "uuid": "a98961b7-adc1-41aa-8726-cfb2c46e42e0",
+            "graphql_id": "T3JnYW5pemF0aW9uLS0tYTk4OTYxYjctYWRjMS00MWFhLTg3MjYtY2ZiMmM0NmU0MmUw",
+            "slug": "my-org"
+        }
+    }
+}
+```
+
+<h3 id="events-cluster-token-registration-blocked">Cluster Token Registration Blocked</h3>
+
+```json
+{
+    "detail-type": "Cluster Token Registration Blocked",
+    "detail": {
+        "version": 1,
+        "blocked_ip": "204.124.80.36",
+        "cluster_token": {
+            "uuid": "c1164b28-bace-436-ac44-4133e1d18ca5",
+            "description": "Default agent token",
+            "allowed_ip_addresses": "202.144.160.0/24",
+        },
+        "organization": {
+            "uuid": "a98961b7-adc1-41aa-8726-cfb2c46e42e0",
+            "graphql_id": "T3JnYW5pemF0aW9uLS0tYTk4OTYxYjctYWRjMS00MWFhLTg3MjYtY2ZiMmM0NmU0MmUw",
+            "slug": "my-org"
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
- Update Event Bridge docs with two new notifications
- Update Webhook docs with two new notifications
- Update allowed IP addresses docs to note it doesn't apply to metrics API