### PR TITLE
Build Exports: we do not currently support SSE-KMS

### DIFF
--- a/pages/pipelines/build_exports.md
+++ b/pages/pipelines/build_exports.md
@@ -48,7 +48,7 @@ To configure build exports for your organization, you'll need to prepare an Amaz
 * Your bucket should use modern S3 security features and configurations, for example (but not limited to):
   - [Block public access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html) to prevent accidental misconfiguration leading to data exposure.
   - [ACLs disabled with bucket owner enforced](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) to ensure your AWS account owns the objects written by Buildkite.
-  - [Server-side data encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html) (`SSE-S3` is enabled by default but you may want to consider `SSE-KMS`).
+  - [Server-side data encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html) (`SSE-S3` is enabled by default, we do not currently support `SSE-KMS` but let us know if you need it).
   - [S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html) to help recover objects from accidental deletion or overwrite.
 * You may want to use [Amazon S3 Lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) to manage storage class and object expiry.
 


### PR DESCRIPTION
The docs for Build Exports — Prepare your Amazon S3 bucket said:

> … you may want to consider `SSE-KMS`

However:

- we definitely don't currently explain how to configure a resource policy on the KMS key to allow our AWS account to encrypt data with it, so it will probably fail with a permission error,
- we probably don't have our application's IAM role configured to allow KMS encryption,
- when it fails due to attempted KMS use, the permission checker doesn't currently pass on that informative error message.

So, the best thing for the moment is to discourage its use in the docs.

The _internal_ error message is something like this:

>     upload failed: - to s3://…/buildkite/build-exports/org=…/deliverability-test.txt An error occurred (AccessDenied) when calling the PutObject operation: User: arn:aws:sts::032379705303:assumed-role/… is not authorized to perform: kms:GenerateDataKey on this resource because the resource does not exist in this Region, no resource-based policies allow access, or a resource-based policy explicitly denies access

---

<img width="1034" alt="image" src="https://github.com/buildkite/docs/assets/15759/c4a98eab-bafc-4fa6-88ee-aa70e1da7718">

