### PR TITLE
Update agent cli reference docs generation

### DIFF
--- a/pages/agent/v3/help/_annotate.md
+++ b/pages/agent/v3/help/_annotate.md
@@ -41,10 +41,12 @@ body entirely and providing a new style value.
 
 ### Example
 
-    $ buildkite-agent annotate "All tests passed! :rocket:"
-    $ cat annotation.md | buildkite-agent annotate --style "warning"
-    $ buildkite-agent annotate --style "success" --context "junit"
-    $ ./script/dynamic_annotation_generator | buildkite-agent annotate --style "success"
+```shell
+$ buildkite-agent annotate "All tests passed! :rocket:"
+$ cat annotation.md | buildkite-agent annotate --style "warning"
+$ buildkite-agent annotate --style "success" --context "junit"
+$ ./script/dynamic_annotation_generator | buildkite-agent annotate --style "success"
+```
 
 ### Options
 

--- a/pages/agent/v3/help/_annotation_remove.md
+++ b/pages/agent/v3/help/_annotation_remove.md
@@ -25,8 +25,10 @@ If you leave context blank, it will use the default context.
 
 ### Example
 
-    $ buildkite-agent annotation remove
-    $ buildkite-agent annotation remove --context "remove-me"
+```shell
+$ buildkite-agent annotation remove
+$ buildkite-agent annotation remove --context "remove-me"
+```
 
 ### Options
 

--- a/pages/agent/v3/help/_artifact_download.md
+++ b/pages/agent/v3/help/_artifact_download.md
@@ -37,7 +37,9 @@ artifact paths.
 
 ### Example
 
-    $ buildkite-agent artifact download "pkg/*.tar.gz" . --build xxx
+```shell
+$ buildkite-agent artifact download "pkg/*.tar.gz" . --build xxx
+```
 
 This will search across all the artifacts for the build with files that match that part.
 The first argument is the search query, and the second argument is the download destination.
@@ -45,7 +47,9 @@ The first argument is the search query, and the second argument is the download 
 If you&#39;re trying to download a specific file, and there are multiple artifacts from different
 jobs, you can target the particular job you want to download the artifact from:
 
-    $ buildkite-agent artifact download "pkg/*.tar.gz" . --step "tests" --build xxx
+```shell
+$ buildkite-agent artifact download "pkg/*.tar.gz" . --step "tests" --build xxx
+```
 
 You can also use the step&#39;s jobs id (provided by the environment variable $BUILDKITE_JOB_ID)
 

--- a/pages/agent/v3/help/_artifact_search.md
+++ b/pages/agent/v3/help/_artifact_search.md
@@ -26,7 +26,9 @@ which will break the search.
 
 ### Example
 
-    $ buildkite-agent artifact search "pkg/*.tar.gz" --build xxx
+```shell
+$ buildkite-agent artifact search "pkg/*.tar.gz" --build xxx
+```
 
 This will search across all uploaded artifacts in a build for files that match that query.
 The first argument is the search query.
@@ -34,13 +36,17 @@ The first argument is the search query.
 If you&#39;re trying to find a specific file, and there are multiple artifacts from different
 jobs, you can target the particular job you want to search the artifacts from using --step:
 
-    $ buildkite-agent artifact search "pkg/*.tar.gz" --step "tests" --build xxx
+```shell
+$ buildkite-agent artifact search "pkg/*.tar.gz" --step "tests" --build xxx
+```
 
 You can also use the step&#39;s job id (provided by the environment variable $BUILDKITE_JOB_ID)
 
 Output formatting can be altered with the -format flag as follows:
 
-    $ buildkite-agent artifact search "*" -format "%p\n"
+```shell
+$ buildkite-agent artifact search "*" -format "%p\n"
+```
 
 The above will return a list of filenames separated by newline.
 

--- a/pages/agent/v3/help/_artifact_shasum.md
+++ b/pages/agent/v3/help/_artifact_shasum.md
@@ -32,7 +32,9 @@ which will break the download.
 
 ### Example
 
-    $ buildkite-agent artifact shasum "pkg/release.tar.gz" --build xxx
+```shell
+$ buildkite-agent artifact shasum "pkg/release.tar.gz" --build xxx
+```
 
 This will search for all files in the build with path &quot;pkg/release.tar.gz&quot;,
 and if exactly one match is found, the SHA-1 hash generated during upload
