### PR TITLE
Update docs for 'Creating a pipeline template'

### DIFF
--- a/pages/pipelines/templates.md
+++ b/pages/pipelines/templates.md
@@ -16,9 +16,8 @@ Only administrators can create or update pipeline templates.
 To create a template:
 
 1. Navigate to your [organization’s pipeline templates](https://buildkite.com/organizations/-/pipeline-templates).
-1. If this is your first template, select _Create a Template_. Otherwise, select _New Template_. A pipeline template is created automatically for you.
-1. Update the name and description of your new template and select _Apply_ to save your changes.
-1. Select _Edit_ if you want to change the step configuration for the template.
+2. If this is your first template, select _Create a Template_. Otherwise, select _New Template_.
+3. Enter the name and description for your new template, update the default step configuration and select _Create Template_ to create the template.
 
 An administrator can add multiple templates to use across the organization. Making changes and saving a template will apply those changes to all pipelines using that template.
 


### PR DESCRIPTION
We recently modified the user flow for creating a Pipeline template so we need docs to reflect this change. We no longer immediately create a template, we now follow a more standard creation flow: click create > fill out a form > click save.