### PR TITLE
Fix Algolia crawler 

### DIFF
--- a/config/algolia.json
+++ b/config/algolia.json
@@ -11,11 +11,7 @@
     "lvl5": ".Page article h6",
     "text": ".Page article p, .Page article li, .Page article td"
   },
-  "selectors_exclude": [
-    "[data-algolia-exclude]",
-    ".Docs__toc",
-    ".HomepageCategory"
-  ],
+  "selectors_exclude": ["[data-algolia-exclude]", ".Toc", ".Footer", ".Nav"],
   "custom_settings": {
     "synonyms": [["Pipeline.yml", "Pipeline.yaml", "config.yml", "config.yaml"]]
   }

--- a/config/algolia.json
+++ b/config/algolia.json
@@ -1,24 +1,15 @@
 {
   "index_name": "prod_docs",
-  "start_urls": [
-    "https://buildkite.com/docs"
-  ],
-  "stop_urls": [
-    "agent/v2"
-  ],
+  "start_urls": ["https://buildkite.com/docs"],
+  "stop_urls": ["agent/v2"],
   "selectors": {
-    "lvl0": {
-      "selector": ".Docs__nav__section-container.current > .Docs__nav__section-heading",
-      "global": true,
-      "default_value": "Documentation"
-    },
-    "lvl1": ".Page h1",
-    "lvl2": ".Page h2",
-    "lvl3": ".Page h3",
-    "lvl4": ".Page h4, .Page th",
-    "lvl5": ".Page h5, .Page td:first-child",
-    "lvl6": ".Page h6",
-    "text": ".Page p, .Page li, .Page td"
+    "lvl0": ".Page article h1",
+    "lvl1": ".Page article h2",
+    "lvl2": ".Page article h3",
+    "lvl3": ".Page article h4, .Page article th",
+    "lvl4": ".Page article h5, .Page article td:first-child",
+    "lvl5": ".Page article h6",
+    "text": ".Page article p, .Page article li, .Page article td"
   },
   "selectors_exclude": [
     "[data-algolia-exclude]",
@@ -26,14 +17,6 @@
     ".HomepageCategory"
   ],
   "custom_settings": {
-    "synonyms": [
-      [
-        "Pipeline.yml",
-        "Pipeline.yaml",
-        "config.yml",
-        "config.yaml"
-      ]
-
-    ]
+    "synonyms": [["Pipeline.yml", "Pipeline.yaml", "config.yml", "config.yaml"]]
   }
 }


### PR DESCRIPTION
It appears our self-run Algolia crawler is over indexing a bunch of records because we're been including each item of the nav and table of contents, resulting in ~500 additional records per-page.

This PR updates out algolia config to exclude irrelevant content and fixes up the selectors to match the latest page hierarchy.

For reference:

- https://docsearch.algolia.com/docs/legacy/config-file
- https://docsearch.algolia.com/docs/legacy/how-do-we-build-an-index