@@ -41,11 +43,13 @@ is printed.
 If you would like to target artifacts from a specific build step, you can do
 so by using the --step argument.
 
-    $ buildkite-agent artifact shasum "pkg/release.tar.gz" --step "release" --build xxx
+```shell
+$ buildkite-agent artifact shasum "pkg/release.tar.gz" --step "release" --build xxx
+```
 
 You can also use the step&#39;s job ID (provided by the environment variable $BUILDKITE_JOB_ID)
 
-The --sha256 argument requests SHA-256 instead of SHA-1; this is only
+The `--sha256` argument requests SHA-256 instead of SHA-1; this is only
 available for artifacts uploaded since SHA-256 support was added to the
 agent.
 

--- a/pages/agent/v3/help/_artifact_upload.md
+++ b/pages/agent/v3/help/_artifact_upload.md
@@ -32,42 +32,56 @@ Buildkite-managed Amazon S3 bucket, where they’re retained for six months.
 
 ### Example
 
-    $ buildkite-agent artifact upload "log/**/*.log"
+```shell
+$ buildkite-agent artifact upload "log/**/*.log"
+```
 
 You can also upload directly to Amazon S3 if you&#39;d like to host your own artifacts:
 
-    $ export BUILDKITE_S3_ACCESS_KEY_ID=xxx
-    $ export BUILDKITE_S3_SECRET_ACCESS_KEY=yyy
-    $ export BUILDKITE_S3_DEFAULT_REGION=eu-central-1 # default is us-east-1
-    $ export BUILDKITE_S3_ACL=private # default is public-read
-    $ buildkite-agent artifact upload "log/**/*.log" s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID
+```shell
+$ export BUILDKITE_S3_ACCESS_KEY_ID=xxx
+$ export BUILDKITE_S3_SECRET_ACCESS_KEY=yyy
+$ export BUILDKITE_S3_DEFAULT_REGION=eu-central-1 # default is us-east-1
+$ export BUILDKITE_S3_ACL=private # default is public-read
+$ buildkite-agent artifact upload "log/**/*.log" s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID
+```
 
 You can use Amazon IAM assumed roles by specifying the session token:
 
-    $ export BUILDKITE_S3_SESSION_TOKEN=zzz
+```shell
+$ export BUILDKITE_S3_SESSION_TOKEN=zzz
+```
 
 Or upload directly to Google Cloud Storage:
 
-    $ export BUILDKITE_GS_ACL=private
-    $ buildkite-agent artifact upload "log/**/*.log" gs://name-of-your-gs-bucket/$BUILDKITE_JOB_ID
+```shell
+$ export BUILDKITE_GS_ACL=private
+$ buildkite-agent artifact upload "log/**/*.log" gs://name-of-your-gs-bucket/$BUILDKITE_JOB_ID
+```
 
 Or upload directly to Artifactory:
 
-    $ export BUILDKITE_ARTIFACTORY_URL=http://my-artifactory-instance.com/artifactory
-    $ export BUILDKITE_ARTIFACTORY_USER=carol-danvers
-    $ export BUILDKITE_ARTIFACTORY_PASSWORD=xxx
-    $ buildkite-agent artifact upload "log/**/*.log" rt://name-of-your-artifactory-repo/$BUILDKITE_JOB_ID
+```shell
+$ export BUILDKITE_ARTIFACTORY_URL=http://my-artifactory-instance.com/artifactory
+$ export BUILDKITE_ARTIFACTORY_USER=carol-danvers
+$ export BUILDKITE_ARTIFACTORY_PASSWORD=xxx
+$ buildkite-agent artifact upload "log/**/*.log" rt://name-of-your-artifactory-repo/$BUILDKITE_JOB_ID
+```
 
-By default, symlinks to directories will not be explored when resolving the glob, but symlinks to files will be uploaded as the linked files.
-To ignore symlinks to files use:
+By default, symlinks to directories will not be explored when resolving the glob, but symlinks to
+files will be uploaded as the linked files. To ignore symlinks to files use:
 
