### PR TITLE
Add log-collector script section to Elastic Stack docs

### DIFF
--- a/pages/agent/v3/elastic_ci_aws/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_aws/troubleshooting.md
@@ -22,6 +22,13 @@ On Windows instances only:
 
 There are a couple of other log groups that the Elastic CI Stack for AWS sends logs to, but their use cases are pretty specific. For a full accounting of what logs are sent to CloudWatch, see the config for [Linux](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/packer/linux/conf/cloudwatch-agent/config.json) and [Windows](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/-/packer/windows/conf/cloudwatch-agent/amazon-cloudwatch-agent.json).
 
+## Collecting logs via script
+
+An alternative method to collect the logs is to use the [`log-collector`](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/main/utils/log-collector) script in the [`utils`](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/main/utils) folder of our [Elastic CI Stack for AWS Repository](https://github.com/buildkite/elastic-ci-stack-for-aws). 
+
+The script will collect CloudWatch logs for the Instance, Lambda function, and AutoScaling activity and package them in a zip archive which you can send via email to [support@buildkite.com](mailto:support@buildkite.com).
+
+
 ## Accessing Elastic CI Stack for AWS instances directly
 
 Sometimes, looking at the logs isn't enough to figure out what's going on in your instances. In these cases, it can be useful to access the shell on the instance directly:

--- a/pages/agent/v3/elastic_ci_aws/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_aws/troubleshooting.md
@@ -24,7 +24,7 @@ There are a couple of other log groups that the Elastic CI Stack for AWS sends l
 
 ## Collecting logs via script
 
-An alternative method to collect the logs is to use the [`log-collector`](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/main/utils/log-collector) script in the [`utils`](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/main/utils) folder of our [Elastic CI Stack for AWS Repository](https://github.com/buildkite/elastic-ci-stack-for-aws). 
+An alternative method to collect the logs is to use the [`log-collector`](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/main/utils/log-collector) script in the [`utils`](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/main/utils) folder of the [Elastic CI Stack for AWS repository](https://github.com/buildkite/elastic-ci-stack-for-aws).
 
 The script will collect CloudWatch logs for the Instance, Lambda function, and AutoScaling activity and package them in a zip archive which you can send via email to [support@buildkite.com](mailto:support@buildkite.com).
 

--- a/pages/agent/v3/elastic_ci_aws/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_aws/troubleshooting.md
@@ -28,7 +28,6 @@ An alternative method to collect the logs is to use the [`log-collector`](https:
 
 The script collects CloudWatch logs for the Instance, Lambda function, and AutoScaling activity, then packages them in a zip archive that you can email to Support for help at [support@buildkite.com](mailto:support@buildkite.com).
 
-
 ## Accessing Elastic CI Stack for AWS instances directly
 
 Sometimes, looking at the logs isn't enough to figure out what's going on in your instances. In these cases, it can be useful to access the shell on the instance directly:

--- a/pages/agent/v3/elastic_ci_aws/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_aws/troubleshooting.md
@@ -26,7 +26,7 @@ There are a couple of other log groups that the Elastic CI Stack for AWS sends l
 
 An alternative method to collect the logs is to use the [`log-collector`](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/main/utils/log-collector) script in the [`utils`](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/main/utils) folder of the [Elastic CI Stack for AWS repository](https://github.com/buildkite/elastic-ci-stack-for-aws).
 
-The script will collect CloudWatch logs for the Instance, Lambda function, and AutoScaling activity and package them in a zip archive which you can send via email to [support@buildkite.com](mailto:support@buildkite.com).
+The script collects CloudWatch logs for the Instance, Lambda function, and AutoScaling activity, then packages them in a zip archive that you can email to Support for help at [support@buildkite.com](mailto:support@buildkite.com).
 
 
 ## Accessing Elastic CI Stack for AWS instances directly

--- a/pages/agent/v3/elastic_ci_aws/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_aws/troubleshooting.md
@@ -26,7 +26,7 @@ There are a couple of other log groups that the Elastic CI Stack for AWS sends l
 
 An alternative method to collect the logs is to use the [`log-collector`](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/main/utils/log-collector) script in the [`utils`](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/main/utils) folder of the [Elastic CI Stack for AWS repository](https://github.com/buildkite/elastic-ci-stack-for-aws).
 
-The script collects CloudWatch logs for the Instance, Lambda function, and AutoScaling activity, then packages them in a zip archive that you can email to Support for help at [support@buildkite.com](mailto:support@buildkite.com).
+The script collects CloudWatch Logs for the Instance, Lambda function, and AutoScaling activity, then packages them in a zip archive that you can email to Support for help at [support@buildkite.com](mailto:support@buildkite.com).
 
 ## Accessing Elastic CI Stack for AWS instances directly
 


### PR DESCRIPTION
This commit will add a section to the Elastic Stack troubleshooting docs under **Using Cloudwatch Logs** in it's own section outlining how and where to use the log-collector script to send troubleshooting logs to the Support Team at Buildkite.