### PR TITLE
Add page meta descriptions

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -161,21 +161,33 @@ class Page
     @name.to_s.gsub(/[^0-9a-zA-Z\-\_\/]/, '').underscore
   end
 
-  def metadata
-    defaults = {
-      # Default to rendering table of contents
-      "toc": true,
-      # Default to H3s being included in the table of contents
-      "toc_include_h3": true
-    }
-    if file.front_matter
-      defaults.merge(file.front_matter.symbolize_keys)
-    else
-      defaults
-    end
+  # Should page render a table of contents?
+  def toc?
+    front_matter.fetch(:toc)
+  end
+
+  # Should page include H3s in the table of contents?
+  def toc_include_h3?
+    front_matter.fetch(:toc_include_h3)
   end
 
   private
+
+  def front_matter
+    @front_matter ||= begin
+      defaults = {
+        # Default to rendering table of contents
+        "toc": true,
+        # Default to H3s being included in the table of contents
+        "toc_include_h3": true,
+      }
+      if file.front_matter
+        defaults.merge(file.front_matter.symbolize_keys)
+      else
+        defaults
+      end
+    end
+  end
 
   def file
     @_file ||= ::FrontMatterParser::Parser.parse_file(filename)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -129,10 +129,6 @@ class Page
     extracted_data.fetch("sections")
   end
 
-  def description
-    extracted_data.fetch("shortDescription")
-  end
-
   def markdown_body
     erb_renderer = ERB.new(contents, trim_mode: '-')
     template_binding = TemplateBinding.new(view_helpers: @view,
@@ -161,12 +157,17 @@ class Page
     @name.to_s.gsub(/[^0-9a-zA-Z\-\_\/]/, '').underscore
   end
 
+  # Page description, either from front matter or extracted from the markdown
+  def description
+    front_matter.fetch(:description, extracted_data.fetch("shortDescription"))
+  end
+
   # Should page render a table of contents?
   def toc?
     front_matter.fetch(:toc)
   end
 
-  # Should page include H3s in the table of contents?
+  # Should pageinclude H3s in the table of contents?
   def toc_include_h3?
     front_matter.fetch(:toc_include_h3)
   end

--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -6,6 +6,9 @@
 <link rel="preload" as="font" type="font/woff2" href="https://www2.buildkiteassets.com/assets/maison-neue/MaisonNeueWEB-Medium-9884c2338b4896f2fd56d7a93ee2150c2855644550ee60a9a9ff2137b6d3b507.woff2" crossorigin="anonymous" />
 
 <title><%= [content_for(:page_title), "Buildkite Documentation"].compact.join(" | ") %></title>
+<% if description = content_for(:page_description) %>
+<meta name="description" content="<%= description %>" />
+<% end %>
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <%= stylesheet_link_tag "docsearch", "application", media: "all" %>

--- a/app/views/application/_toc.html.erb
+++ b/app/views/application/_toc.html.erb
@@ -1,4 +1,4 @@
-  <% if @page.metadata[:toc] %>
+  <% if @page.toc? %>
     <nav class="Toc">
       <button class="Toc__toggle">
         <h2 class="Toc__title">On this page</h2>
@@ -10,7 +10,7 @@
               <%= section[:header] %>
             </a>
 
-            <% if section[:subsections].count && @page.metadata[:toc_include_h3] %>
+            <% if section[:subsections].count && @page.toc_include_h3? %>
               <ul class="Toc__list">
                 <% section[:subsections].each do |subsection| %>
                   <li class="Toc__list-item">
@@ -21,7 +21,6 @@
                 <% end %>
               </ul>
             <% end %>
-
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
Adds meta descriptions to all pages with content pulled from YAML front matter or falling back to the first paragraph.

Closes ONB-317, ONB-326