### PR TITLE
Clusters: Update agent connection instructions to include token creation

### DIFF
--- a/pages/clusters/manage_clusters.md
+++ b/pages/clusters/manage_clusters.md
@@ -37,7 +37,7 @@ To connect an agent:
 1. Enter a description.
 1. Select _Create Token_.
 1. Select _Copy to Clipboard_ and save the token somewhere secure.
-1. Select _Okay, I'm done!_.
+1. Select _Okay, I'm done!_
 1. [Use the token](/docs/agent/v3/tokens#using-and-storing-tokens) with the relevant agents, along with [the key from the relevant cluster queue](/docs/agent/v3/queues#setting-an-agents-queue).
 
 You can also create, edit, and revoke other agent tokens from the cluster’s _Agent tokens_.

--- a/pages/clusters/manage_clusters.md
+++ b/pages/clusters/manage_clusters.md
@@ -33,7 +33,11 @@ Agents are associated with a cluster through the cluster’s agent tokens.
 To connect an agent:
 
 1. Navigate to the cluster's _Agent tokens_.
-1. Copy the auto-generated token.
+1. Select _New Token_.
+1. Enter a description.
+1. Select _Create Token_.
+1. Select _Copy to Clipboard_ and save the token somewhere secure.
+1. Select _Okay, I'm done!_.
 1. [Use the token](/docs/agent/v3/tokens#using-and-storing-tokens) with the relevant agents, along with [the key from the relevant cluster queue](/docs/agent/v3/queues#setting-an-agents-queue).
 
 You can also create, edit, and revoke other agent tokens from the cluster’s _Agent tokens_.

--- a/pages/clusters/overview.md
+++ b/pages/clusters/overview.md
@@ -20,6 +20,7 @@ Enabling clusters also changes access to agent tokens. Rather than being availab
 
 To enable clusters:
 
+1. Securely save any existing agent tokens you need because these won't be available after enabling clusters.
 1. Navigate to your [organization’s pipeline settings](https://buildkite.com/organizations/~/pipeline-settings).
 1. In _Clusters_, select _Enable Clusters_.
 

--- a/pages/clusters/overview.md
+++ b/pages/clusters/overview.md
@@ -18,7 +18,6 @@ Any Buildkite administrator can enable clusters for an organization. Once you en
 
 Enabling clusters also changes access to agent tokens. Rather than being available in the Buildkite dashboard, agent tokens are only visible upon creation, ensuring greater security for your applications.
 
-
 To enable clusters:
 
 1. Navigate to your [organization’s pipeline settings](https://buildkite.com/organizations/~/pipeline-settings).

--- a/pages/clusters/overview.md
+++ b/pages/clusters/overview.md
@@ -16,6 +16,9 @@ Clusters encapsulate groups of agents and pipelines, enabling the following:
 
 Any Buildkite administrator can enable clusters for an organization. Once you enable clusters, you can only disable them by contacting support.
 
+Enabling clusters also changes access to agent tokens. Rather than being available in the Buildkite dashboard, agent tokens are only visible upon creation, ensuring greater security for your applications.
+
+
 To enable clusters:
 
 1. Navigate to your [organization’s pipeline settings](https://buildkite.com/organizations/~/pipeline-settings).


### PR DESCRIPTION
Linear ticket: [EDGE-1055](https://linear.app/buildkite/issue/EDGE-1055/ui-hide-agentregistrationtokentoken-and-clustertokentoken)

Updates the docs to reflect the new cluster token creation flow, as per the changes in [this PR](https://github.com/buildkite/buildkite/pull/13136/files). 