-    $ buildkite-agent artifact upload --upload-skip-symlinks "log/**/*.log"
+```shell
+$ buildkite-agent artifact upload --upload-skip-symlinks "log/**/*.log"
+```
 
 Note: uploading symlinks to files without following them is not supported.
 If you need to preserve them in a directory, we recommend creating a tar archive:
 
-    $ tar -cvf log.tar log/**/*
-    $ buildkite-agent upload log.tar
+```shell
+$ tar -cvf log.tar log/**/*
+$ buildkite-agent upload log.tar
+```
 
 ### Options
 

--- a/pages/agent/v3/help/_bootstrap.md
+++ b/pages/agent/v3/help/_bootstrap.md
@@ -34,9 +34,13 @@ See https://buildkite.com/docs/agent/v3/hooks for more details.
 
 ### Example
 
-    $ eval $(curl -s -H "Authorization: Bearer xxx" \
-        "https://api.buildkite.com/v2/organizations/[org]/pipelines/[proj]/builds/[build]/jobs/[job]/env.txt" | sed 's/^/export /')
-    $ buildkite-agent bootstrap --build-path builds
+```shell
+$ eval $(curl -s -H "Authorization: Bearer xxx" \
+   "https://api.buildkite.com/v2/organizations/[org]/pipelines/[proj]/builds/[build]/jobs/[job]/env.txt" | \
+   sed 's/^/export /' \
+ )
+$ buildkite-agent bootstrap --build-path builds
+```
 
 ### Options
 

--- a/pages/agent/v3/help/_env_dump.md
+++ b/pages/agent/v3/help/_env_dump.md
@@ -17,6 +17,7 @@ script.
 `buildkite-agent env dump [options]`
 
 ### Description
+
 Prints out the environment of the current process as a JSON object, easily
 parsable by other programs. Used when executing hooks to discover changes
 that hooks make to the environment.

--- a/pages/agent/v3/help/_env_get.md
+++ b/pages/agent/v3/help/_env_get.md
@@ -17,6 +17,7 @@ script.
 `buildkite-agent env get [variables]`
 
 ### Description
+
 Retrieves environment variables and their current values from the current job
 execution environment.
 
@@ -28,6 +29,7 @@ phases of the job. However, `env get` can be used to inspect the changes made
 with `env set` and `env unset`.
 
 ### Examples
