### PR TITLE
Added in build.failing to be consistent with the webhook events overview

### DIFF
--- a/pages/apis/webhooks/build_events.md
+++ b/pages/apis/webhooks/build_events.md
@@ -10,6 +10,7 @@
     <tr><th><code>build.scheduled</code></th><td>A build has been scheduled</td></tr>
     <tr><th><code>build.running</code></th><td>A build has started running</td></tr>
     <tr><th><code>build.finished</code></th><td>A build has finished</td></tr>
+    <tr><th><code>build.failing</code></th><td>A build is failing</td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
We have` build.failing` event mentioned in the in the webhooks overview [page](https://buildkite.com/docs/apis/webhooks), but not listed as a build event [here](https://buildkite.com/docs/apis/webhooks/build-events).