### PR TITLE
Bump ecr-plugin to v2.7.0

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -8,9 +8,9 @@ steps:
     agents:
       queue: deploy
     plugins:
-     ecr#v2.0.0:
-       login: true
-       account-ids: ${ECR_ACCOUNT_ID}
+      ecr#v2.7.0:
+        login: true
+        account-ids: ${ECR_ACCOUNT_ID}
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying


### PR DESCRIPTION
Fix an issue with pushing up the docs image to ECR by using the latest version of our buildkite-ecr-plugin.