### PR TITLE
Remove beta callout for GitHub merge queues

### DIFF
--- a/pages/tutorials/github_merge_queue.md
+++ b/pages/tutorials/github_merge_queue.md
@@ -1,8 +1,5 @@
 # Using GitHub merge queues
 
->🚧 GitHub beta feature
-> The merge queue feature for pull requests is in public beta and subject to change.
-
 Merge queues are a feature of GitHub to improve development velocity on busy branches. They can increase the rate at which pull requests are merged into a branch while ensuring all the required branch protection checks pass. Merge queues preserve the order of pull requests to merge, remove redundant builds, and reduce flaky merges.
 
 


### PR DESCRIPTION
See [GitHub merge queue is generally available](https://github.blog/2023-07-12-github-merge-queue-is-generally-available/).