### PR TITLE
fix tags-from-host env var typo

### DIFF
--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -300,7 +300,7 @@ attributes:
   desc: |
       Include the host's Google Cloud instance labels as tags.
 - name: tags-from-host
-  env_var: BUILDKITE_AGENTS_TAGS_FROM_HOST
+  env_var: BUILDKITE_AGENT_TAGS_FROM_HOST
   default_value: "false"
   required: false
   desc: |


### PR DESCRIPTION
This PR fixes a typo in regards to the BUILDKITE_AGENT_TAGS_FROM_HOST env var in our documentation.

As seen here: https://github.com/buildkite/agent/blob/main/clicommand/agent_start.go#L317, the original
text has the env var as BUILDKITE_AGENTS_TAGS_FROM_HOST which is incorrect.