### PR TITLE
Clarify how to view query complexity of a query

### DIFF
--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -154,7 +154,7 @@ RateLimit-Reset: 120
 
 ### View query complexity
 
-To include the complexity data in responses, set `Buildkite-Include-Query-Stats` header to `true` in GraphQL requests. This returns the complexity data in the response like the following:
+To include the complexity data in responses, set the `Buildkite-Include-Query-Stats` header to `true` in GraphQL requests. This returns the complexity data in the response like the following:
 
 ```json
 {

--- a/pages/apis/graphql/graphql_resource_limits.md
+++ b/pages/apis/graphql/graphql_resource_limits.md
@@ -154,7 +154,7 @@ RateLimit-Reset: 120
 
 ### View query complexity
 
-To include the complexity data in responses, use the `Buildkite-Include-Query-Stats` header in GraphQL requests. This returns the complexity data in the response like the following:
+To include the complexity data in responses, set `Buildkite-Include-Query-Stats` header to `true` in GraphQL requests. This returns the complexity data in the response like the following:
 
 ```json
 {


### PR DESCRIPTION
We had some confusion from customers about the value of the header required to access the query complexity. 

This change makes it explicit that the value of `true` needs to be passed in the header.