### PR TITLE
Added timeboxed Auditevents example to the GraphQL Cookbook

### DIFF
--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -831,49 +831,49 @@ mutation deleteOrgMember {
 Query your organization's audit events. Audit events are only available to Enterprise customers.
 
 ```graphql
-  query getOrganizationAuditEvents{
-    organization(slug:"organization-slug"){
-      auditEvents(first: 500){
-        edges{
-          node{
+query getOrganizationAuditEvents{
+  organization(slug:"organization-slug"){
+    auditEvents(first: 500){
+      edges{
+        node{
+          type
+          occurredAt
+          actor{
+            name
+          }
+          subject{
+            name
             type
-            occurredAt
-            actor{
-              name
-            }
-            subject{
-              name
-              type
-            }
           }
         }
       }
     }
   }
+}
 ```
 
 To get all audit events in a given period, use the `occurredAtFrom` and `occurredAtTo` filters like in the following query:
 
 ```graphql
-  query getOrganizationAuditEvents{
-    organization(slug:"organization-slug"){
-      auditEvents(first: 500, occurredAtFrom: "2023-01-01T12:00:00.000", occurredAtTo: "2023-01-01T13:00:00.000"){
-        edges{
-          node{
+query getTimeScopedOrganizationAuditEvents{
+  organization(slug:"organization-slug"){
+    auditEvents(first: 500, occurredAtFrom: "2023-01-01T12:00:00.000", occurredAtTo: "2023-01-01T13:00:00.000"){
+      edges{
+        node{
+          type
+          occurredAt
+          actor{
+            name
+          }
+          subject{
+            name
             type
-            occurredAt
-            actor{
-              name
-            }
-            subject{
-              name
-              type
-            }
           }
         }
       }
     }
   }
+}
 ```
 
 ## Teams

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -852,9 +852,7 @@ Query your organization's audit events. Audit events are only available to Enter
   }
 ```
 
-### Get timeboxed organization audit events 
-
-Query your organization's audit events in a timeboxed manner using the `occurredAtFrom` and `occurredAtTo` filters in an Organization's `auditEvents` field. Audit events are only available to Enterprise customers.
+To get all audit events in a given period, use the `occurredAtFrom` and `occurredAtTo` filters like in the following query:
 
 ```graphql
   query getOrganizationAuditEvents{

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -807,6 +807,7 @@ query {
       }
     }
   }
+}
 ```
 
 Then, use the ID to delete the user:
@@ -833,6 +834,32 @@ Query your organization's audit events. Audit events are only available to Enter
   query getOrganizationAuditEvents{
     organization(slug:"organization-slug"){
       auditEvents(first: 500){
+        edges{
+          node{
+            type
+            occurredAt
+            actor{
+              name
+            }
+            subject{
+              name
+              type
+            }
+          }
+        }
+      }
+    }
+  }
+```
+
+### Get timeboxed organization audit events 
+
+Query your organization's audit events in a timeboxed manner using the `occurredAtFrom` and `occurredAtTo` filters in an Organization's `auditEvents` field. Audit events are only available to Enterprise customers.
+
+```graphql
+  query getOrganizationAuditEvents{
+    organization(slug:"organization-slug"){
+      auditEvents(first: 500, occurredAtFrom: "2023-01-01T12:00:00.000", occurredAtTo: "2023-01-01T13:00:00.000"){
         edges{
           node{
             type


### PR DESCRIPTION
Similar to what we have for the `auditEvents` query, just with a example using `occurredAtFrom` and `occurredAtTo` filtering 