+
 Getting all variables in key=value format:
 
 ```shell

--- a/pages/agent/v3/help/_env_set.md
+++ b/pages/agent/v3/help/_env_set.md
@@ -17,6 +17,7 @@ script.
 `buildkite-agent env set [variable]`
 
 ### Description
+
 Sets environment variables in the current job execution environment.
 Changes to the job environment variables only apply to subsequent phases of the job.
 This command cannot unset Buildkite read-only variables.

--- a/pages/agent/v3/help/_env_unset.md
+++ b/pages/agent/v3/help/_env_unset.md
@@ -17,6 +17,7 @@ script.
 `buildkite-agent env unset [variables]`
 
 ### Description
+
 Unsets environment variables in the current job execution environment.
 Changes to the job environment variables only apply to subsequent phases of the job.
 This command cannot unset Buildkite read-only variables.

--- a/pages/agent/v3/help/_lock_acquire.md
+++ b/pages/agent/v3/help/_lock_acquire.md
@@ -17,6 +17,7 @@ script.
 `buildkite-agent lock acquire [key]`
 
 ### Description
+
 Acquires the lock for the given key. `lock acquire` will wait (potentially
 forever) until it can acquire the lock, if the lock is already held by
 another process. If multiple processes are waiting for the same lock, there

--- a/pages/agent/v3/help/_lock_do.md
+++ b/pages/agent/v3/help/_lock_do.md
@@ -17,6 +17,7 @@ script.
 `buildkite-agent lock do [key]`
 
 ### Description
+
 Begins a do-once lock. Do-once can be used by multiple processes to
 wait for completion of some shared work, where only one process should do
 the work.

--- a/pages/agent/v3/help/_lock_done.md
+++ b/pages/agent/v3/help/_lock_done.md
@@ -17,6 +17,7 @@ script.
 `buildkite-agent lock done [key]`
 
 ### Description
+
 Completes a do-once lock. This should only be used by the process performing
 the work.
 

--- a/pages/agent/v3/help/_lock_get.md
+++ b/pages/agent/v3/help/_lock_get.md
@@ -17,6 +17,7 @@ script.
 `buildkite-agent lock get [key]`
 
 ### Description
+
 Retrieves the value of a lock key. Any key not in use returns an empty
 string.
 

--- a/pages/agent/v3/help/_lock_release.md
+++ b/pages/agent/v3/help/_lock_release.md
@@ -17,6 +17,7 @@ script.
 `buildkite-agent lock release [key] [token]`
 
 ### Description
+
 Releases the lock for the given key. This should only be called by the
 process that acquired the lock. To help prevent different processes unlocking
 each other unintentionally, the output from `lock acquire` is required as the

--- a/pages/agent/v3/help/_meta_data_exists.md
+++ b/pages/agent/v3/help/_meta_data_exists.md
@@ -23,7 +23,9 @@ exit with a status of 100 if the key doesn&#39;t exist.
 
 ### Example
 
-    $ buildkite-agent meta-data exists "foo"
+```shell
+$ buildkite-agent meta-data exists "foo"
+```
 
 ### Options
 

--- a/pages/agent/v3/help/_meta_data_get.md
+++ b/pages/agent/v3/help/_meta_data_get.md
@@ -18,11 +18,13 @@ script.
 
 ### Description
 
-Get data from a builds key/value store.
+Get data from a build&#39;s key/value store.
 
 ### Example
 
-    $ buildkite-agent meta-data get "foo"
+```shell
+$ buildkite-agent meta-data get "foo"
+```
 
 ### Options
 

--- a/pages/agent/v3/help/_meta_data_keys.md
+++ b/pages/agent/v3/help/_meta_data_keys.md
@@ -23,7 +23,9 @@ and terminated with a trailing newline.
 
 ### Example
 
-    $ buildkite-agent meta-data keys
+```shell
+$ buildkite-agent meta-data keys
+```
 
 ### Options
 

--- a/pages/agent/v3/help/_meta_data_set.md
+++ b/pages/agent/v3/help/_meta_data_set.md
@@ -28,9 +28,11 @@ characters are not allowed.
 
 ### Example
 
-    $ buildkite-agent meta-data set "foo" "bar"
-    $ buildkite-agent meta-data set "foo" < ./tmp/meta-data-value
-    $ ./script/meta-data-generator | buildkite-agent meta-data set "foo"
+```shell
+$ buildkite-agent meta-data set "foo" "bar"
+$ buildkite-agent meta-data set "foo" < ./tmp/meta-data-value
+$ ./script/meta-data-generator | buildkite-agent meta-data set "foo"
+```
 
 ### Options
 

--- a/pages/agent/v3/help/_oidc_request_token.md
+++ b/pages/agent/v3/help/_oidc_request_token.md
@@ -17,16 +17,19 @@ script.
 `buildkite-agent oidc request-token [options...]`
 
 ### Description
+
 Requests and prints an OIDC token from Buildkite that claims the Job ID
 (amongst other things) and the specified audience. If no audience is
 specified, the endpoint&#39;s default audience will be claimed.
 
 ### Example
-    $ buildkite-agent oidc request-token --audience sts.amazonaws.com
+
+```shell
+$ buildkite-agent oidc request-token --audience sts.amazonaws.com
+```
 
 Requests and prints an OIDC token from Buildkite that claims the Job ID
 (amongst other things) and the audience &quot;sts.amazonaws.com&quot;.
-
 
 ### Options
 

--- a/pages/agent/v3/help/_pipeline_upload.md
+++ b/pages/agent/v3/help/_pipeline_upload.md
@@ -39,9 +39,11 @@ must be split into multiple files and uploaded in separate steps.
 
 ### Example
 
-    $ buildkite-agent pipeline upload
-    $ buildkite-agent pipeline upload my-custom-pipeline.yml
-    $ ./script/dynamic_step_generator | buildkite-agent pipeline upload
+```shell
+$ buildkite-agent pipeline upload
+$ buildkite-agent pipeline upload my-custom-pipeline.yml
+$ ./script/dynamic_step_generator | buildkite-agent pipeline upload
+```
 
 ### Options
 

--- a/pages/agent/v3/help/_start.md
+++ b/pages/agent/v3/help/_start.md
@@ -27,7 +27,9 @@ The agent will run any jobs within a PTY (pseudo terminal) if available.
 
 ### Example
 
-    $ buildkite-agent start --token xxx
+```shell
+$ buildkite-agent start --token xxx
+```
 
 ### Options
 

--- a/pages/agent/v3/help/_step_get.md
+++ b/pages/agent/v3/help/_step_get.md
@@ -27,10 +27,12 @@ output the data (currently only JSON is supported).
 
 ### Example
 
-    $ buildkite-agent step get "label" --step "key"
-    $ buildkite-agent step get --format json
-    $ buildkite-agent step get "retry" --format json
-    $ buildkite-agent step get "state" --step "my-other-step"
+```shell
+$ buildkite-agent step get "label" --step "key"
+$ buildkite-agent step get --format json
+$ buildkite-agent step get "retry" --format json
+$ buildkite-agent step get "state" --step "my-other-step"
+```
 
 ### Options
 

--- a/pages/agent/v3/help/_step_update.md
+++ b/pages/agent/v3/help/_step_update.md
@@ -32,10 +32,12 @@ meaning you will have to handle all commit statuses through the pipeline.yml
 
 ### Example
 
-    $ buildkite-agent step update "label" "New Label"
-    $ buildkite-agent step update "label" " (add to end of label)" --append
-    $ buildkite-agent step update "label" < ./tmp/some-new-label
-    $ ./script/label-generator | buildkite-agent step update "label"
+```shell
+$ buildkite-agent step update "label" "New Label"
+$ buildkite-agent step update "label" " (add to end of label)" --append
+$ buildkite-agent step update "label" < ./tmp/some-new-label
+$ ./script/label-generator | buildkite-agent step update "label"
+```
 
 ### Options
 

--- a/scripts/cli2md.rb
+++ b/scripts/cli2md.rb
@@ -46,6 +46,7 @@ ARGF.each_with_index do |line, line_num|
     # helptext for... reasons.
     # See: https://github.com/buildkite/agent/blob/main/clicommand/prime-signs.md
     desc.tr!("′", "`")
