### PR TITLE
Smooth scroll the table of contents

### DIFF
--- a/app/assets/stylesheets/base/_global.scss
+++ b/app/assets/stylesheets/base/_global.scss
@@ -5,6 +5,7 @@ html {
   font-size: $font-size-base;
   font-weight: normal;
   line-height: map-get($line-heights, "default");
+  scroll-behavior: smooth;
 }
 
 .system-font {

--- a/app/assets/stylesheets/components/_toc.scss
+++ b/app/assets/stylesheets/components/_toc.scss
@@ -82,6 +82,23 @@
     margin-top: 2px;
   }
 
+  // It's possible that two elements are being highlighted at the same time
+  // (e.g. when the user is scrolling between two headings). In this case, we
+  // only want to highlight the first one.
+  .Toc__list-item--current + .Toc__list-item--current {
+    > .Toc__link {
+      background-color: initial;
+      color: $charcoal-500;
+    }
+  }
+
+  .Toc__list-item--current {
+    > .Toc__link {
+      background-color: $purple-100;
+      color: $purple-600;
+    }
+  }
+
   .Toc__link {
     border-radius: 5px;
     color: $charcoal-500;
@@ -90,11 +107,6 @@
     text-decoration: none;
 
     &:hover {
-      color: $purple-600;
-    }
-
-    &--current {
-      background-color: $purple-100;
       color: $purple-600;
     }
   }

--- a/app/frontend/components/toc.js
+++ b/app/frontend/components/toc.js
@@ -1,49 +1,25 @@
 export function initToc() {
   const initCurrentLinkListener = () => {
-    const scrollPadding = 125;
-    const currentClassName = "Toc__link--current";
-    const tocLinkNodes = document.querySelectorAll(".Toc__link--h2");
-    const headingNodes = document.querySelectorAll("h2.Docs__heading");
+    const content = document.querySelector(".Page");
 
-    const getDistanceFromTop = (element) => {
-      if (!element.offsetParent) {
-        return element.offsetTop;
-      }
-      return element.offsetTop + getDistanceFromTop(element.offsetParent);
-    };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const id = entry.target.getAttribute("id");
 
-    const getHeadingPos = (heading) => getDistanceFromTop(heading);
+          const link = document.querySelector(`.Toc__link--h2[href="#${id}"]`);
+          if (entry.intersectionRatio > 0) {
+            link.parentElement.classList.add("Toc__list-item--current");
+          } else {
+            link.parentElement.classList.remove("Toc__list-item--current");
+          }
+        });
+      },
+      { rootMargin: `-${content.offsetTop}px 0px 0px 0px` }
+    );
 
-    const setCurrentLink = (hash) => {
-      tocLinkNodes.forEach((link) => {
-        link.classList.remove(currentClassName);
-        link.removeAttribute("aria-current");
-      });
-
-      const currentNode = [...tocLinkNodes].find((link) => link.hash === hash);
-      if (currentNode) {
-        currentNode.classList.add(currentClassName);
-        currentNode.setAttribute("aria-current", "");
-      }
-    };
-
-    const handleScroll = () => {
-      const topPos = window.scrollY + scrollPadding;
-
-      headingNodes.forEach((heading) => {
-        const pos = getHeadingPos(heading);
-        if (topPos >= pos) {
-          setCurrentLink(`#${heading.id}`);
-        }
-      });
-    };
-
-    window.addEventListener("scroll", handleScroll);
-
-    tocLinkNodes.forEach((link) => {
-      link.addEventListener("click", (e) => {
-        setTimeout(() => setCurrentLink(e.target.hash), 25);
-      });
+    document.querySelectorAll("section[id]").forEach((sections) => {
+      observer.observe(sections);
     });
   };
 

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -21,6 +21,7 @@ class Page::Renderer
     doc = add_callout(doc)
     doc = decorate_external_links(doc)
     doc = init_responsive_tables(doc)
+    doc = wrap_sections(doc)
     doc.to_html.html_safe
   end
 
@@ -51,6 +52,23 @@ class Page::Renderer
     def codespan(code)
       %{<code>#{EscapeUtils.escape_html(code)}</code>}
     end
+  end
+
+  def wrap_sections(doc)
+    h2s = doc.css('h2')
+    h2s.each do |h2|
+      next_element = h2.next_element
+      h2.wrap("<section id=\"#{h2['id']}\"></section>")
+
+      while !next_element.nil? && next_element.name != 'h2' do
+        current_element = next_element
+        next_element = next_element.next_element
+
+        h2.parent.add_child(current_element)
+      end
+    end
+
+    doc
   end
 
   def add_automatic_ids_to_headings(doc)

--- a/app/views/application/_toc.html.erb
+++ b/app/views/application/_toc.html.erb
@@ -6,7 +6,7 @@
       <ul class="Toc__list Toc__list--is-collapsed">
         <% @page.sections.each do |section| %>
           <li class="Toc__list-item">
-            <a class="Toc__link Toc__link--h2" href="#<%= section[:id] %>">
+            <a data-turbo="false" class="Toc__link Toc__link--h2" href="#<%= section[:id] %>">
               <%= section[:header] %>
             </a>
 
@@ -14,7 +14,7 @@
               <ul class="Toc__list">
                 <% section[:subsections].each do |subsection| %>
                   <li class="Toc__list-item">
-                    <a class="Toc__link Toc__link--h3" href="#<%= "#{section[:id]}-#{subsection[:id]}" %>">
+                    <a data-turbo="false" class="Toc__link Toc__link--h3" href="#<%= "#{section[:id]}-#{subsection[:id]}" %>">
                       <%= subsection[:header] %>
                     </a>
                   </li>


### PR DESCRIPTION
This PR makes the table of contents links scroll smoothly to the content on the page. 

Whilst building this out, I ended up rewriting most of the logic for table of contents link highlighting to use the more performant [`IntersectionObserver` API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) and wrapped content in `section` tags.