### PR TITLE
Clarifying language for assigning pipeline templates

### DIFF
--- a/pages/pipelines/templates.md
+++ b/pages/pipelines/templates.md
@@ -7,7 +7,9 @@
 
 Pipeline templates allow you to define standard pipeline step configurations to use across all the pipelines in your organization.
 
-When a pipeline has a template assigned, the pipeline inherits its step configuration from the template. Configuring a custom step configuration for that pipeline in the Buildkite dashboard is no longer possible.
+When a pipeline has a template assigned, the pipeline inherits its step configuration from the template. Configuring a custom step configuration for that pipeline in the Buildkite dashboard is no longer possible. This includes any custom command steps!
+
+In order to assign a pipeline template to a pipeline, you will have to enable [Requiring pipeline templates](#requiring-pipeline-templates) for your organization.
 
 ## Creating a pipeline template
 


### PR DESCRIPTION
This PR adds some clarification to the UI design around pipeline templates. You can't assign a template to a pipeline unless the org requires pipeline templates.