### PR TITLE
Remove web archive link to Ruby best practices

### DIFF
--- a/pages/test_analytics/ruby_collectors.md
+++ b/pages/test_analytics/ruby_collectors.md
@@ -61,7 +61,7 @@ Failure/Error: allow_any_instance_of(Object).to receive(:sleep)
        Using `any_instance` to stub a method (sleep) that has been defined on a prepended module (Buildkite::TestCollector::Object::CustomObjectSleep) is not supported.
 ```
 
-You can fix them by being more specific in your stubbing, which is [better practice](https://web.archive.org/web/20220810120550/https://relishapp.com/rspec/rspec-mocks/v/3-11/docs/working-with-legacy-code/any-instance), by replacing `allow_any_instance_of(Object).to receive(:sleep)` with `allow_any_instance_of(TheClassUnderTest).to receive(:sleep)`.
+You can fix them by being more specific in your stubbing by replacing `allow_any_instance_of(Object).to receive(:sleep)` with `allow_any_instance_of(TheClassUnderTest).to receive(:sleep)`.
 
 ## minitest collector
 


### PR DESCRIPTION
We run a link checker as part of linting the docs, and this link keeps causing it to fail by returning a 429. We don't want Google penalizing us for broken outbound links. From my understanding of the paragraph, we're mainly linking there to add legitimacy to our suggestion, but our suggestion provides the solution. If that's true, I don't think we need this link.

If I'm missing something, is there another resource we could link to or some information from that page we could pull into our docs?