### PR TITLE
Add Update the revoke inactive tokens after to GraphQL cookbook

### DIFF
--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -691,6 +691,23 @@ mutation UpdateSessionDuration {
 }
 ```
 
+### Update inactive API token revocation
+
+On the Enterprise plan, you can control when inactive API tokens are revoked. By default, they are never (`NEVER`) revoked, but you can set your token revocation to either 30, 60, 90, 180, or 365 days.
+
+```graphql
+mutation UpdateRevokeInactiveTokenPeriod {
+  organizationRevokeInactiveTokensAfterUpdate(input: {
+    organizationId: "organization-id",
+    revokeInactiveTokensAfter: DAYS_30
+  }) {
+    organization {
+      revokeInactiveTokensAfter
+    }
+  }
+}
+```
+
 ### Pin SSO sessions to IP addresses
 
 You can require users to re-authenticate with your SSO provider when their IP address changes with the following call, replacing `ID` with the GraphQL ID of the SSO provider:

--- a/pages/apis/managing_api_tokens.md
+++ b/pages/apis/managing_api_tokens.md
@@ -66,14 +66,14 @@ If you'd like to limit access to your organization by IP address, you can create
 
 You can also manage the allowlist with the [`organizationApiIpAllowlistUpdate`](/docs/apis/graphql/schemas/mutation/organizationapiipallowlistupdate) mutation in the GraphQL API.
 
-## Revoking inactive tokens automatically
+## Inactive API tokens revocation
 
 > 📘 Enterprise feature
-> Revoking inactive tokens automatically is only available on an [Enterprise](https://buildkite.com/pricing) plan.
+> Revoking inactive API tokens automatically is only available on an [Enterprise](https://buildkite.com/pricing) plan.
 
-To enable the automatic revocation of inactive tokens, navigate to your [organization's security settings](https://buildkite.com/organizations/~/security) and specify the maximum timeframe for inactive tokens to remain valid.
+To enable the inactive API tokens revocation, navigate to your [organization's security settings](https://buildkite.com/organizations/~/security) and specify the maximum timeframe for inactive tokens to remain valid.
 
-Inactive tokens refer to those that have not been used within the specified duration. When an API token surpasses the configured setting, Buildkite will automatically revoke the token's access to your organization.
+Inactive API tokens refer to those that have not been used within the specified duration. When an API token surpasses the configured setting, Buildkite will automatically revoke the token's access to your organization.
 
 Upon token revocation, Buildkite will notify the owner of their change in access.
 


### PR DESCRIPTION
Update the feature name

![CleanShot 2023-07-24 at 12 30 00@2x](https://github.com/buildkite/docs/assets/1000669/fb73d58c-7955-450f-b0db-baeec49aa76e)


Add cookbook for how to use [revoke inactive tokens after](https://buildkite.com/releases/2023-06/api-token-expiry-policies) via GraphQL API.


![CleanShot 2023-07-24 at 12 30 20@2x](https://github.com/buildkite/docs/assets/1000669/46cc1b4c-bf8e-40f6-85bd-04fd4c3e769a)
