### PR TITLE
PIE-1940: Update description for TA json duration field

### DIFF
--- a/data/content/test_analytics_json_fields_history.yaml
+++ b/data/content/test_analytics_json_fields_history.yaml
@@ -16,7 +16,7 @@ fields:
   required: true
   type: number
   desc: |
-      How long the test took to run
+      How long the test took to run. This value is microseconds stored as a float.
   examples:
 - name: children
   required: false

--- a/data/content/test_analytics_json_fields_span.yaml
+++ b/data/content/test_analytics_json_fields_span.yaml
@@ -26,7 +26,7 @@ fields:
   required: true
   type: number
   desc: |
-      How long the span took to run
+      How long the span took to run. This value is microseconds stored as a float.
   examples:
 - name: detail
   required : false


### PR DESCRIPTION
Change requested via support ticket to clarify the time unit for the JSON upload history object duration.

Also updated the duration attribute for the span section with the same information.

[PIE-1940](https://linear.app/buildkite/issue/PIE-1940/update-json-history-docs-to-clarify-the-time-unit-for-duration)
[Support ticket](https://3.basecamp.com/3453178/buckets/20365997/card_tables/cards/6449334609)
[Slack conversation](https://buildkite.slack.com/archives/C02RH06NMH6/p1692007930840309)


<img width="1920" alt="Screenshot 2023-08-16 at 10 07 48 (2)" src="https://github.com/buildkite/docs/assets/13619812/ea85631e-30ad-446c-933c-a222f048fbd4">

<img width="819" alt="Screenshot 2023-08-17 at 10 03 05" src="https://github.com/buildkite/docs/assets/13619812/5617c155-dc1a-44e5-8eb6-8b1a477bf052">
