### PR TITLE
Update docs for Elastic CI Stack v6

### DIFF
--- a/pages/agent/v3/aws.md
+++ b/pages/agent/v3/aws.md
@@ -28,7 +28,7 @@ the [GitHub repository](https://github.com/buildkite/elastic-ci-stack-for-aws).
 To run the agent on your own AWS instances, use the installer that matches your
 instance operating system:
 
-* For Amazon Linux 2 use the [Red Hat/CentOS installer](/docs/agent/v3/redhat)
+* For Amazon Linux 2 or later use the [Red Hat/CentOS installer](/docs/agent/v3/redhat)
 * For macOS, use [installing the agent on your own AWS EC2 Mac instances](#installing-the-agent-on-your-own-aws-ec2-mac-instances)
 
 ## Using the experimental Elastic CI Stack for AWS for EC2 Mac CloudFormation template
@@ -105,7 +105,7 @@ To avoid this, you need to prevent the builds from accessing your EC2 metadata o
 * Compartmentalizing your Buildkite agents
 * Downgrading an instance profile role
 
-If you run all the build steps in Docker containers, take a look at [compartmentalizing your agents](#preventing-builds-from-accessing-amazon-ec2-metadata-restricting-permissions-using-compartmentalization-of-agents). If you are using Kubernetes for your Buildkite CI, use the [same approach](#preventing-builds-from-accessing-amazon-ec2-metadata-restricting-permissions-using-compartmentalization-of-agents) and also check out [this article](https://github.com/blakestoddard/scaledkite) for more information and inspiration.  
+If you run all the build steps in Docker containers, take a look at [compartmentalizing your agents](#preventing-builds-from-accessing-amazon-ec2-metadata-restricting-permissions-using-compartmentalization-of-agents). If you are using Kubernetes for your Buildkite CI, use the [same approach](#preventing-builds-from-accessing-amazon-ec2-metadata-restricting-permissions-using-compartmentalization-of-agents) and also check out [this article](https://github.com/blakestoddard/scaledkite) for more information and inspiration.
 
 ### Restricting permissions using compartmentalization of agents
 
@@ -146,4 +146,4 @@ There is no exact recommended quantity of agents in a pool. An optimal pool size
 
 You can start with one or two extra instances that are always available for running lightweight jobs (for example, pipeline uploads), and you can increase the number of agents per machine so that they can run in parallel.
 
-For organizations where at any given moment there are engineers working (for example, for shift-based 24/7 schedules or in globally distributed teams), having a large pool of build agents always available makes sense. Otherwise, idly running agents overnight might be a waste of resources.  
+For organizations where at any given moment there are engineers working (for example, for shift-based 24/7 schedules or in globally distributed teams), having a large pool of build agents always available makes sense. Otherwise, idly running agents overnight might be a waste of resources.

--- a/pages/agent/v3/aws.md
+++ b/pages/agent/v3/aws.md
@@ -28,7 +28,7 @@ the [GitHub repository](https://github.com/buildkite/elastic-ci-stack-for-aws).
 To run the agent on your own AWS instances, use the installer that matches your
 instance operating system:
 
-* For Amazon Linux 2 or later use the [Red Hat/CentOS installer](/docs/agent/v3/redhat)
+* For Amazon Linux 2 or later, use the [Red Hat/CentOS installer](/docs/agent/v3/redhat)
 * For macOS, use [installing the agent on your own AWS EC2 Mac instances](#installing-the-agent-on-your-own-aws-ec2-mac-instances)
 
 ## Using the experimental Elastic CI Stack for AWS for EC2 Mac CloudFormation template

--- a/pages/agent/v3/elastic_ci_aws.md
+++ b/pages/agent/v3/elastic_ci_aws.md
@@ -9,7 +9,6 @@ The [Elastic CI Stack for AWS](https://github.com/buildkite/elastic-ci-stack-for
 This guide leads you through getting started with the stack for Linux and Windows.
 
 <!-- vale off -->
-<!-- alex ignore master -->
 
 > 📘 Get hands-on
 > Read on for detailed instructions, or jump straight in:
@@ -26,7 +25,7 @@ The following AMIs are available in all the supported regions:
 - Amazon Linux 2 (64-bit ARM, Graviton)
 - Windows Server 2019 (64-bit x86)
 
-If you want to use the [AWS CLI](https://aws.amazon.com/cli/) instead, download [`config.json.example`](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/config.json.example), rename it to `config.json`, add your Buildkite Agent token (and any other config values), and then run the below command:
+If you want to use the [AWS CLI](https://aws.amazon.com/cli/) instead, download [`config.json.example`](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/config.json.example), rename it to `config.json`, add your Buildkite Agent token (and any other config values), and then run the below command:
 
 ```bash
 aws cloudformation create-stack \

--- a/pages/agent/v3/elastic_ci_aws.md
+++ b/pages/agent/v3/elastic_ci_aws.md
@@ -21,8 +21,8 @@ This guide leads you through getting started with the stack for Linux and Window
 Most Elastic CI Stack for AWS features are supported on both Linux and Windows.
 The following AMIs are available in all the supported regions:
 
-- Amazon Linux 2 (64-bit x86)
-- Amazon Linux 2 (64-bit ARM, Graviton)
+- Amazon Linux 2023 (64-bit x86)
+- Amazon Linux 2023 (64-bit ARM, Graviton)
 - Windows Server 2019 (64-bit x86)
 
 If you want to use the [AWS CLI](https://aws.amazon.com/cli/) instead, download [`config.json.example`](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/config.json.example), rename it to `config.json`, add your Buildkite Agent token (and any other config values), and then run the below command:
@@ -70,7 +70,7 @@ Buildkite services are billed according to your [plan](https://buildkite.com/pri
 
 <!-- vale off -->
 
-- [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/)
+- [Amazon Linux 2023](https://aws.amazon.com/amazon-linux-2/)
 - [Buildkite Agent v3.50.2](https://buildkite.com/docs/agent)
 - [Git](https://git-scm.com/) and [Git LFS](https://git-lfs.com/)
 - [Docker](https://www.docker.com)

--- a/pages/agent/v3/elastic_ci_aws.md
+++ b/pages/agent/v3/elastic_ci_aws.md
@@ -41,7 +41,7 @@ aws cloudformation create-stack \
 The Elastic CI Stack for AWS does not require familiarity with the underlying AWS services to deploy it. However, to run builds, some familiarity with the following AWS services is required:
 
 - [AWS CloudFormation](https://aws.amazon.com/cloudformation/)
-- [Amazon EC2](https://aws.amazon.com/ec2/) (to select an EC2 `InstanceType` stack parameter appropriate for your workload)
+- [Amazon EC2](https://aws.amazon.com/ec2/) (to select an EC2 `InstanceTypes` stack parameter appropriate for your workload)
 - [Amazon S3](https://aws.amazon.com/s3/) (to copy your git clone secret for cloning and building private repositories)
 
 Elastic CI Stack for AWS provides defaults and pre-configurations suited for most use cases without the need for additional customization. Still, you'll benefit from familiarity with VPCs, availability zones, subnets, and security groups for custom instance networking.

--- a/pages/agent/v3/elastic_ci_aws/cloudformation_service_role.md
+++ b/pages/agent/v3/elastic_ci_aws/cloudformation_service_role.md
@@ -10,7 +10,7 @@ stack using an IAM User or Role that has been granted limited permissions, or
 use an [AWS CloudFormation service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html).
 
 The Elastic CI Stack for AWS repository contains an experimental
-[service role template](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/templates/service-role.yml).
+[service role template](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/templates/service-role.yml).
 This template creates an IAM Role and set of IAM Policies with the IAM Actions
 necessary to create, update, and delete a CloudFormation Stack created with the
 Elastic CI Stack for AWS template.

--- a/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
+++ b/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
@@ -174,7 +174,7 @@ If the file is private, you also need to create an IAM policy to allow the insta
 }
 ```
 
-After creating the policy, you must specify the policy's ARN in the `ManagedPolicyARN` stack parameter.
+After creating the policy, you must specify the policy's ARN in the `ManagedPolicyARNs` stack parameter.
 
 ## Health monitoring
 

--- a/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
+++ b/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
@@ -100,6 +100,7 @@ https://s3.amazonaws.com/buildkite-aws-stack/main/${COMMIT}.aws-stack.yml
 
 >📘 Versions prior to v6.0.0
 > Per commit builds for versions prior to v6.0.0, in particular for commits that are ancestors of [419f271](https://github.com/buildkite/elastic-ci-stack-for-aws/commit/419f271b54802c4c8301730bc35b34ed379074c4), were published to
+>
 > ```text
 > https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.yml`.
 > ```

--- a/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
+++ b/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
@@ -90,7 +90,9 @@ The most recent build of the CloudFormation stack is published to
 `https://s3.amazonaws.com/buildkite-aws-stack/main/aws-stack.yml`, along with
 a version for each commit at
 `https://s3.amazonaws.com/buildkite-aws-stack/main/${COMMIT}.aws-stack.yml`.
-Note: for commits that are ancestors of [419f271b54802c4c8301730bc35b34ed379074c4](https://github.com/buildkite/elastic-ci-stack-for-aws/commit/419f271b54802c4c8301730bc35b34ed379074c4), the build was published to `https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.yml`.
+
+>📘 Ancestors of commit 419f271
+> For commits that are ancestors of [419f271](https://github.com/buildkite/elastic-ci-stack-for-aws/commit/419f271b54802c4c8301730bc35b34ed379074c4), the build was published to `https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.yml`.
 
 <!-- vale off -->
 

--- a/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
+++ b/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
@@ -86,13 +86,23 @@ or a specific release available from the [releases page](https://github.com/buil
 
 The latest stable release can be deployed to any of our supported AWS Regions.
 
-The most recent build of the CloudFormation stack is published to
-`https://s3.amazonaws.com/buildkite-aws-stack/main/aws-stack.yml`, along with
-a version for each commit at
-`https://s3.amazonaws.com/buildkite-aws-stack/main/${COMMIT}.aws-stack.yml`.
+The most recent build of the CloudFormation stack is published to:
 
->📘 Ancestors of commit 419f271
-> For commits that are ancestors of [419f271](https://github.com/buildkite/elastic-ci-stack-for-aws/commit/419f271b54802c4c8301730bc35b34ed379074c4), the build was published to `https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.yml`.
+```text
+https://s3.amazonaws.com/buildkite-aws-stack/main/aws-stack.yml
+```
+
+With a version for each commit also published at:
+
+```text
+https://s3.amazonaws.com/buildkite-aws-stack/main/${COMMIT}.aws-stack.yml
+```
+
+>📘 Versions prior to v6.0.0
+> Per commit builds for versions prior to v6.0.0, in particular for commits that are ancestors of [419f271](https://github.com/buildkite/elastic-ci-stack-for-aws/commit/419f271b54802c4c8301730bc35b34ed379074c4), were published to
+> ```text
+> https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.yml`.
+> ```
 
 <!-- vale off -->
 

--- a/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
+++ b/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
@@ -90,8 +90,7 @@ The most recent build of the CloudFormation stack is published to
 `https://s3.amazonaws.com/buildkite-aws-stack/main/aws-stack.yml`, along with
 a version for each commit at
 `https://s3.amazonaws.com/buildkite-aws-stack/main/${COMMIT}.aws-stack.yml`.
-For commits that are ancestors of , the is build was published to
-`https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.yml`.
+Note: for commits that are ancestors of [419f271b54802c4c8301730bc35b34ed379074c4](https://github.com/buildkite/elastic-ci-stack-for-aws/commit/419f271b54802c4c8301730bc35b34ed379074c4), the build was published to `https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.yml`.
 
 <!-- vale off -->
 

--- a/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
+++ b/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
@@ -102,7 +102,7 @@ https://s3.amazonaws.com/buildkite-aws-stack/main/${COMMIT}.aws-stack.yml
 > Per commit builds for versions prior to v6.0.0, in particular for commits that are ancestors of [419f271](https://github.com/buildkite/elastic-ci-stack-for-aws/commit/419f271b54802c4c8301730bc35b34ed379074c4), were published to
 >
 > ```text
-> https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.yml`.
+> https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.yml
 > ```
 
 <!-- vale off -->

--- a/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
+++ b/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
@@ -87,14 +87,15 @@ or a specific release available from the [releases page](https://github.com/buil
 The latest stable release can be deployed to any of our supported AWS Regions.
 
 The most recent build of the CloudFormation stack is published to
-`https://s3.amazonaws.com/buildkite-aws-stack/master/aws-stack.yml`, along with
+`https://s3.amazonaws.com/buildkite-aws-stack/main/aws-stack.yml`, along with
 a version for each commit at
+`https://s3.amazonaws.com/buildkite-aws-stack/main/${COMMIT}.aws-stack.yml`.
+For commits that are ancestors of , the is build was published to
 `https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.yml`.
 
 <!-- vale off -->
-<!-- alex ignore master -->
 
-A master branch release can also be deployed to any of our supported AWS
+A main branch release can also be deployed to any of our supported AWS
 Regions.
 
 <!-- vale on -->
@@ -136,7 +137,7 @@ You can view the stack's metrics under _Custom Namespaces_ > _Buildkite_ within 
 
 ## Reading instance and agent logs
 
-Each instance streams file system logs such as `/var/log/messages` and `/var/log/docker` into namespaced AWS log groups. A full list of files and log groups can be found in the relevant [Linux](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/packer/linux/conf/cloudwatch-agent/config.json) CloudWatch agent `config.json` file.
+Each instance streams file system logs such as `/var/log/messages` and `/var/log/docker` into namespaced AWS log groups. A full list of files and log groups can be found in the relevant [Linux](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/packer/linux/conf/cloudwatch-agent/config.json) CloudWatch agent `config.json` file.
 
 Within each stream the logs are grouped by instance ID.
 

--- a/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
+++ b/pages/agent/v3/elastic_ci_aws/managing_elastic_ci_stack.md
@@ -99,7 +99,7 @@ https://s3.amazonaws.com/buildkite-aws-stack/main/${COMMIT}.aws-stack.yml
 ```
 
 >📘 Versions prior to v6.0.0
-> Per commit builds for versions prior to v6.0.0, in particular for commits that are ancestors of [419f271](https://github.com/buildkite/elastic-ci-stack-for-aws/commit/419f271b54802c4c8301730bc35b34ed379074c4), were published to
+> Per-commit builds for versions prior to v6.0.0, in particular for commits that are ancestors of [419f271](https://github.com/buildkite/elastic-ci-stack-for-aws/commit/419f271b54802c4c8301730bc35b34ed379074c4), were published to:
 >
 > ```text
 > https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.yml

--- a/pages/agent/v3/elastic_ci_aws/parameters.md
+++ b/pages/agent/v3/elastic_ci_aws/parameters.md
@@ -6,7 +6,7 @@ toc: false
 
 To create an Auto Scaling group and the launch template for the Elastic CI Stack for AWS deployment, you can either use the default YAML config file, or you can copy it, and substitute that YAML config file with your own configuration file when you create new instances.
 
-The following tables list all the available parameters for the [`aws-stack.yml` template](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/templates/aws-stack.yml) which creates an Auto Scaling group and the launch template for the Elastic CI Stack for AWS deployment.
+The following tables list all the available parameters for the [`aws-stack.yml` template](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/templates/aws-stack.yml) which creates an Auto Scaling group and the launch template for the Elastic CI Stack for AWS deployment.
 
 You can use these parameters to configure the EC2 instances to suit your needs.
 

--- a/pages/agent/v3/elastic_ci_aws/security.md
+++ b/pages/agent/v3/elastic_ci_aws/security.md
@@ -7,7 +7,7 @@ The S3 buckets that Buildkite Agent creates for secrets don't allow public acces
 * `VpcId`
 * `Subnets`
 * `AvailabilityZones`
-* `SecurityGroupId`
+* `SecurityGroupIds`
 
 Anyone with commit access to your codebase (including third-party pull-requests if you've enabled them in Buildkite) also has access to your secrets bucket files.
 

--- a/pages/agent/v3/elastic_ci_aws/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_aws/troubleshooting.md
@@ -9,7 +9,7 @@ Infrastructure as code isn't always easy to troubleshoot, but here are some ways
 Elastic CI Stack for AWS sends logs to various CloudWatch log streams:
 
 * Buildkite Agent logs get sent to the `buildkite/buildkite-agent/{instance_id}` log stream. If there are problems within the agent itself, the agent logs should help diagnose.
-* Output from an Elastic CI Stack for AWS instance's startup script ([Linux](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/packer/linux/conf/bin/bk-install-elastic-stack.sh) or [Windows](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/packer/windows/conf/bin/bk-install-elastic-stack.ps1)) get sent to the `/buildkite/elastic-stack/{instance_id}` log stream. If an instance is failing to launch cleanly, it's often a problem with the startup script, making this log stream especially useful for debugging problems with the Elastic CI Stack for AWS.
+* Output from an Elastic CI Stack for AWS instance's startup script ([Linux](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/packer/linux/conf/bin/bk-install-elastic-stack.sh) or [Windows](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/packer/windows/conf/bin/bk-install-elastic-stack.ps1)) get sent to the `/buildkite/elastic-stack/{instance_id}` log stream. If an instance is failing to launch cleanly, it's often a problem with the startup script, making this log stream especially useful for debugging problems with the Elastic CI Stack for AWS.
 
 Additionally, on Linux instances only:
 
@@ -20,7 +20,7 @@ On Windows instances only:
 
 * Logs from the UserData execution process (similar to the `/buildkite/cloud-init/output` group above) are sent to the `/buildkite/EC2Launch/UserdataExecution/{instance_id}` log stream.
 
-There are a couple of other log groups that the Elastic CI Stack for AWS sends logs to, but their use cases are pretty specific. For a full accounting of what logs are sent to CloudWatch, see the config for [Linux](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/packer/linux/conf/cloudwatch-agent/config.json) and [Windows](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/packer/windows/conf/cloudwatch-agent/amazon-cloudwatch-agent.json).
+There are a couple of other log groups that the Elastic CI Stack for AWS sends logs to, but their use cases are pretty specific. For a full accounting of what logs are sent to CloudWatch, see the config for [Linux](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/packer/linux/conf/cloudwatch-agent/config.json) and [Windows](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/packer/windows/conf/cloudwatch-agent/amazon-cloudwatch-agent.json).
 
 ## Accessing  Elastic CI Stack for AWS instances directly
 

--- a/pages/agent/v3/elastic_ci_aws/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_aws/troubleshooting.md
@@ -33,7 +33,7 @@ Sometimes, looking at the logs isn't enough to figure out what's going on in you
 
 Resource shortage can cause this issue. See the Auto Scaling group's Activity log for diagnostics.
 
-To fix this issue, change or add more instance types to the `InstanceType` template parameter. If 100% of your existing instances are Spot Instances, switch some of them to On-Demand Instances by setting `OnDemandPercentage` parameter to a value above zero.
+To fix this issue, change or add more instance types to the `InstanceTypes` template parameter. If 100% of your existing instances are Spot Instances, switch some of them to On-Demand Instances by setting `OnDemandPercentage` parameter to a value above zero.
 
 ## Stacks over-provision agents
 

--- a/pages/agent/v3/elastic_ci_aws/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_aws/troubleshooting.md
@@ -22,7 +22,7 @@ On Windows instances only:
 
 There are a couple of other log groups that the Elastic CI Stack for AWS sends logs to, but their use cases are pretty specific. For a full accounting of what logs are sent to CloudWatch, see the config for [Linux](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/packer/linux/conf/cloudwatch-agent/config.json) and [Windows](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/packer/windows/conf/cloudwatch-agent/amazon-cloudwatch-agent.json).
 
-## Accessing  Elastic CI Stack for AWS instances directly
+## Accessing Elastic CI Stack for AWS instances directly
 
 Sometimes, looking at the logs isn't enough to figure out what's going on in your instances. In these cases, it can be useful to access the shell on the instance directly:
 

--- a/pages/agent/v3/redhat.md
+++ b/pages/agent/v3/redhat.md
@@ -1,7 +1,6 @@
 # Installing Buildkite Agent on Red Hat Enterprise Linux, CentOS, and Amazon Linux
 
-The Buildkite Agent is supported on Red Hat Enterprise Linux 7 and newer, CentOS 7 and newer, and Amazon Linux 2
-using our yum repository.
+The Buildkite Agent is supported on Red Hat Enterprise Linux 7 and newer, CentOS 7 and newer, and Amazon Linux 2 and newer using our yum repository.
 
 
 ## Installation


### PR DESCRIPTION
The main changes are Amazon Linux 2023 and several parameter renames. We are also renaming the `master` branch to `main`. This affects several URLs to github, but also URLs to the stack templates. The github URLs have been changed to be agnostic to what the default branch is.

See https://github.com/buildkite/elastic-ci-stack-for-aws/releases/tag/v6.0.0 for more details.

That link won't be up while this is a draft. In the meantime, use https://github.com/buildkite/elastic-ci-stack-for-aws/releases/tag/v6.0.0-beta1 and https://github.com/buildkite/elastic-ci-stack-for-aws/releases/tag/v6.0.0-beta2 instead.