### PR TITLE
Explicit dependencies on a wait step can break the wait intention 

### DIFF
--- a/pages/pipelines/wait_step.md
+++ b/pages/pipelines/wait_step.md
@@ -45,6 +45,10 @@ _Optional attributes:_
   </tr>
 </table>
 
+>🚧 <code>depends_on</code> and <code>wait</code>
+> Use explicit dependencies in a wait step  with care. A wait step with the <code>depends_on</code> attribute might break the intention of waiting when you have missing dependencies. Jobs following the wait step no longer waits for previous steps to complete to continue if their dependencies are missing.
+
+
 ## Conditional wait
 
 You can use a conditional to only wait when certain conditions are met:


### PR DESCRIPTION
We received a customer feedback where jobs following a wait step were ran without waiting for previous steps to continue as opposed to what we say in the docs on wait steps. After investigation, it was the caused by the use of `depends_on` attribute with a missing dependency. Details at this HS ticket [56014]( https://secure.helpscout.net/conversation/2334371567/56014/) .