### PR TITLE
Clarify the behavior of using multiple stacks per queue

### DIFF
--- a/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
+++ b/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
@@ -68,7 +68,7 @@ If you configure `MinSize` < `MaxSize` in your AWS autoscaling configuration, th
 
 This means you can scale down to zero when idle, which means you can use larger instances for the same cost.
 
-Metrics are collected with a Lambda function, polling every 10 seconds based on the queue the stack is configured with. The autoscaler monitors only one queue, and the monitoring drives the scaling of the stack. You should only use one Elastic CI Stack for AWS per queue to avoid scaling up redundant agents. If you target the same queue with multiple stacks, each stack will scale up to handle the work.
+Metrics are collected with a Lambda function, polling every 10 seconds based on the queue the stack is configured with. The autoscaler monitors only one queue, and the monitoring drives the scaling of the stack. You should only use one Elastic CI Stack for AWS per queue to avoid scaling up redundant agents. If you target the same queue with multiple stacks, each stack will independently scale up additional agents as if it were the only stack running, leading to over provisioning.
 
 ## Terminating the instance after the job is complete
 

--- a/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
+++ b/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
@@ -68,7 +68,7 @@ If you configure `MinSize` < `MaxSize` in your AWS autoscaling configuration, th
 
 This means you can scale down to zero when idle, which means you can use larger instances for the same cost.
 
-Metrics are collected with a Lambda function, polling every 10 seconds based on the queue the stack is configured with. The autoscaler monitors only one queue, and the monitoring drives the scaling of the stack. This means that usually you need one Elastic CI Stack for AWS per queue.
+Metrics are collected with a Lambda function, polling every 10 seconds based on the queue the stack is configured with. The autoscaler monitors only one queue, and the monitoring drives the scaling of the stack. You should only use one Elastic CI Stack for AWS per queue to avoid scaling up redundant agents. If you target the same queue with multiple stacks, each stack will scale up to handle the work.
 
 ## Terminating the instance after the job is complete
 

--- a/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
+++ b/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
@@ -68,7 +68,7 @@ If you configure `MinSize` < `MaxSize` in your AWS autoscaling configuration, th
 
 This means you can scale down to zero when idle, which means you can use larger instances for the same cost.
 
-Metrics are collected with a Lambda function, polling every 10 seconds based on the queue the stack is configured with. The autoscaler monitors only one queue, and the monitoring drives the scaling of the stack. You should only use one Elastic CI Stack for AWS per queue to avoid scaling up redundant agents. If you target the same queue with multiple stacks, each stack will independently scale up additional agents as if it were the only stack running, leading to over provisioning.
+Metrics are collected with a Lambda function, polling every 10 seconds based on the queue the stack is configured with. The autoscaler monitors only one queue, and the monitoring drives the scaling of the stack. You should only use one Elastic CI Stack for AWS per queue to avoid scaling up redundant agents. If you target the same queue with multiple stacks, each stack will independently scale up additional agents as if it were the only stack running, leading to over-provisioning.
 
 ## Terminating the instance after the job is complete
 

--- a/pages/agent/v3/elastic_ci_aws/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_aws/troubleshooting.md
@@ -37,9 +37,9 @@ To fix this issue, change or add more instance types to the `InstanceType` templ
 
 ## Stacks over-provision agents
 
-If you have multiple Elastic CI Stacks, check that they listen to unique queues—determined by the `BuildkiteQueue` parameter. Each Elastic CI Stack you launch through CloudFormation should have a unique value for this parameter. Otherwise, each scales out independently to service all the jobs on the queue, but the jobs will be distributed amongst them. This will mean that your stacks are over-provisioned.
+If you have multiple stacks, check that they listen to unique queues—determined by the `BuildkiteQueue` parameter. Each Elastic CI Stack for AWS you launch through CloudFormation should have a unique value for this parameter. Otherwise, each scales out independently to service all the jobs on the queue, but the jobs will be distributed amongst them. This will mean that your stacks are over-provisioned.
 
-This could also happen if you have agents that are not part of an Elastic CI Stack [started with a tag](/docs/agent/v3/cli-start#tags) of the form `queue=<name of queue>`. Any agents started like this will compete with an Elastic CI Stack for jobs, but the Elastic CI Stack will scale out as if this competition did not exist.
+This could also happen if you have agents that are not part of an Elastic CI Stack for AWS [started with a tag](/docs/agent/v3/cli-start#tags) of the form `queue=<name of queue>`. Any agents started like this will compete with a stack for jobs, but the stack will scale out as if this competition did not exist.
 
 ## Instances fail to boot Buildkite Agent
 

--- a/pages/agent/v3/elastic_ci_aws/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_aws/troubleshooting.md
@@ -35,6 +35,12 @@ Resource shortage can cause this issue. See the Auto Scaling group's Activity lo
 
 To fix this issue, change or add more instance types to the `InstanceType` template parameter. If 100% of your existing instances are Spot Instances, switch some of them to On-Demand Instances by setting `OnDemandPercentage` parameter to a value above zero.
 
+## Stacks over-provision agents
+
+If you have multiple Elastic CI Stacks, check that they listen to unique queues—determined by the `BuildkiteQueue` parameter. Each Elastic CI Stack you launch through CloudFormation should have a unique value for this parameter. Otherwise, each scales out independently to service all the jobs on the queue, but the jobs will be distributed amongst them. This will mean that your stacks are over-provisioned.
+
+This could also happen if you have agents that are not part of an Elastic CI Stack [started with a tag](/docs/agent/v3/cli-start#tags) of the form `queue=<name of queue>`. Any agents started like this will compete with an Elastic CI Stack for jobs, but the Elastic CI Stack will scale out as if this competition did not exist.
+
 ## Instances fail to boot Buildkite Agent
 
 See the Auto Scaling group's Activity logs and CloudWatch Logs for the booting instances to determine the issue. Observe where in the `UserData` script the boot is failing. Identify what resource is failing when the instances are attempting to use it, and fix that issue.


### PR DESCRIPTION
@catkins wrote an [internal post](https://3.basecamp.com/3453178/buckets/23112918/messages/6363965965) about scaling up redundant agents if you use multiple elastic stacks per queue. This change aims to use a stronger recommendation not to do that and clarify the behavior if you do.