### PR TITLE
Stop indexing `#main` URLs

### DIFF
--- a/config/algolia.json
+++ b/config/algolia.json
@@ -1,7 +1,7 @@
 {
   "index_name": "prod_docs",
   "start_urls": ["https://buildkite.com/docs"],
-  "stop_urls": ["agent/v2"],
+  "stop_urls": ["agent/v2", "**#main"],
   "selectors": {
     "lvl0": ".Page article h1",
     "lvl1": ".Page article h2",


### PR DESCRIPTION
I'm seeing a bunch of empty results in our search index with links to `#main`. 

~~This PR removes the link to see if that fixes the problem and we can look at bringing it back later.~~

This PR attempts to stop `#main` URLs from being indexed