### PR TITLE
correct BUILDKITE_REPO description to be modifiable

### DIFF
--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -376,6 +376,7 @@ variables:
 - name: BUILDKITE_REPO
   desc: |
     The repository of your pipeline. This variable can be set by exporting the environment variable in the `environment` or `pre-checkout` hooks.
+  modifable: true
   example: "git@github.com:acme-inc/my-project.git"
 - name: BUILDKITE_REPO_MIRROR
   desc: |


### PR DESCRIPTION
As seen as far back as here: https://github.com/buildkite/agent/blob/a4ee642d625171b69c255a663a8aae4f0737334d/CHANGELOG.md?plain=1#L1069C22-L1069C22

BUILDKITE_REPO has been modifiable since agent version 3.7.0. Our current docs state it is not modifiable, which
has caused some confusion.