+    desc.gsub!(Dir.home, "$HOME")
     print "<tr id=\"#{command}\">"
     print "<th><code>--#{command} #{value}</code> <a class=\"Docs__attribute__link\" href=\"##{command}\">#</a></th>"
     print "<td><p>#{desc}"

--- a/scripts/cli2md.rb
+++ b/scripts/cli2md.rb
@@ -11,7 +11,8 @@ state = STATE_INITIAL
 # read from stdin or files in the args
 ARGF.each_with_index do |line, line_num|
   # Replace all prime symbols with backticks. We use prime symbols instead of backticks in CLI
-  # helptext because Go does not support escaping backticks in backtick delimited strings.
+  # helptext because the cli framework we use, urfave/cli, has special handling for backticks.
+  #
   # See: https://github.com/buildkite/agent/blob/main/clicommand/prime-signs.md
   line.tr!("′", "`")
 

--- a/scripts/cli2md.rb
+++ b/scripts/cli2md.rb
@@ -82,6 +82,8 @@ ARGF.each_with_index do |line, line_num|
   when STATE_INITIAL
     puts CGI.escapeHTML(line.lstrip)
     next
+  else
+    warn "Unknown state #{state} on line #{line_num}: #{line}"
   end
 end
 

--- a/scripts/cli2md.rb
+++ b/scripts/cli2md.rb
@@ -88,8 +88,10 @@ ARGF.each_with_index do |line, line_num|
   end
 end
 
-# last line of input was in a table
-puts "</table>\n\n<!-- vale on -->\n" if state == STATE_TABLE
-
-# last line of input was in a code block
-puts "```" if state == STATE_CODE
+# handle when the last line was in a code block or table
+case state
+when STATE_TABLE
+  puts "</table>\n\n<!-- vale on -->\n"
+when STATE_CODE
+  puts "```"
+end

--- a/scripts/cli2md.rb
+++ b/scripts/cli2md.rb
@@ -22,9 +22,11 @@ ARGF.each_with_index do |line, line_num|
   # Headings end in `:`
   if /^(\w*):$/ =~ line
     puts "### #{Regexp.last_match(1)}"
