### PR TITLE
add GraphQL query for audit events

### DIFF
--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -826,6 +826,7 @@ mutation deleteOrgMember {
 ```
 
 ### Get organization audit events
+
 Query your organization's audit events. Audit events are only available to Enterprise customers.
 
 ```graphql

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -825,6 +825,31 @@ mutation deleteOrgMember {
 }
 ```
 
+### Get organization audit events
+Query your organization's audit events. Audit events are only available to Enterprise customers.
+
+```graphql
+  query getOrganizationAuditEvents{
+    organization(slug:"<organization-slug>"){
+      auditEvents(first: 500){
+        edges{
+          node{
+            type
+            occurredAt
+            actor{
+              name
+            }
+            subject{
+              name
+              type
+            }
+          }
+        }
+      }
+    }
+  }
+```
+
 ## Teams
 
 A collection of common tasks with teams using the GraphQL API.

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -831,7 +831,7 @@ Query your organization's audit events. Audit events are only available to Enter
 
 ```graphql
   query getOrganizationAuditEvents{
-    organization(slug:"<organization-slug>"){
+    organization(slug:"organization-slug"){
       auditEvents(first: 500){
         edges{
           node{


### PR DESCRIPTION
querying audit events is possible via GraphQL, for Enterprise customers.