### PR TITLE
Update exit status troubleshooting note

### DIFF
--- a/pages/pipelines.md
+++ b/pages/pipelines.md
@@ -94,4 +94,4 @@ Job exit status may include the exit signal reason, which indicates whether the 
 <%= image "exit-status.png", width: 2048/2, height: 880/2, alt: "Exit status of a job" %>
 
 >🚧
-> Exit status information available in the <a href="/docs/apis/graphql-api">GraphQL API</a> but not the <a href="/docs/apis/rest-api">REST API</a>.
+> Exit status information is only available using the <a href="/docs/apis/graphql-api">GraphQL API</a>.

--- a/pages/pipelines.md
+++ b/pages/pipelines.md
@@ -93,5 +93,4 @@ Job exit status may include the exit signal reason, which indicates whether the 
 
 <%= image "exit-status.png", width: 2048/2, height: 880/2, alt: "Exit status of a job" %>
 
->🚧
-> Exit status information is only available using the <a href="/docs/apis/graphql-api">GraphQL API</a>.
+If you want to access the exit status through an API, it's only available in the [GraphQL API](/docs/apis/graphql-api).


### PR DESCRIPTION
The way the note is currently written is a bit confusing:

<img width="780" alt="CleanShot 2023-08-23 at 16 46 12@2x" src="https://github.com/buildkite/docs/assets/677025/08e8f612-6b2e-4074-b4f8-9a49ba2a1965">

We could rewrite this callout while maintaining a link to the REST API, but to be as clear as we can (and assuming my interpretation is accurate), I think we should either say exit status is “only available when using the GraphQL API”, or “is not available when using the REST API”, rather than trying to word this note in such a way that it refers to _both_ APIs, while trying to indicate it’s only available in one.

A smaller rewrite could read:

```
Exit status information is available in the <a href="/docs/apis/graphql-api">GraphQL API</a>, but not the <a href="/docs/apis/rest-api">REST API</a>
```