### PR TITLE
Add note about conditional on build state should be only used at pipe…

### DIFF
--- a/pages/pipelines/conditionals.md
+++ b/pages/pipelines/conditionals.md
@@ -93,6 +93,9 @@ notify:
 ```
 {: codeblock-file="pipeline.yml"}
 
+>📘 Evaluating conditionals based on build state
+> Conditional expressions on build state will be available only at pipeline level and should not be used at step level.
+
 ## Conditionals and the broken state
 
 Jobs become `broken` when their configuration prevents them from running. This might be because their [branch configuration](/docs/pipelines/branch-configuration) doesn't match the build's branch, or because a conditional returned `false`. This is distinct from `skipped` jobs, which might happen if a newer build is started and build skipping is enabled. A rough explanation is that jobs break because of something _inside_ the build and are skipped by something _outside_ the build.

--- a/pages/pipelines/conditionals.md
+++ b/pages/pipelines/conditionals.md
@@ -93,8 +93,7 @@ notify:
 ```
 {: codeblock-file="pipeline.yml"}
 
->📘 Evaluating conditionals based on build state
-> Conditional expressions on build state will be available only at pipeline level and should not be used at step level.
+Note that conditional expressions on the build state are only available at the pipeline level. You can't use them at the step level.
 
 ## Conditionals and the broken state
 


### PR DESCRIPTION
Conditional expressions in notify for build state should only be used at pipeline level and not at step level.