### PR TITLE
Use fully-qualified brew formula name w/tap to avoid ambiguity

### DIFF
--- a/pages/agent/v3/macos.md
+++ b/pages/agent/v3/macos.md
@@ -12,7 +12,7 @@ To install the agent using Homebrew:
 1. On the command line, install the agent by running:
 
     ```shell
-    brew tap buildkite/buildkite && brew install buildkite-agent
+    brew tap buildkite/buildkite && brew install buildkite/buildkite/buildkite-agent
     ```
 
 1. Add your [agent token](/docs/agent/v3/tokens) to authenticate the agent by replacing `INSERT-YOUR-AGENT-TOKEN-HERE` with your agent token and running:


### PR DESCRIPTION
Without the fully-qualified formula name, `brew` might complain, _eg_:

```
$ brew tap buildkite/buildkite && brew install buildkite-agent
Error: Formulae found in multiple taps:
       * shopify/shopify/buildkite-agent
       * buildkite/buildkite/buildkite-agent

Please use the fully-qualified name (e.g. shopify/shopify/buildkite-agent) to refer to the formula.
```