### PR TITLE
Add dockerized version of the docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,35 @@
-version: '3'
+version: "3"
 services:
   app:
     build:
       context: .
       args:
         RAILS_ENV: ${RAILS_ENV:-development}
-    volumes:
-      - '.:/app'
-      - /app/node_modules
+    depends_on:
+      - vite
+    environment:
+      VITE_RUBY_HOST: vite
     ports:
-      - '3000:3000'
+      - "3000:3000"
+    volumes:
+      - ".:/app"
+      - /app/node_modules
+
+  vite:
+    build:
+      context: .
+      args:
+        RAILS_ENV: ${RAILS_ENV:-development}
+    entrypoint: bin/vite dev
+    environment:
+      DEBUG: "*vite*"
+      RAILS_ENV: development
+      VITE_RUBY_HOST: 0.0.0.0
+    ports:
+      - "3036:3036"
+    volumes:
+      - .:/app
+      - /app/node_modules
 
   muffet:
     depends_on:


### PR DESCRIPTION
I keep running into issues with conflicting gems between buildkite and our docs.

This PR dockerizes vite so now everything can be run with the following:

```sh
docker-compose up -d app
```