### PR TITLE
PIE 1850 Add created_at to test analytics runs#index and runs#show api endpoints

### DIFF
--- a/pages/apis/rest_api/analytics/runs.md
+++ b/pages/apis/rest_api/analytics/runs.md
@@ -15,7 +15,8 @@ curl "https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{su
     "branch": "main",
     "commit_sha": "1c3214fcceb2c14579a2c3c50cd78f1442fd8936",
     "url": "https://api.buildkite.com/v2/analytics/organizations/my_great_org/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2",
-    "web_url":"https://buildkite.com/organizations/my_great_org/analytics/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2"
+    "web_url": "https://buildkite.com/organizations/my_great_org/analytics/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2",
+    "created_at": "2023-06-25T05:32:53.228Z"
   }
 ]
 ```
@@ -36,7 +37,8 @@ curl "https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{su
   "branch": "main",
   "commit_sha": "1c3214fcceb2c14579a2c3c50cd78f1442fd8936",
   "url": "https://api.buildkite.com/v2/analytics/organizations/my_great_org/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2",
-  "web_url":"https://buildkite.com/organizations/my_great_org/analytics/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2"
+  "web_url": "https://buildkite.com/organizations/my_great_org/analytics/suites/my_suite_slug/runs/64374307-12ab-4b13-a3f3-6a408f644ea2",
+  "created_at": "2023-06-25T05:32:53.228Z"
 }
 ```
 


### PR DESCRIPTION
Description

We are adding a `created_at` field to  test analytics runs#index and runs#show api endpoints. This PR adds the new field to our api docs.

<img width="725" alt="Screenshot 2023-07-17 at 11 41 15 am" src="https://github.com/buildkite/docs/assets/47379003/23af1810-e7ad-43db-908a-59b12ae02d03">

<img width="715" alt="Screenshot 2023-07-17 at 11 41 23 am" src="https://github.com/buildkite/docs/assets/47379003/c0e5b3cc-46fc-41ea-8351-47c17a41f117">

