### PR TITLE
The read_flaky_tests scope has been removed

### DIFF
--- a/pages/apis/managing_api_tokens.md
+++ b/pages/apis/managing_api_tokens.md
@@ -31,8 +31,6 @@ REST API scopes are very granular, you can select some or all of the following:
 * Read Suites `read_suites` - Permission to list and retrieve details of test suites; including runs,
   tests, executions, etc.
 * Write Suites `write_suites` - Permission to create, update and delete test suites
-* Read Flaky Tests `read_flaky_tests` - Deprecated. Use `read_suites` instead. Permission to list
-  flaky tests
 
 When creating API access tokens, you can also restrict which network address are allowed to use them, using [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
 


### PR DESCRIPTION
Removed in https://github.com/buildkite/buildkite/pull/13089

Note, I didn't remove it from the [schema docs](https://github.com/buildkite/docs/blob/9f43215cd7134d3c78c09dc3154e0b0b7625383b/pages/apis/graphql/schemas/enum/apiaccesstokenscopes.md?plain=1#L43). There are a lot of changes to the schema so I think updating it is outside the scope of this PR.