### PR TITLE
Add Limits to GraphQL nav data

### DIFF
--- a/scripts/graphql_api_content/nav_data.rb
+++ b/scripts/graphql_api_content/nav_data.rb
@@ -29,6 +29,10 @@ module NavData
         "path" => "apis/graphql/graphql-cookbook"
       },
       {
+        "name" => "Limits",
+        "path" => "apis/graphql/graphql-resource-limits"
+      },
+      {
         "name" => "Queries",
         "children" => convert_to_nav_items(type_sets["query_types"], "query")
       },

--- a/spec/scripts/graphql_api_content/nav_data_spec.rb
+++ b/spec/scripts/graphql_api_content/nav_data_spec.rb
@@ -307,6 +307,10 @@ RSpec.describe NavData do
             "path" => "apis/graphql/graphql-cookbook"
           },
           {
+            "name" => "Limits",
+            "path" => "apis/graphql/graphql-resource-limits"
+          },
+          {
             "name" => "Queries",
             "children" => [
               {


### PR DESCRIPTION
Limits doc was introduced in https://github.com/buildkite/docs/pull/2229 and it should have updated this `scripts/graphql_api_content/nav_data.rb` instead of the resulting `data/nav_graphql.yml`.

