### PR TITLE
Doc 654 add reference to queues on branch configurations

### DIFF
--- a/pages/agent/v3/queues.md
+++ b/pages/agent/v3/queues.md
@@ -28,12 +28,17 @@ buildkite-agent start --tags "queue=building,queue=testing"
 
 ## Targeting a queue
 
-Target specific queues using the `agents` attribute on your pipeline steps.
+Target specific queues using the `agents` attribute on your pipeline steps or at the root level for the entire pipeline.
 
-For example, the following build step matches only agents running on the `deploy` queue (and ignores the agents running the `default` queue):
+For example, the following pipeline would run on the `priority` queue as determined by the root level `agents` attribute (and ignores the agents running the `default` queue). The `tests.sh` build step matches only agents running on the `deploy` queue.
 
 ```yaml
+agents:
+  queue: "priority"
+
 steps:
+  - command: echo "hello"
+
   - command: tests.sh
     agents:
       queue: "deploy"

--- a/pages/agent/v3/queues.md
+++ b/pages/agent/v3/queues.md
@@ -45,4 +45,4 @@ steps:
 
 ## Alternative methods
 
-Alternatively you can use [branch patterns](/docs/pipelines/branch-configuration) to control which pipelines and build steps are built based on the branch names.
+[Branch patterns](/docs/pipelines/branch-configuration) are another way to control what work is done. You can use branch patterns to determine which pipelines and steps run based on the branch name.

--- a/pages/agent/v3/queues.md
+++ b/pages/agent/v3/queues.md
@@ -4,6 +4,7 @@ Each pipeline has the ability to separate jobs using queues. This allows you to 
 
 Common use cases for queues include deployment agents, and pools of agents for specific pipelines or teams.
 
+Alternatively you can use [branch patterns](/docs/pipelines/branch-configuration) to ensure pipelines and build steps are only built when necessary (determined by branch name).
 
 ## The default queue
 

--- a/pages/agent/v3/queues.md
+++ b/pages/agent/v3/queues.md
@@ -4,8 +4,6 @@ Each pipeline has the ability to separate jobs using queues. This allows you to 
 
 Common use cases for queues include deployment agents, and pools of agents for specific pipelines or teams.
 
-Alternatively you can use [branch patterns](/docs/pipelines/branch-configuration) to ensure pipelines and build steps are only built when necessary (determined by branch name).
-
 ## The default queue
 
 If you don't configure a queue for your agent by setting an [agent tag](/docs/agent/v3/cli-start#setting-tags) of `queue=my_example_queue` it will accept jobs from the default queue as if you had set `queue=default`.
@@ -24,8 +22,8 @@ buildkite-agent start --tags "queue=building,queue=testing"
 
 <%= image "agent-queues.png", width: 1182/2, height: 160/2, alt: "Screenshot of an agent's tags showing both building and testing queues" %>
 
->🚧 Configuring cluster queues
->If you have [Clusters](/docs/clusters/overview) enabled and are configuring your agent with a _cluster queue_, you need to create the cluster queue first. See [Create a cluster queue](/docs/clusters/manage-clusters#set-up-clusters-create-a-queue) for more information.
+> 🚧 Configuring cluster queues
+> If you have [Clusters](/docs/clusters/overview) enabled and are configuring your agent with a _cluster queue_, you need to create the cluster queue first. See [Create a cluster queue](/docs/clusters/manage-clusters#set-up-clusters-create-a-queue) for more information.
 
 ## Targeting a queue
 
@@ -44,3 +42,7 @@ steps:
     agents:
       queue: "deploy"
 ```
+
+## Alternative methods
+
+Alternatively you can use [branch patterns](/docs/pipelines/branch-configuration) to control which pipelines and build steps are built based on the branch names.

--- a/pages/pipelines/branch_configuration.md
+++ b/pages/pipelines/branch_configuration.md
@@ -1,6 +1,6 @@
 # Branch configuration
 
-You can use branch patterns to ensure pipelines are only triggered when necessary. This guide shows you how to set up branch patterns for whole pipelines and individual build steps.
+You can use branch patterns to ensure pipelines are only built when necessary. This guide shows you how to set up branch patterns for whole pipelines and individual build steps. On the agent side, you can use [Agent Queues](/docs/agent/v3/queues) to control which pipelines and build steps run on which agents.
 
 In step-level and pipeline-level branch filtering, you can use `*` as a wildcard, and `!` for not, as shown in the [examples](#branch-pattern-examples). If you want a full range of regular expressions that operate on more than branch names, take a look at the [conditionals](/docs/pipelines/conditionals) page.
 

--- a/pages/pipelines/branch_configuration.md
+++ b/pages/pipelines/branch_configuration.md
@@ -1,6 +1,6 @@
 # Branch configuration
 
-You can use branch patterns to ensure pipelines are only built when necessary. This guide shows you how to set up branch patterns for whole pipelines and individual build steps. On the agent side, you can use [Agent Queues](/docs/agent/v3/queues) to control which pipelines and build steps run on which agents.
+You can use branch patterns to ensure pipelines are only built when necessary. This guide shows you how to set up branch patterns for whole pipelines and individual build steps.
 
 In step-level and pipeline-level branch filtering, you can use `*` as a wildcard, and `!` for not, as shown in the [examples](#branch-pattern-examples). If you want a full range of regular expressions that operate on more than branch names, take a look at the [conditionals](/docs/pipelines/conditionals) page.
 
@@ -68,3 +68,7 @@ The following are examples of patterns, and the branches that they will match:
 * `v* !v1.*` will match any branch that begins with a `v` unless it also begins with `v1.`, such as `v2.3`, but not `v1.1`
 
 For more advanced step filtering, see the [Using conditionals](/docs/pipelines/conditionals) guide.
+
+## Alternative methods
+
+Alternatively you can use [Agent Queues](/docs/agent/v3/queues) to control which pipelines and build steps run on which agents.

--- a/pages/pipelines/branch_configuration.md
+++ b/pages/pipelines/branch_configuration.md
@@ -71,4 +71,4 @@ For more advanced step filtering, see the [Using conditionals](/docs/pipelines/c
 
 ## Alternative methods
 
-Alternatively you can use [Agent Queues](/docs/agent/v3/queues) to control which pipelines and build steps run on which agents.
+[Queues](/docs/agent/v3/queues) are another way to control what work is done. You can use queues to determine which pipelines and steps run on particular agents.


### PR DESCRIPTION
Purpose of this was to add **Agent Queues** as an alternative way of filtering pipelines and steps from being done – and where (agents) they are completed.

Then I added another example to the `Queues` page so it was clear the `queue` YAML attribute could be used as either root level or on a specific step.

Then I added a reference to branch filtering from the Queues page for completeness.

**QUERY:** I wasn't sure about referencing things as either 'build steps' or 'jobs'. It differs page to page. Welcome your input @mbelton-buildkite 