+
   # Initial usage command
   elsif line_num == 2
     puts "`#{line.strip}`"
+
   # code blocks
   elsif /^\s{4}/ =~ line
     puts "```shell" unless in_code
@@ -62,7 +64,8 @@ ARGF.each_with_index do |line, line_num|
     print "<br /><strong>Environment variable</strong>: <code>#{env_var}</code>" unless env_var.nil? || env_var.empty?
     print "</p></td>"
     print "</tr>"
-    puts
+    print "\n"
+
   else
     puts CGI.escapeHTML(line.lstrip)
   end

--- a/scripts/cli2md.rb
+++ b/scripts/cli2md.rb
@@ -66,6 +66,11 @@ ARGF.each_with_index do |line, line_num|
     print "</tr>"
     print "\n"
 
+  # first line after a table
+  elsif in_table
+    puts "</table>\n\n<!-- vale on -->\n" if in_table
+    in_table = false
+
   else
     puts CGI.escapeHTML(line.lstrip)
   end

--- a/scripts/cli2md.rb
+++ b/scripts/cli2md.rb
@@ -1,66 +1,64 @@
-require 'cgi'
+# frozen_string_literal: true
+
+require "cgi"
 
 incode = false
-
 first_param = false
 
+# read from stdin or files in the args
 ARGF.each_with_index do |line, line_num|
-    # Headings
-    if /^(\w*):/ =~ line
-        puts "### #{$1}"
-    # Initial usage command
-    elsif line_num == 2
-        puts "`#{line.strip}`"
-    # Code sections
-    elsif /\s{3}\$/ =~ line
-        # Break code lines that end in \
-        if line [-2] == "\\"
-            incode=true
-        end
-        puts " #{line}"
-    # If previous line ends in \ indent to code block
-    elsif incode == true
-        incode = false
-        puts "   #{line}"
-    # Lists of parameters
-    #    --config value                         Path to a configuration file [$BUILDKITE_AGENT_CONFIG]
-    elsif /\s{3}(-{2}[a-z0-9\- ]*)([A-Z].*)$/ =~ line
-        if(first_param==false)
-            puts "<!-- vale off -->\n\n<table class=\"Docs__attribute__table\">"
-            first_param = true
-        end
-        command_and_value = $1.rstrip
-        command = command_and_value.split[0][2..-1]
-        value = command_and_value.split[1]
-        desc    = $2
-
-        # Extract $BUILDKITE_* env and remove from desc
-        /(\$BUILDKITE[A-Z0-9_]*)/ =~ desc
-        env_var = $1
-        desc.gsub!(/(\s\[\$BUILDKITE[A-Z0-9_]*\])/,"")
-
-
-        # Wrap https://agent.buildkite.com/v3 in code
-        desc.gsub!('https://agent.buildkite.com/v3',"<code>https://agent.buildkite.com/v3</code>")
-
-        # Replace all prime symbols with backticks. We use prime symbols instead of backticks in CLI helptext for... reasons.
-        # See: https://github.com/buildkite/agent/blob/main/clicommand/prime-signs.md
-        desc.tr!('′', '`')
-        print "<tr id=\"#{command}\">"
-        print "<th><code>--#{command} #{value}</code> <a class=\"Docs__attribute__link\" href=\"##{command}\">#</a></th>"
-        print "<td><p>#{desc}"
-        unless env_var.nil? || env_var.empty?
-            print "<br /><strong>Environment variable</strong>: <code>#{env_var}</code>"
-        end
-        print "</p></td>"
-        print "</tr>"
-        puts
-    else
-        if(first_param==true)
-            puts "</table>\n\n<!-- vale on -->\n"
-            first_param = false
-            next
-        end
-        puts CGI::escapeHTML(line.lstrip)
+  # Headings
+  if /^(\w*):/ =~ line
+    puts "### #{Regexp.last_match(1)}"
+  # Initial usage command
+  elsif line_num == 2
+    puts "`#{line.strip}`"
+  # Code sections
+  elsif /\s{3}\$/ =~ line
+    # Break code lines that end in \
+    incode = true if line[-2] == "\\"
+    puts " #{line}"
+  # If previous line ends in \ indent to code block
+  elsif incode
+    incode = false
+    puts "  #{line}"
+  # Lists of parameters
+  #  --config value             Path to a configuration file [$BUILDKITE_AGENT_CONFIG]
+  elsif /\s{3}(-{2}[a-z0-9\- ]*)([A-Z].*)$/ =~ line
+    if first_param == false
+      puts "<!-- vale off -->\n\n<table class=\"Docs__attribute__table\">"
+      first_param = true
     end
