### PR TITLE
Update build_exports to bring visibility on IAM conditions and connectivity tests

### DIFF
--- a/pages/pipelines/build_exports.md
+++ b/pages/pipelines/build_exports.md
@@ -98,7 +98,7 @@ Your Buildkite Organization ID (UUID) can be found on the settings page describe
     "description": "Allow Buildkite's service-account to create objects only within the build exports prefix",
 }
 ```
-  - Your Buildkite Organization ID (UUID) can be found on the [organization's pipeline settings](https://buildkite.com/organizations/~/pipeline-settings).
+    Your Buildkite Organization ID (UUID) can be found on the [organization's pipeline settings](https://buildkite.com/organizations/~/pipeline-settings).
 * Your bucket must grant our Buildkite service-account (`buildkite-production-aws@buildkite-pipelines.iam.gserviceaccount.com`) `storage.objects.create` permission.
 * Your bucket should use modern Google Cloud Storage security features and configurations, for example (but not limited to):
   - [Public access prevention](https://cloud.google.com/storage/docs/public-access-prevention) to prevent accidental misconfiguration leading to data exposure.

--- a/pages/pipelines/build_exports.md
+++ b/pages/pipelines/build_exports.md
@@ -91,13 +91,14 @@ Your Buildkite Organization ID (UUID) can be found on the settings page describe
   - Scope the `"Storage Object Creator"` role using IAM Conditions to limit access to objects matching the prefix `buildkite/build-exports/org=YOUR-BUILDKITE-ORGANIZATION-UUID/*`.
   - Your IAM Conditions should look like this, with `YOUR-BUCKET-NAME-HERE` and `YOUR-BUILDKITE-ORGANIZATION-UUID` substituted with your details:
 
-```json
-{
-    "expression": "resource.name.startsWith('projects/_/buckets/YOUR-BUCKET-NAME-HERE/objects/buildkite/build-exports/org=YOUR-BUILDKITE-ORGANIZATION-UUID/')",
-    "title": "Scope build exports prefix",
-    "description": "Allow Buildkite's service-account to create objects only within the build exports prefix",
-}
-```
+    ```json
+    {
+      "expression": "resource.name.startsWith('projects/_/buckets/YOUR-BUCKET-NAME-HERE/objects/buildkite/build-exports/org=YOUR-BUILDKITE-ORGANIZATION-UUID/')",
+      "title": "Scope build exports prefix",
+      "description": "Allow Buildkite's service-account to create objects only within the build exports prefix",
+    }
+    ```
+
     Your Buildkite Organization ID (UUID) can be found on the [organization's pipeline settings](https://buildkite.com/organizations/~/pipeline-settings).
 * Your bucket must grant our Buildkite service-account (`buildkite-production-aws@buildkite-pipelines.iam.gserviceaccount.com`) `storage.objects.create` permission.
 * Your bucket should use modern Google Cloud Storage security features and configurations, for example (but not limited to):

--- a/pages/pipelines/build_exports.md
+++ b/pages/pipelines/build_exports.md
@@ -86,7 +86,7 @@ Your Buildkite Organization ID (UUID) can be found on the settings page describe
 ### Prepare your Google Cloud Storage bucket
 
 * Read and understand [Google Cloud Storage security best practices](https://cloud.google.com/security/best-practices) and [Best practices for Cloud Storage](https://cloud.google.com/storage/docs/).
-* Your bucket must have a policy allowing our Buildkite service-account access as described here and demonstrated in the example below¹.
+* Your bucket must have a policy allowing our Buildkite service-account access as described here.
   - Assign Buildkite's service-account `buildkite-production-aws@buildkite-pipelines.iam.gserviceaccount.com` the `"Storage Object Creator"`.
   - Scope the `"Storage Object Creator"` role using IAM Conditions to limit access to objects matching the prefix `buildkite/build-exports/org=YOUR-BUILDKITE-ORGANIZATION-UUID/*`.
   - Your IAM Conditions should look like this, with `YOUR-BUCKET-NAME-HERE` and `YOUR-BUILDKITE-ORGANIZATION-UUID` substituted with your details:


### PR DESCRIPTION
As part of this PR, we are updating the following

1. Improving visibility into IAM conditions config that customers need to set up for GCP based on user feedback
2. Add notes around how users can be sure that once build export is enabled there is connectivity validation performed by us 