### PR TITLE
Remove the agent upgrading page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,7 +82,7 @@ Rails.application.routes.draw do
   get "/docs/test-analytics/js-collectors",       to: redirect("/docs/test-analytics/javascript-collectors")
   get "/docs/tutorials/elastic-ci-stack-aws",     to: redirect("/docs/agent/v3/elastic-ci-aws")
   get "/docs/agent/clusters",                     to: redirect("/docs/clusters/overview")
-  get "/docs/agent/v3/upgrading",                 to: redirect("/docs/agent/v3/installation#upgrade-the-agent")
+  get "/docs/agent/v3/upgrading",                 to: redirect("/docs/agent/v3/installation#upgrade-agents")
 
   # Doc sections that don't have overview/index pages, so need redirecting
   get "/docs/tutorials",    to: redirect("/docs/tutorials/getting-started"), status: 302

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
   get "/docs/test-analytics/js-collectors",       to: redirect("/docs/test-analytics/javascript-collectors")
   get "/docs/tutorials/elastic-ci-stack-aws",     to: redirect("/docs/agent/v3/elastic-ci-aws")
   get "/docs/agent/clusters",                     to: redirect("/docs/clusters/overview")
+  get "/docs/agent/v3/upgrading",                 to: redirect("/docs/agent/v3/installation#upgrade-the-agent")
 
   # Doc sections that don't have overview/index pages, so need redirecting
   get "/docs/tutorials",    to: redirect("/docs/tutorials/getting-started"), status: 302

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -62,8 +62,6 @@
           path: "agent/v3"
         - name: "Installation"
           path: "agent/v3/installation"
-        - name: "Upgrading"
-          path: "agent/v3/upgrading"
         - name: "Configuration"
           path: "agent/v3/configuration"
         - name: "SSH keys"

--- a/pages/agent/v3/installation.md
+++ b/pages/agent/v3/installation.md
@@ -33,7 +33,7 @@ If your architecture isn't on the releases page send an email to support and we'
 
 To update your agents, you can either:
 
-- Use the package manager for your operating system.
-- Re-run the installation script.
+* Use the package manager for your operating system.
+* Re-run the installation script.
 
 As long as you're using Agent v3 or later, no configuration changes are necessary.

--- a/pages/agent/v3/installation.md
+++ b/pages/agent/v3/installation.md
@@ -1,7 +1,3 @@
----
-toc: false
----
-
 # How to install Buildkite Agent
 
 The Buildkite agent runs on your own machine, whether it's a VPS, server, desktop computer, embedded device. There are installers for:
@@ -32,3 +28,12 @@ buildkite-agent start --help
 ```
 
 If your architecture isn't on the releases page send an email to support and we'll help you out, or check out the [buildkite-agent's readme](https://github.com/buildkite/agent#readme) for instructions on how to compile it yourself.
+
+## Upgrade the agent
+
+To update your agents, you can either:
+
+- Use the package manager for your operating system.
+- Re-run the installation script.
+
+As long as you're using Agent v3 or later, no configuration changes are necessary.

--- a/pages/agent/v3/installation.md
+++ b/pages/agent/v3/installation.md
@@ -29,7 +29,7 @@ buildkite-agent start --help
 
 If your architecture isn't on the releases page send an email to support and we'll help you out, or check out the [buildkite-agent's readme](https://github.com/buildkite/agent#readme) for instructions on how to compile it yourself.
 
-## Upgrade the agent
+## Upgrade agents
 
 To update your agents, you can either:
 

--- a/pages/agent/v3/upgrading.md
+++ b/pages/agent/v3/upgrading.md
@@ -1,9 +1,0 @@
----
-toc: false
----
-
-# Upgrading your Buildkite Agents
-
-Upgrade your Agents using your operating system package manager, or by re-running the installation script.
-As long as you're using Agent v3 or later, no configuration changes are necessary.
-


### PR DESCRIPTION
We've had multiple pieces of feedback that the current [Upgrading page](https://buildkite.com/docs/agent/v3/upgrading) looks incomplete and bad. It also recently showed up in a report showing that it's a bad page for our SEO since it lacks content.

This change:

- Moves the information into the Installation page. I think that's the logical place for it. I also updated the style.
- Removes the Upgrading page.
- Adds a redirect to the new location.
- Displays the table of contents on the Installation page now that there are two headings to show.