+    command_and_value = Regexp.last_match(1).rstrip
+    command = command_and_value.split[0][2..]
+    value = command_and_value.split[1]
+    desc  = Regexp.last_match(2)
+
+    # Extract $BUILDKITE_* env and remove from desc
+    /(\$BUILDKITE[A-Z0-9_]*)/ =~ desc
+    env_var = Regexp.last_match(1)
+    desc.gsub!(/(\s\[\$BUILDKITE[A-Z0-9_]*\])/, "")
+
+    # Wrap https://agent.buildkite.com/v3 in code
+    desc.gsub!("https://agent.buildkite.com/v3", "<code>https://agent.buildkite.com/v3</code>")
+
+    # Replace all prime symbols with backticks. We use prime symbols instead of backticks in CLI
+    # helptext for... reasons.
+    # See: https://github.com/buildkite/agent/blob/main/clicommand/prime-signs.md
+    desc.tr!("′", "`")
+    print "<tr id=\"#{command}\">"
+    print "<th><code>--#{command} #{value}</code> <a class=\"Docs__attribute__link\" href=\"##{command}\">#</a></th>"
+    print "<td><p>#{desc}"
+    print "<br /><strong>Environment variable</strong>: <code>#{env_var}</code>" unless env_var.nil? || env_var.empty?
+    print "</p></td>"
+    print "</tr>"
+    puts
+  else
+    if first_param
+      puts "</table>\n\n<!-- vale on -->\n"
+      first_param = false
+      next
+    end
+    puts CGI.escapeHTML(line.lstrip)
+  end
 end

--- a/scripts/cli2md.rb
+++ b/scripts/cli2md.rb
@@ -2,37 +2,51 @@
 
 require "cgi"
 
-incode = false
-first_param = false
+# are we in a code block?
+in_code = false
+
+# are with in the table of parameters?
+in_table = false
 
 # read from stdin or files in the args
 ARGF.each_with_index do |line, line_num|
-  # Headings
+  # Replace all prime symbols with backticks. We use prime symbols instead of backticks in CLI
+  # helptext because Go does not support escaping backticks in backtick delimited strings.
+  # See: https://github.com/buildkite/agent/blob/main/clicommand/prime-signs.md
+  line.tr!("′", "`")
+
+  # Some agent help texts dynamically replace $HOME with the current user's home directory.
+  # We need to replace it back for the docs
+  line.gsub!(Dir.home, "$HOME")
+
+  # Headings end in `:`
   if /^(\w*):/ =~ line
     puts "### #{Regexp.last_match(1)}"
   # Initial usage command
   elsif line_num == 2
     puts "`#{line.strip}`"
-  # Code sections
-  elsif /\s{3}\$/ =~ line
-    # Break code lines that end in \
-    incode = true if line[-2] == "\\"
-    puts " #{line}"
-  # If previous line ends in \ indent to code block
-  elsif incode
-    incode = false
-    puts "  #{line}"
+  # code blocks
+  elsif /^\s{4}/ =~ line
+    puts "```shell" unless in_code
+    puts line.gsub(/^\s{4}/, "")
+    in_code = true
+
+  # first line after a code block
+  elsif in_code
+    in_code = false
+    puts "```"
+    puts line
+
   # Lists of parameters
   #  --config value             Path to a configuration file [$BUILDKITE_AGENT_CONFIG]
-  elsif /\s{3}(-{2}[a-z0-9\- ]*)([A-Z].*)$/ =~ line
-    if first_param == false
-      puts "<!-- vale off -->\n\n<table class=\"Docs__attribute__table\">"
-      first_param = true
-    end
+  elsif /\s{2}(-{2}[a-z0-9\- ]*)([A-Z].*)$/ =~ line
+    puts %(<!-- vale off -->\n\n<table class="Docs__attribute__table">) unless in_table
+    in_table = true
+
     command_and_value = Regexp.last_match(1).rstrip
     command = command_and_value.split[0][2..]
     value = command_and_value.split[1]
