### PR TITLE
Update event formatting of webhook data

### DIFF
--- a/pages/apis/webhooks/build_events.md
+++ b/pages/apis/webhooks/build_events.md
@@ -1,24 +1,41 @@
 # Build webhook events
 
-
 ## Events
 
 <table>
-<tbody>
-  <tr><th><code>build.scheduled</code></th><td>A build has been scheduled</td></tr>
-  <tr><th><code>build.running</code></th><td>A build has started running</td></tr>
-  <tr><th><code>build.finished</code></th><td>A build has finished</td></tr>
-</tbody>
+  <thead>
+    <tr><th>Event</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><th><code>build.scheduled</code></th><td>A build has been scheduled</td></tr>
+    <tr><th><code>build.running</code></th><td>A build has started running</td></tr>
+    <tr><th><code>build.finished</code></th><td>A build has finished</td></tr>
+  </tbody>
 </table>
 
 ## Request body data
 
 <table>
-<tbody>
-  <tr><th><code>build</code></th><td>The <a href="/docs/api/builds">Build</a> this notification relates to</td></tr>
-  <tr><th><code>pipeline</code></th><td>The <a href="/docs/api/pipelines">Pipeline</a> this notification relates to</td></tr>
-  <tr><th><code>sender</code></th><td>The user who created the webhook</td></tr>
-</tbody>
+  <thead>
+    <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>build</code></td>
+      <td><a href="/docs/api/builds">Build</a></td>
+      <td>The build this notification relates to</td>
+    </tr>
+    <tr>
+      <td><code>pipeline</code></td>
+      <td><a href="/docs/api/pipelines">Pipeline</a></td>
+      <td>The pipeline this notification relates to</td>
+    </tr>
+    <tr>
+      <td><code>sender</code></td>
+      <td>String</td>
+      <td>The user who created the webhook</td>
+    </tr>
+  </tbody>
 </table>
 
 Example request body:

--- a/pages/apis/webhooks/job_events.md
+++ b/pages/apis/webhooks/job_events.md
@@ -4,35 +4,57 @@
 ## Events
 
 <table>
-<tbody>
-  <tr>
-    <th><code>job.scheduled</code></th>
-    <td>A command step job has been scheduled to run on an agent</td>
-  </tr>
-  <tr>
-    <th><code>job.started</code></th>
-    <td>A command step job has started running on an agent</td>
-  </tr>
-  <tr>
-    <th><code>job.finished</code></th>
-    <td>A job has finished</td>
-  </tr>
-  <tr>
-    <th><code>job.activated</code></th>
-    <td>A block step job has been unblocked using the web or API</td>
-  </tr>
-</tbody>
+  <thead>
+    <tr><th>Event</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th><code>job.scheduled</code></th>
+      <td>A command step job has been scheduled to run on an agent</td>
+    </tr>
+    <tr>
+      <th><code>job.started</code></th>
+      <td>A command step job has started running on an agent</td>
+    </tr>
+    <tr>
+      <th><code>job.finished</code></th>
+      <td>A job has finished</td>
+    </tr>
+    <tr>
+      <th><code>job.activated</code></th>
+      <td>A block step job has been unblocked using the web or API</td>
+    </tr>
+  </tbody>
 </table>
 
 ## Request body data
 
 <table>
-<tbody>
-  <tr><th><code>job</code></th><td>The <a href="/docs/api/jobs">Job</a> this notification relates to</td></tr>
-  <tr><th><code>build</code></th><td>The <a href="/docs/api/builds">Build</a> this notification relates to</td></tr>
-  <tr><th><code>pipeline</code></th><td>The <a href="/docs/api/pipelines">Pipeline</a> this notification relates to</td></tr>
-  <tr><th><code>sender</code></th><td>The user who created the webhook</td></tr>
-</tbody>
+  <thead>
+    <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>job</code></td>
+      <td><a href="/docs/api/jobs">Job</a></td>
+      <td>The job this notification relates to</td>
+    </tr>
+    <tr>
+      <td><code>build</code></td>
+      <td><a href="/docs/api/builds">Build</a></td>
+      <td>The build this notification relates to</td>
+    </tr>
+    <tr>
+      <td><code>pipeline</code></td>
+      <td><a href="/docs/api/pipelines">Pipeline</a></td>
+      <td>The pipeline this notification relates to</td>
+    </tr>
+    <tr>
+      <td><code>sender</code></td>
+      <td>String</td>
+      <td>The user who created the webhook</td>
+    </tr>
+  </tbody>
 </table>
 
 Example request body:


### PR DESCRIPTION
This formatting change is to help make the object types more obvious. Rather than reproducing them in the webhook event pages, we'll keep the REST API as the source of truth for ease of maintenance. 

These changes match a recent change in the Agent and Cluster token event pages.