### PR TITLE
Mark BUILDKITE_REPO as modifiable

### DIFF
--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -376,6 +376,7 @@ variables:
 - name: BUILDKITE_REPO
   desc: |
     The repository of your pipeline. This variable can be set by exporting the environment variable in the `environment` or `pre-checkout` hooks.
+  modifiable: true
   example: "git@github.com:acme-inc/my-project.git"
 - name: BUILDKITE_REPO_MIRROR
   desc: |


### PR DESCRIPTION
This is a bandaid on a bigger problem. `BUILDKITE_REPO` being marked as not modifiable has caused confusion for users, but the idea of being "modifiable" needs revisiting. Context captured [here](https://3.basecamp.com/3453178/buckets/28474015/messages/6359356260#__recording_6365240200).

Note, this is the same change first raised in #2307.