### PR TITLE
Add documentation for `git-mirrors-skip-update`

### DIFF
--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -115,7 +115,7 @@ attributes:
   desc: |
       Path to where mirrors of git repositories are stored. Refer to [Git mirrors](/docs/agent/v3#promoted-experiments-git-mirrors) for more information on this feature. Introduced in [v3.47.0](https://github.com/buildkite/agent/releases/tag/v3.47.0).
       _Example:_ `/tmp/buildkite-git-mirrors`
-name: git-mirrors-skip-update
+- name: git-mirrors-skip-update
   env_var: BUILDKITE_GIT_MIRRORS_SKIP_UPDATE
   default_value: "false"
   required: false

--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -115,6 +115,13 @@ attributes:
   desc: |
       Path to where mirrors of git repositories are stored. Refer to [Git mirrors](/docs/agent/v3#promoted-experiments-git-mirrors) for more information on this feature. Introduced in [v3.47.0](https://github.com/buildkite/agent/releases/tag/v3.47.0).
       _Example:_ `/tmp/buildkite-git-mirrors`
+name: git-mirrors-skip-update
+  env_var: BUILDKITE_GIT_MIRRORS_SKIP_UPDATE
+  default_value: "false"
+  required: false
+  experimental: false
+  desc: |
+       Skips updating the git mirror before cloning. Refer to [Git mirrors](/docs/agent/v3#promoted-experiments-git-mirrors) for more information on this feature. Introduced in [v3.47.0](https://github.com/buildkite/agent/releases/tag/v3.47.0).
 - name: health-check-addr
   env_var: BUILDKITE_AGENT_HEALTH_CHECK_ADDR
   default_value: "disabled"

--- a/pages/agent/v3.md
+++ b/pages/agent/v3.md
@@ -167,6 +167,7 @@ See the following agent configuration options for more information:
 - [git-clone-mirror-flags](/docs/agent/v3/configuration#git-clone-mirror-flags)
 - [git-mirrors-lock-timeout](/docs/agent/v3/configuration#git-mirrors-lock-timeout)
 - [git-mirrors-path](/docs/agent/v3/configuration#git-mirrors-path)
+- [git-mirrors-skip-update](/docs/agent/v3/configuration#git-mirrors-skip-update)
 
 ### Redacted variables
 


### PR DESCRIPTION
This appears to have been missed but is a crucial feature that we make use of and may be useful to others too.