### PR TITLE
PIE-1941: Update TA JSON failure_expanded

### DIFF
--- a/data/content/test_analytics_json_fields_failure_expanded.yaml
+++ b/data/content/test_analytics_json_fields_failure_expanded.yaml
@@ -1,0 +1,14 @@
+fields:
+- name: expanded
+  required: true
+  type: array
+  enumerated_values:
+  desc: |
+      An array of strings describing the failure
+- name: backtrace
+  required: true
+  type: array
+  enumerated_values:
+  desc: |
+      An array of strings documenting the backtrace of the failed test
+

--- a/pages/test_analytics/importing_json.md
+++ b/pages/test_analytics/importing_json.md
@@ -215,29 +215,60 @@ end
   "result": "failed",
   "failure_reason": "Failure/Error: expect(true).to eq false",
   "failure_expanded": [
-  {
-      "expanded": [
-      "  expected: false",
-      "       got: true",
-      "",
-      "  (compared using ==)",
-      "",
-      "  Diff:",
-      "  @@ -1 +1 @@",
-      "  -false","  +true"
-      ],
-      "backtrace": [
-      "./spec/models/analytics/upload_spec.rb:25:in `block (3 levels) in \u003ctop (required)\u003e'","./spec/support/log.rb:17:in `run'",
-      "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-      "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
-      "/Users/abc/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-      "-e:1:in `\u003cmain\u003e'"
-      ]
-  }
+    /* failure_expanded object */
   ],
   "history": {
     /* history object */
   }
+}
+```
+
+### Failure expanded objects
+
+A failure expanded array contains extra details about the failed test.
+
+<table class="responsive-table">
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% TEST_ANALYTICS_JSON_FIELDS_FAILURE_EXPANDED['fields'].each do |field| -%>
+      <tr>
+        <td><code><%= field['name'] %></code> <%= '(required)' if field['required'] %></td>
+        <td><%= field['type'] %> <%= render_enumerated_values(field['enumerated_values']) %></td>
+        <td>
+          <%= render_markdown(text: field['desc']) %>
+        </td>
+      </tr>
+    <% end -%>
+  </tbody>
+</table>
+
+**Example:**
+
+```js
+{
+  "expanded": [
+  "  expected: false",
+  "       got: true",
+  "",
+  "  (compared using ==)",
+  "",
+  "  Diff:",
+  "  @@ -1 +1 @@",
+  "  -false","  +true"
+  ],
+  "backtrace": [
+    "./spec/models/analytics/upload_spec.rb:25:in `block (3 levels) in \u003ctop (required)\u003e'","./spec/support/log.rb:17:in `run'",
+    "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
+    "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
+    "/Users/abc/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
+    "-e:1:in `\u003cmain\u003e'"
+  ]
 }
 ```
 

--- a/pages/test_analytics/importing_json.md
+++ b/pages/test_analytics/importing_json.md
@@ -253,14 +253,14 @@ A failure expanded array contains extra details about the failed test.
 ```js
 {
   "expanded": [
-  "  expected: false",
-  "       got: true",
-  "",
-  "  (compared using ==)",
-  "",
-  "  Diff:",
-  "  @@ -1 +1 @@",
-  "  -false","  +true"
+    "  expected: false",
+    "       got: true",
+    "",
+    "  (compared using ==)",
+    "",
+    "  Diff:",
+    "  @@ -1 +1 @@",
+    "  -false","  +true"
   ],
   "backtrace": [
     "./spec/models/analytics/upload_spec.rb:25:in `block (3 levels) in \u003ctop (required)\u003e'","./spec/support/log.rb:17:in `run'",

--- a/pages/test_analytics/importing_json.md
+++ b/pages/test_analytics/importing_json.md
@@ -263,11 +263,11 @@ A failure expanded array contains extra details about the failed test.
     "  -false","  +true"
   ],
   "backtrace": [
-    "./spec/models/analytics/upload_spec.rb:25:in `block (3 levels) in \u003ctop (required)\u003e'","./spec/support/log.rb:17:in `run'",
-    "./spec/support/log.rb:66:in `block (2 levels) in \u003ctop (required)\u003e'",
-    "./spec/support/database.rb:19:in `block (2 levels) in \u003ctop (required)\u003e'",
+    "./spec/models/analytics/upload_spec.rb:25:in `block (3 levels) in <top (required)>'","./spec/support/log.rb:17:in `run'",
+    "./spec/support/log.rb:66:in `block (2 levels) in <top (required)>'",
+    "./spec/support/database.rb:19:in `block (2 levels) in <top (required)>'",
     "/Users/abc/Documents/rspec-buildkite-analytics/lib/rspec/buildkite/analytics/uploader.rb:153:in `block (2 levels) in configure'",
-    "-e:1:in `\u003cmain\u003e'"
+    "-e:1:in `<main>'"
   ]
 }
 ```


### PR DESCRIPTION
We had some customer feedback regarding their difficulty using the failure_expanded object in their custom collector. The keys within the hash are required fields on the frontend, so I have updated the docs to detail this further. (Please feel free to recommend better words).

[PIE-1941](https://linear.app/buildkite/issue/PIE-1941)
[Support ticket](https://3.basecamp.com/3453178/buckets/20365997/card_tables/cards/6449338274)
[Slack conversation](https://buildkite.slack.com/archives/C02RH06NMH6/p1692007930840309) 

<img width="1920" alt="Screenshot 2023-08-16 at 10 55 59 (2)" src="https://github.com/buildkite/docs/assets/13619812/7055af5e-34fd-4006-9b67-da9c5b5aa0df">