-    desc  = Regexp.last_match(2)
+    desc = Regexp.last_match(2)
 
     # Extract $BUILDKITE_* env and remove from desc
     /(\$BUILDKITE[A-Z0-9_]*)/ =~ desc
@@ -42,24 +56,20 @@ ARGF.each_with_index do |line, line_num|
     # Wrap https://agent.buildkite.com/v3 in code
     desc.gsub!("https://agent.buildkite.com/v3", "<code>https://agent.buildkite.com/v3</code>")
 
-    # Replace all prime symbols with backticks. We use prime symbols instead of backticks in CLI
-    # helptext for... reasons.
-    # See: https://github.com/buildkite/agent/blob/main/clicommand/prime-signs.md
-    desc.tr!("′", "`")
-    desc.gsub!(Dir.home, "$HOME")
-    print "<tr id=\"#{command}\">"
-    print "<th><code>--#{command} #{value}</code> <a class=\"Docs__attribute__link\" href=\"##{command}\">#</a></th>"
+    print %(<tr id="#{command}">)
+    print %(<th><code>--#{command} #{value}</code> <a class="Docs__attribute__link" href="##{command}">#</a></th>)
     print "<td><p>#{desc}"
     print "<br /><strong>Environment variable</strong>: <code>#{env_var}</code>" unless env_var.nil? || env_var.empty?
     print "</p></td>"
     print "</tr>"
     puts
   else
-    if first_param
-      puts "</table>\n\n<!-- vale on -->\n"
-      first_param = false
-      next
-    end
     puts CGI.escapeHTML(line.lstrip)
   end
 end
+
+# last line of input was in a table
+puts "</table>\n\n<!-- vale on -->\n" if in_table
+
+# last line of input was in a code block
+puts "```" if in_code

--- a/scripts/cli2md.rb
+++ b/scripts/cli2md.rb
@@ -20,7 +20,7 @@ ARGF.each_with_index do |line, line_num|
   line.gsub!(Dir.home, "$HOME")
 
   # Headings end in `:`
-  if /^(\w*):/ =~ line
+  if /^(\w*):$/ =~ line
     puts "### #{Regexp.last_match(1)}"
   # Initial usage command
   elsif line_num == 2

--- a/scripts/update-agent-help.sh
+++ b/scripts/update-agent-help.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 commands=(
@@ -29,12 +30,12 @@ commands=(
   "step update"
 )
 
-scripts_dir="$(dirname "${BASH_SOURCE[0]}")"
-base_dir=$( cd "${scripts_dir}/.." ; pwd -P )
+scripts_dir=$(dirname "${BASH_SOURCE[0]}")
+base_dir=$(git rev-parse --show-toplevel)
 
-for command in "${commands[@]}" ; do
+for command in "${commands[@]}"; do
   file="${base_dir}/pages/agent/v3/help/_${command//[- ]/_}.md"
-  if [[ ! -f "$file" ]] ; then
+  if [[ ! -f "$file" ]]; then
     echo "File $file doesn't exist"
     exit 1
   fi
@@ -58,5 +59,7 @@ script.
 
 EOF
 
-  buildkite-agent $command --help | ruby "${scripts_dir}/cli2md.rb" >>"$file"
+  # shellcheck disable=SC2086
+  buildkite-agent $command --help | \
+    ruby "${scripts_dir}/cli2md.rb" >>"$file"
 done


### PR DESCRIPTION
This is the script `cli2md.rb` that generates the agent cli reference docs.
Its input is the output of `buildkite-agent` commands with the flag `--help`.

We've changed some of the practices since when this script was first written. Now:

- We will encase code blocks in `shell` backtick blocks. In the input, we will use 4 spaces to indicate the start of a code block.
- We will also replace prime signs with backticks in all the input, previously it was just the descriptions of the arguments.
- We also remove the user's home directory from the docs, since it is not relevant to the docs.
- We also make the state machine explicit, instead of using 2 boolean variables to control it.

There is a companion [PR](https://github.com/buildkite/agent/pull/2317) to adjust the cli commands in the agent to work consistently with this script. If you checkout that version of the agent, compile it and run `scripts/update-agent-help.sh`, it should be a no-op.