### PR TITLE
[Update] Updating `agentTokenCreate` mutation to use new `tokenValue`.

### DIFF
--- a/pages/agent/v3/tokens.md
+++ b/pages/agent/v3/tokens.md
@@ -25,10 +25,10 @@ mutation {
     organizationID: "organization-id",
     description: "A description"
   }) {
+    tokenValue
     agentTokenEdge {
       node {
         id
-        token
       }
     }
   }


### PR DESCRIPTION
## Context

With a recent [security update](https://buildkite.com/changelog/207-agent-token-being-deprecated-from-graphql-apis) from Buildkite, the `token` field in `agentTokenEdge` is deprecated but is now changed to `tokenValue` to retrieve the token when creating one through `agentTokenCreate` mutation.


## This PR
- Updates the `buildkite-agent` `v3` documentation to use updated GraphQL API when creating agent token