### PR TITLE
Update docs with notes on pipeline provider webhook_url permissions

### DIFF
--- a/pages/apis/rest_api/builds.md
+++ b/pages/apis/rest_api/builds.md
@@ -171,6 +171,8 @@ Optional [query string parameters](/docs/api#query-string-parameters):
 
 Required scope: `read_builds`
 
+Note: `pipeline.provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
+
 Success response: `200 OK`
 
 ## Get a build
@@ -298,6 +300,8 @@ Optional [query string parameters](/docs/api#query-string-parameters):
 </table>
 
 Required scope: `read_builds`
+
+Note: `pipeline.provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
 
 Success response: `200 OK`
 
@@ -452,6 +456,8 @@ Optional [request body properties](/docs/api#request-body-properties):
 
 Required scope: `write_builds`
 
+Note: `pipeline.provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
+
 Success response: `201 Created`
 
 Error responses:
@@ -575,6 +581,8 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 
 Required scope: `write_builds`
 
+Note: `pipeline.provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
+
 Success response: `200 OK`
 
 Error responses:
@@ -696,6 +704,8 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 ```
 
 Required scope: `write_builds`
+
+Note: `pipeline.provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
 
 Success response: `200 OK`
 

--- a/pages/apis/rest_api/builds.md
+++ b/pages/apis/rest_api/builds.md
@@ -165,13 +165,14 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
 ]
 ```
 
+> 📘 Webhook URL
+> The response only includes a webhook URL in `pipeline.provider.webhook_url` if the user has edit permissions for the pipeline. Otherwise, the field returns with an empty string.
+
 Optional [query string parameters](/docs/api#query-string-parameters):
 
 <%= render_markdown partial: 'apis/rest_api/builds_list_query_strings' %>
 
 Required scope: `read_builds`
-
-Note: `pipeline.provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
 
 Success response: `200 OK`
 
@@ -286,6 +287,9 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
 }
 ```
 
+> 📘 Webhook URL
+> The response only includes a webhook URL in `pipeline.provider.webhook_url` if the user has edit permissions for the pipeline. Otherwise, the field returns with an empty string.
+
 Optional [query string parameters](/docs/api#query-string-parameters):
 
 <table>
@@ -300,8 +304,6 @@ Optional [query string parameters](/docs/api#query-string-parameters):
 </table>
 
 Required scope: `read_builds`
-
-Note: `pipeline.provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
 
 Success response: `200 OK`
 
@@ -427,6 +429,8 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
   }
 }
 ```
+> 📘 Webhook URL
+> The response only includes a webhook URL in `pipeline.provider.webhook_url` if the user has edit permissions for the pipeline. Otherwise, the field returns with an empty string.
 
 Required [request body properties](/docs/api#request-body-properties):
 
@@ -455,8 +459,6 @@ Optional [request body properties](/docs/api#request-body-properties):
 </table>
 
 Required scope: `write_builds`
-
-Note: `pipeline.provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
 
 Success response: `201 Created`
 
@@ -579,9 +581,10 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 }
 ```
 
-Required scope: `write_builds`
+> 📘 Webhook URL
+> The response only includes a webhook URL in `pipeline.provider.webhook_url` if the user has edit permissions for the pipeline. Otherwise, the field returns with an empty string.
 
-Note: `pipeline.provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
+Required scope: `write_builds`
 
 Success response: `200 OK`
 
@@ -703,9 +706,10 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
 }
 ```
 
-Required scope: `write_builds`
+> 📘 Webhook URL
+> The response only includes a webhook URL in `pipeline.provider.webhook_url` if the user has edit permissions for the pipeline. Otherwise, the field returns with an empty string.
 
-Note: `pipeline.provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
+Required scope: `write_builds`
 
 Success response: `200 OK`
 

--- a/pages/apis/rest_api/pipelines.md
+++ b/pages/apis/rest_api/pipelines.md
@@ -74,9 +74,10 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines"
 ]
 ```
 
-Required scope: `read_pipelines`
+> 📘 Webhook URL
+> The response only includes a webhook URL in `provider.webhook_url` if the user has edit permissions for the pipeline. Otherwise, the field returns with an empty string.
 
-Note: `provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
+Required scope: `read_pipelines`
 
 Success response: `200 OK`
 
@@ -150,9 +151,10 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{slug}"
 }
 ```
 
-Required scope: `read_pipelines`
+> 📘 Webhook URL
+> The response only includes a webhook URL in `pipeline.provider.webhook_url` if the user has edit permissions for the pipeline. Otherwise, the field returns with an empty string.
 
-Note: `provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
+Required scope: `read_pipelines`
 
 Success response: `200 OK`
 

--- a/pages/apis/rest_api/pipelines.md
+++ b/pages/apis/rest_api/pipelines.md
@@ -76,6 +76,8 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines"
 
 Required scope: `read_pipelines`
 
+Note: `provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
+
 Success response: `200 OK`
 
 ## Get a pipeline
@@ -150,8 +152,9 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{slug}"
 
 Required scope: `read_pipelines`
 
-Success response: `200 OK`
+Note: `provider.webhook_url` value is only returned if the user has edit permissions for the pipeline.
 
+Success response: `200 OK`
 
 ## Create a YAML pipeline
 


### PR DESCRIPTION
### Context

**What was the problem?**
For some time now, provider webhook_url for pipelines has been exposed in our REST API and webhook payloads without all of the correct permissions checks: anyone with a READ scoped agent token was able to see it. The problem here is that only users with edit permissions for the pipeline should be able to see the provider webhook_url - but we were not performing this additional check.

**Why is this such a concern?**
With the webhook_url you can trigger builds. We don't want read-only folks doing this. Not only that, but you can also use it to trigger builds as other people, potentially circumventing permissions etc.

In summary, to GET the pipeline provider webhook_url, the user should have:
- a READ scoped agent token
- "full access" permissions to edit the pipeline.

### Changes made 
The following changes are made in [#13075](https://github.com/buildkite/buildkite/pull/13075):

**REST API:**
We now check the permissions of the user making the request, and only return the provider webhook_url value if can_edit_pipeline? returns true for that user. If the user doesn't have edit permissions, we return a blank string.

**Webhooks**:
Unfortunately there is no user available in this context for us to do a permissions check on. This means from now on we will never return the provider webhook_url for pipelines via webhook, because without the permissions check it is unsafe to do so. A blank string is returned instead.

**How might these changes affect customers?**

- There may be some customers without pipeline edit permissions who are used to retrieving the provider webhook_url via API. When the change goes live, they will no longer be able to do this. This may cause slight disruption for some customers, but is easily fixed by enabling pipeline edit permissions for that user. The customer can do this themselves.

- We don't know exactly how customers might be using the pipeline data inside webhooks. There may be some customers who are utilising the provider webhook_url attribute. They will no longer be able to do this.

### How does this affect the docs?

We want to let customers know that the value of a pipeline provider webhook_url is only available to users with edit permissions on the pipeline. I've added notes to this effect under the relevant payloads where pipeline provider webhook_url is included. I'd love some feedback on the placement, format and wording on these additions. 

Thanks 💜

