### PR TITLE
Add example for queue and tag targeting rule

### DIFF
--- a/pages/agent/v3/cli_start.md
+++ b/pages/agent/v3/cli_start.md
@@ -66,6 +66,16 @@ The `queue` tag works differently from other tags, and can be used for isolating
 
 If you specify a `queue` and [agent `tags`](#agent-targeting), your build will only run on agents that match **all** of the specified criteria.
 
+For example, if a job has agent targeting rules set as shown below then an agent should be present which has both queue=test and postgres=1.9.4 otherwise job will not schedule to an agent.
+
+```yaml
+steps:
+  - command: "script.sh"
+    agents:
+      postgres: '1.9.4'
+      queue: test
+```
+
 ## Sourcing tags from Amazon Web Services
 
 You can load an Agent's tags from the underlying Amazon EC2 instance using `--tags-from-ec2-tags` for the instance tags and `--tags-from-ec2` to load the EC2 metadata (for example, instance name and machine type).

--- a/pages/agent/v3/cli_start.md
+++ b/pages/agent/v3/cli_start.md
@@ -66,7 +66,7 @@ The `queue` tag works differently from other tags, and can be used for isolating
 
 If you specify a `queue` and [agent `tags`](#agent-targeting), your build will only run on agents that match **all** of the specified criteria.
 
-For example, if a job has agent targeting rules set as shown below then an agent should be present which has both queue=test and postgres=1.9.4 otherwise job will not schedule to an agent.
+For example, if a job has the following agent targeting rules, an agent with both `queue=test` and `postgres=1.9.4` should be present. Otherwise, the job will not dispatch to an agent.
 
 ```yaml
 steps:


### PR DESCRIPTION
In this PR added an example to specify that when a job has targeting rules set with both tag and queue then an agent should be present which has both in order for the job to be scheduled.