### PR TITLE
Clusters category in GraphQL Cookbook/initial examples

### DIFF
--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -602,12 +602,12 @@ A collection of common tasks with clusters using the GraphQL API.
 
 ### List cluster IDs
 
-Get the fist 10 clusters and their information for a particular organization.
+Get the fist 10 clusters and their information for a particular organization:
 
 ```graphql
 query getClusters {
   organization(slug: "organization-slug") {
-		clusters(first: 10){
+    clusters(first: 10){
       edges{
         node{
           id
@@ -623,30 +623,30 @@ query getClusters {
 
 ### List cluster queue IDs
 
-Get the fist 10 cluster queues for a particular cluster by specifying its UUID in `cluster-uuid`.
+Get the fist 10 cluster queues for a particular cluster by specifying its UUID in `cluster-uuid`:
 
 ```graphql
 query getClusterQueues {
-	organization(slug: "organization-slug") {
-		cluster(id: ""cluster-uuid") {
-			queues(first: 10) {
-				edges {
-					node {
-						id
-						uuid
-						key
-						description
-					}
-				}
-			}
-		}
-	}
+  organization(slug: "organization-slug") {
+    cluster(id: "cluster-uuid") {
+      queues(first: 10) {
+        edges {
+          node {
+            id
+            uuid
+            key
+            description
+          }
+        }
+      }
+    }
+  }
 }
 ```
 
 ### List jobs in a particular cluster queue
 
-To get jobs for a particular cluster queue, use the `clusterQueue` filter, passing in the ID of the cluster queue to filter jobs from. 
+To get jobs for a particular cluster queue, use the `clusterQueue` filter, passing in the ID of the cluster queue to filter jobs from:
 
 ```graphql
 query getClusterQueueJobs {
@@ -673,10 +673,10 @@ query getClusterQueueJobs {
 }
 ```
 
-To obtain jobs for a particular cluster queue in a particular state, use the `clusterQueue` filter, passing in the ID of the cluster queue to filter jobs from, and the `state` list filter by [JobStates](https://buildkite.com/docs/apis/graphql/schemas/enum/jobstates):
+To obtain jobs for a particular cluster queue in a particular state, use the `clusterQueue` filter, passing in the ID of the cluster queue to filter jobs from, and the `state` list filter by one or more [JobStates](https://buildkite.com/docs/apis/graphql/schemas/enum/jobstates):
 
 ```graphql
-query getClusterQueueJobsByState {
+query getClusterQueueJobsByJobState {
   organization(slug: "organization-slug") {
     jobs(
       first: 10, 

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -602,7 +602,7 @@ A collection of common tasks with clusters using the GraphQL API.
 
 ### List cluster IDs
 
-Get the first 10 clusters and their information for a particular organization:
+Get the first 10 clusters and their information for an organization:
 
 ```graphql
 query getClusters {
@@ -646,7 +646,7 @@ query getClusterQueues {
 
 ### List jobs in a particular cluster queue
 
-To get jobs for a particular cluster queue, use the `clusterQueue` filter, passing in the ID of the cluster queue to filter jobs from:
+To get jobs within a cluster queue, use the `clusterQueue` filter, passing in the ID of the cluster queue to filter jobs from:
 
 ```graphql
 query getClusterQueueJobs {
@@ -673,7 +673,7 @@ query getClusterQueueJobs {
 }
 ```
 
-To obtain jobs for a particular cluster queue in a particular state, use the `clusterQueue` filter, passing in the ID of the cluster queue to filter jobs from, and the `state` list filter by one or more [JobStates](https://buildkite.com/docs/apis/graphql/schemas/enum/jobstates):
+To obtain jobs within a cluster queue of a particular state, use the `clusterQueue` filter, passing in the ID of the cluster queue to filter jobs from, and the `state` list filter by one or more [JobStates](https://buildkite.com/docs/apis/graphql/schemas/enum/jobstates):
 
 ```graphql
 query getClusterQueueJobsByJobState {

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -596,6 +596,114 @@ mutation {
 }
 ```
 
+## Clusters
+
+A collection of common tasks with clusters using the GraphQL API.
+
+### List cluster IDs
+
+Get the fist 10 clusters and their information for a particular organization.
+
+```graphql
+query getClusters {
+  organization(slug: "organization-slug") {
+		clusters(first: 10){
+      edges{
+        node{
+          id
+          uuid
+          color
+          description
+        }
+      }
+    }
+  }
+}
+```
+
+### List cluster queue IDs
+
+Get the fist 10 cluster queues for a particular cluster by specifying its UUID in `cluster-uuid`.
+
+```graphql
+query getClusterQueues {
+	organization(slug: "organization-slug") {
+		cluster(id: ""cluster-uuid") {
+			queues(first: 10) {
+				edges {
+					node {
+						id
+						uuid
+						key
+						description
+					}
+				}
+			}
+		}
+	}
+}
+```
+
+### List jobs in a particular cluster queue
+
+To get jobs for a particular cluster queue, use the `clusterQueue` filter, passing in the ID of the cluster queue to filter jobs from. 
+
+```graphql
+query getClusterQueueJobs {
+  organization(slug: "organization-slug") {
+    jobs(first: 10, clusterQueue: "cluster-queue-id") {
+      edges {
+        node {
+          ... on JobTypeCommand {
+            id
+            state
+            label
+            url
+            build {
+              number
+            }
+            pipeline {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+To obtain jobs for a particular cluster queue in a particular state, use the `clusterQueue` filter, passing in the ID of the cluster queue to filter jobs from, and the `state` list filter by [JobStates](https://buildkite.com/docs/apis/graphql/schemas/enum/jobstates):
+
+```graphql
+query getClusterQueueJobsByState {
+  organization(slug: "organization-slug") {
+    jobs(
+      first: 10, 
+      clusterQueue: "cluster-queue-id",
+      state: [WAITING, BLOCKED]
+    ){
+      edges {
+        node {
+          ... on JobTypeCommand {
+            id
+            state
+            label
+            url
+            build {
+              number
+            }
+            pipeline {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ## Organizations
 
 A collection of common tasks with organizations using the GraphQL API.
@@ -823,7 +931,7 @@ This deletes a member from an organization. It does not delete their Buildkite u
 First, find the member's ID:
 
 ```graphql
-query {
+query getOrganizationMemberIds {
   organization(slug: "organization-slug") {
     members(search: "organization-member-name", first: 10) {
       edges {
@@ -837,6 +945,7 @@ query {
       }
     }
   }
+}
 ```
 
 Then, use the ID to delete the user:

--- a/pages/apis/graphql/graphql_cookbook.md
+++ b/pages/apis/graphql/graphql_cookbook.md
@@ -602,7 +602,7 @@ A collection of common tasks with clusters using the GraphQL API.
 
 ### List cluster IDs
 
-Get the fist 10 clusters and their information for a particular organization:
+Get the first 10 clusters and their information for a particular organization:
 
 ```graphql
 query getClusters {
@@ -623,7 +623,7 @@ query getClusters {
 
 ### List cluster queue IDs
 
-Get the fist 10 cluster queues for a particular cluster by specifying its UUID in `cluster-uuid`:
+Get the first 10 cluster queues for a particular cluster by specifying its UUID in `cluster-uuid`:
 
 ```graphql
 query getClusterQueues {


### PR DESCRIPTION
Added an initial example Clusters section in the GraphQL cookbook with some examples:

![image](https://github.com/buildkite/docs/assets/70425486/5fe6a111-286a-4f18-90bd-1d065fa2abec)

Contains the first few examples

- getClusters
- getClusterQueues
- getClusterQueueJobs
- getClusterQueueJobsByJobState