### PR TITLE
Table of contents (V2)

### DIFF
--- a/app/assets/stylesheets/components/_toc.scss
+++ b/app/assets/stylesheets/components/_toc.scss
@@ -79,6 +79,23 @@
     margin-top: 2px;
   }
 
+  // It's possible that two elements are being highlighted at the same time
+  // (e.g. when the user is scrolling between two headings). In this case, we
+  // only want to highlight the first one.
+  .Toc__list-item--current + .Toc__list-item--current {
+    > .Toc__link {
+      background-color: initial;
+      color: $charcoal-500;
+    }
+  }
+
+  .Toc__list-item--current {
+    > .Toc__link {
+      background-color: $purple-100;
+      color: $purple-600;
+    }
+  }
+
   .Toc__link {
     border-radius: 5px;
     color: $navy-500;
@@ -87,11 +104,6 @@
     text-decoration: none;
 
     &:hover {
-      color: $purple-600;
-    }
-
-    &--current {
-      background-color: $purple-100;
       color: $purple-600;
     }
   }

--- a/app/assets/stylesheets/components/_toc.scss
+++ b/app/assets/stylesheets/components/_toc.scss
@@ -5,6 +5,7 @@
   box-shadow: $box-shadow-depth-100;
   max-width: map-get($max-w, "prose");
   margin-inline: auto;
+  position: relative;
 
   @media (min-width: $screen-lg) {
     background-color: transparent;

--- a/app/assets/stylesheets/components/_toc.scss
+++ b/app/assets/stylesheets/components/_toc.scss
@@ -88,7 +88,6 @@
   }
 
   .Toc__link {
-    transition: color 300ms ease-in-out, transform 300ms ease-in-out;
     border-radius: 5px;
     color: $navy-500;
     display: block;
@@ -117,17 +116,27 @@
   width: 100%;
   height: 100%;
   z-index: -1;
-
   display: none;
+
   @media (min-width: $screen-lg) {
     display: initial;
   }
 }
 
 .Toc path {
-  transition: all 300ms ease;
   fill: transparent;
   stroke: $purple-600;
   stroke-width: 3px;
   stroke-dasharray: 0 0 0 1000;
+}
+
+// Less animations on page load.
+.Toc--is-ready {
+  path {
+    transition: all 300ms ease;
+  }
+
+  .Toc__link {
+    transition: color 300ms ease-in-out, transform 300ms ease-in-out;
+  }
 }

--- a/app/assets/stylesheets/components/_toc.scss
+++ b/app/assets/stylesheets/components/_toc.scss
@@ -81,12 +81,13 @@
 
   .Toc__list-item.active {
     > .Toc__link {
-      transition: color 300ms ease-in-out;
       color: $purple-600;
+      transform: translate(5px);
     }
   }
 
   .Toc__link {
+    transition: color 300ms ease-in-out, transform 300ms ease-in-out;
     border-radius: 5px;
     color: $navy-500;
     display: block;

--- a/app/assets/stylesheets/components/_toc.scss
+++ b/app/assets/stylesheets/components/_toc.scss
@@ -79,19 +79,9 @@
     margin-top: 2px;
   }
 
-  // It's possible that two elements are being highlighted at the same time
-  // (e.g. when the user is scrolling between two headings). In this case, we
-  // only want to highlight the first one.
-  .Toc__list-item--current + .Toc__list-item--current {
+  .Toc__list-item.active {
     > .Toc__link {
-      background-color: initial;
-      color: $charcoal-500;
-    }
-  }
-
-  .Toc__list-item--current {
-    > .Toc__link {
-      background-color: $purple-100;
+      transition: color 300ms ease-in-out;
       color: $purple-600;
     }
   }
@@ -102,6 +92,7 @@
     display: block;
     padding: 6px 16px;
     text-decoration: none;
+    display: inline-block;
 
     &:hover {
       color: $purple-600;
@@ -110,6 +101,31 @@
 
   .Toc__link--h3 {
     font-size: 0.875rem;
-    padding-left: 16px + 10px;
   }
+}
+
+.Toc__list-item .Toc__list {
+  padding-left: 16px;
+}
+
+.Toc svg {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+
+  display: none;
+  @media (min-width: $screen-lg) {
+    display: initial;
+  }
+}
+
+.Toc path {
+  transition: all 300ms ease;
+  fill: transparent;
+  stroke: $purple-600;
+  stroke-width: 3px;
+  stroke-dasharray: 0 0 0 1000;
 }

--- a/app/frontend/components/toc.js
+++ b/app/frontend/components/toc.js
@@ -101,9 +101,15 @@ export function initToc() {
     );
 
     drawPath();
+
     document.querySelectorAll("section[id]").forEach((section) => {
       observer.observe(section);
     });
+
+    // Wait for the nav to be ready before animating the path
+    setTimeout(() => {
+      nav.classList.add("Toc--is-ready");
+    }, 100);
   };
 
   const initToggle = () => {

--- a/app/frontend/components/toc.js
+++ b/app/frontend/components/toc.js
@@ -37,7 +37,7 @@ export function initToc() {
     });
   }
 
-  function syncPath() {
+  function syncPath(clickedItem = null) {
     const pathLength = navPath.getTotalLength();
 
     let pathStart = pathLength;
@@ -45,22 +45,30 @@ export function initToc() {
     let lastPathStart, lastPathEnd;
     let visibleItemFound = false;
 
-    items.forEach((item) => {
-      // Only make the first visible item active
-      item.listItem.classList.remove("active");
-      if (visibleItemFound) {
+    if (clickedItem) {
+      items.forEach((item) => item.listItem.classList.remove("active"));
+      clickedItem.listItem.classList.add("active");
+      pathStart = Math.min(clickedItem.pathStart, pathStart);
+      pathEnd = Math.max(clickedItem.pathEnd, pathEnd);
+      visibleItemFound = true;
+    } else {
+      items.forEach((item) => {
+        // Only make the first visible item active
         item.listItem.classList.remove("active");
-        return;
-      }
+        if (visibleItemFound) {
+          item.listItem.classList.remove("active");
+          return;
+        }
 
-      if (item.listItem.classList.contains(visibleClass)) {
-        item.listItem.classList.add("active");
+        if (item.listItem.classList.contains(visibleClass)) {
+          item.listItem.classList.add("active");
 
-        pathStart = Math.min(item.pathStart, pathStart);
-        pathEnd = Math.max(item.pathEnd, pathEnd);
-        visibleItemFound = true;
-      }
-    });
+          pathStart = Math.min(item.pathStart, pathStart);
+          pathEnd = Math.max(item.pathEnd, pathEnd);
+          visibleItemFound = true;
+        }
+      });
+    }
 
     if (visibleItemFound && pathStart < pathEnd) {
       if (pathStart !== lastPathStart || pathEnd !== lastPathEnd) {
@@ -125,6 +133,16 @@ export function initToc() {
       listNode.classList.toggle("Toc__list--is-collapsed");
     });
   };
+
+  // Force the clicked item to be active.
+  items.forEach((item) => {
+    item.anchor.addEventListener("click", (e) => {
+      setTimeout(() => {
+        item.listItem.classList.add(visibleClass);
+        syncPath(item);
+      }, 25);
+    });
+  });
 
   initCurrentLinkListener();
   initToggle();

--- a/app/frontend/components/toc.js
+++ b/app/frontend/components/toc.js
@@ -1,49 +1,25 @@
 export function initToc() {
   const initCurrentLinkListener = () => {
-    const scrollPadding = 125;
-    const currentClassName = "Toc__link--current";
-    const tocLinkNodes = document.querySelectorAll(".Toc__link--h2");
-    const headingNodes = document.querySelectorAll("h2.Docs__heading");
+    const content = document.querySelector(".Page");
 
-    const getDistanceFromTop = (element) => {
-      if (!element.offsetParent) {
-        return element.offsetTop;
-      }
-      return element.offsetTop + getDistanceFromTop(element.offsetParent);
-    };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const id = entry.target.getAttribute("id");
 
-    const getHeadingPos = (heading) => getDistanceFromTop(heading);
+          const link = document.querySelector(`.Toc__link--h2[href="#${id}"]`);
+          if (entry.intersectionRatio > 0) {
+            link.parentElement.classList.add("Toc__list-item--current");
+          } else {
+            link.parentElement.classList.remove("Toc__list-item--current");
+          }
+        });
+      },
+      { rootMargin: `-${content.offsetTop}px 0px 0px 0px` }
+    );
 
-    const setCurrentLink = (hash) => {
-      tocLinkNodes.forEach((link) => {
-        link.classList.remove(currentClassName);
-        link.removeAttribute("aria-current");
-      });
-
-      const currentNode = [...tocLinkNodes].find((link) => link.hash === hash);
-      if (currentNode) {
-        currentNode.classList.add(currentClassName);
-        currentNode.setAttribute("aria-current", "");
-      }
-    };
-
-    const handleScroll = () => {
-      const topPos = window.scrollY + scrollPadding;
-
-      headingNodes.forEach((heading) => {
-        const pos = getHeadingPos(heading);
-        if (topPos >= pos) {
-          setCurrentLink(`#${heading.id}`);
-        }
-      });
-    };
-
-    window.addEventListener("scroll", handleScroll);
-
-    tocLinkNodes.forEach((link) => {
-      link.addEventListener("click", (e) => {
-        setTimeout(() => setCurrentLink(e.target.hash), 25);
-      });
+    document.querySelectorAll("section[id]").forEach((sections) => {
+      observer.observe(sections);
     });
   };
 

--- a/app/frontend/components/toc.js
+++ b/app/frontend/components/toc.js
@@ -88,7 +88,7 @@ export function initToc() {
           const id = entry.target.getAttribute("id");
 
           const link = document.querySelector(`.Toc__link[href="#${id}"]`);
-          if (entry.intersectionRatio > 0) {
+          if (entry.intersectionRatio >= 0.25) {
             link.parentElement.classList.add(visibleClass);
           } else {
             link.parentElement.classList.remove(visibleClass);
@@ -97,7 +97,7 @@ export function initToc() {
 
         syncPath();
       },
-      { rootMargin: `-${content.offsetTop}px 0px 0px 0px` }
+      { rootMargin: `-${content.offsetTop}px 0px 0px 0px`, threshold: 0.25 }
     );
 
     drawPath();

--- a/app/frontend/components/toc.js
+++ b/app/frontend/components/toc.js
@@ -1,5 +1,85 @@
 export function initToc() {
+  const nav = document.querySelector(".Toc");
+  const visibleClass = "Toc__list-item--visible";
+  const navPath = nav.querySelector("svg path");
+  const navListItems = [...document.querySelectorAll(".Toc__list-item")];
+
+  const items = navListItems.map((listItem) => {
+    const anchor = listItem.querySelector("a");
+    return { listItem, anchor };
+  });
+
+  function drawPath() {
+    let path = [];
+    let pathIndent;
+
+    items.forEach((item, i) => {
+      const x = item.anchor.offsetLeft + 3;
+      const y = item.anchor.offsetTop;
+      const height = item.anchor.offsetHeight;
+
+      if (i === 0) {
+        path.push("M", x, y, "L", x, y + height);
+        item.pathStart = 0;
+      } else {
+        if (pathIndent !== x) path.push("L", pathIndent, y);
+
+        path.push("L", x, y);
+
+        navPath.setAttribute("d", path.join(" "));
+        item.pathStart = navPath.getTotalLength() || 0;
+        path.push("L", x, y + height);
+      }
+
+      pathIndent = x;
+      navPath.setAttribute("d", path.join(" "));
+      item.pathEnd = navPath.getTotalLength();
+    });
+  }
+
+  function syncPath() {
+    const pathLength = navPath.getTotalLength();
+
+    let pathStart = pathLength;
+    let pathEnd = 0;
+    let lastPathStart, lastPathEnd;
+    let visibleItemFound = false;
+
+    items.forEach((item) => {
+      // Only make the first visible item active
+      item.listItem.classList.remove("active");
+      if (visibleItemFound) {
+        item.listItem.classList.remove("active");
+        return;
+      }
+
+      if (item.listItem.classList.contains(visibleClass)) {
+        item.listItem.classList.add("active");
+
+        pathStart = Math.min(item.pathStart, pathStart);
+        pathEnd = Math.max(item.pathEnd, pathEnd);
+        visibleItemFound = true;
+      }
+    });
+
+    if (visibleItemFound && pathStart < pathEnd) {
+      if (pathStart !== lastPathStart || pathEnd !== lastPathEnd) {
+        const dashArray = `1 ${pathStart} ${pathEnd - pathStart} ${pathLength}`;
+
+        navPath.style.setProperty("stroke-dashoffset", "1");
+        navPath.style.setProperty("stroke-dasharray", dashArray);
+        navPath.style.setProperty("opacity", 1);
+      }
+    } else {
+      navPath.style.setProperty("opacity", 0);
+    }
+
+    lastPathStart = pathStart;
+    lastPathEnd = pathEnd;
+  }
+
   const initCurrentLinkListener = () => {
+    drawPath();
     const content = document.querySelector(".Page");
 
     const observer = new IntersectionObserver(
@@ -7,19 +87,22 @@ export function initToc() {
         entries.forEach((entry) => {
           const id = entry.target.getAttribute("id");
 
-          const link = document.querySelector(`.Toc__link--h2[href="#${id}"]`);
+          const link = document.querySelector(`.Toc__link[href="#${id}"]`);
           if (entry.intersectionRatio > 0) {
-            link.parentElement.classList.add("Toc__list-item--current");
+            link.parentElement.classList.add(visibleClass);
           } else {
-            link.parentElement.classList.remove("Toc__list-item--current");
+            link.parentElement.classList.remove(visibleClass);
           }
         });
+
+        syncPath();
       },
       { rootMargin: `-${content.offsetTop}px 0px 0px 0px` }
     );
 
-    document.querySelectorAll("section[id]").forEach((sections) => {
-      observer.observe(sections);
+    drawPath();
+    document.querySelectorAll("section[id]").forEach((section) => {
+      observer.observe(section);
     });
   };
 

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -55,16 +55,16 @@ class Page::Renderer
   end
 
   def wrap_sections(doc)
-    h2s = doc.css('h2')
-    h2s.each do |h2|
-      next_element = h2.next_element
-      h2.wrap("<section id=\"#{h2['id']}\"></section>")
+    headers = doc.css('h2,h3')
+    headers.each do |header|
+      next_element = header.next_element
+      header.wrap("<section id=\"#{header['id']}\"></section>")
 
-      while !next_element.nil? && next_element.name != 'h2' do
+      while !next_element.nil? && !next_element.name.match?(/h2|h3/)  do
         current_element = next_element
         next_element = next_element.next_element
 
-        h2.parent.add_child(current_element)
+        header.parent.add_child(current_element)
       end
     end
 

--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -21,6 +21,7 @@ class Page::Renderer
     doc = add_callout(doc)
     doc = decorate_external_links(doc)
     doc = init_responsive_tables(doc)
+    doc = wrap_sections(doc)
     doc.to_html.html_safe
   end
 
@@ -51,6 +52,23 @@ class Page::Renderer
     def codespan(code)
       %{<code>#{EscapeUtils.escape_html(code)}</code>}
     end
+  end
+
+  def wrap_sections(doc)
+    h2s = doc.css('h2')
+    h2s.each do |h2|
+      next_element = h2.next_element
+      h2.wrap("<section id=\"#{h2['id']}\"></section>")
+
+      while !next_element.nil? && next_element.name != 'h2' do
+        current_element = next_element
+        next_element = next_element.next_element
+
+        h2.parent.add_child(current_element)
+      end
+    end
+
+    doc
   end
 
   def add_automatic_ids_to_headings(doc)

--- a/app/views/application/_toc.html.erb
+++ b/app/views/application/_toc.html.erb
@@ -3,6 +3,7 @@
       <button class="Toc__toggle">
         <h2 class="Toc__title">On this page</h2>
       </button>
+
       <ul class="Toc__list Toc__list--is-collapsed">
         <% @page.sections.each do |section| %>
           <li class="Toc__list-item">
@@ -24,5 +25,9 @@
           </li>
         <% end %>
       </ul>
+
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <path />
+      </svg>
     </nav>
   <% end %>

--- a/app/views/application/_toc.html.erb
+++ b/app/views/application/_toc.html.erb
@@ -6,7 +6,7 @@
       <ul class="Toc__list Toc__list--is-collapsed">
         <% @page.sections.each do |section| %>
           <li class="Toc__list-item">
-            <a class="Toc__link Toc__link--h2" href="#<%= section[:id] %>">
+            <a data-turbo="false" class="Toc__link Toc__link--h2" href="#<%= section[:id] %>">
               <%= section[:header] %>
             </a>
 
@@ -14,7 +14,7 @@
               <ul class="Toc__list">
                 <% section[:subsections].each do |subsection| %>
                   <li class="Toc__list-item">
-                    <a class="Toc__link Toc__link--h3" href="#<%= "#{section[:id]}-#{subsection[:id]}" %>">
+                    <a data-turbo="false" class="Toc__link Toc__link--h3" href="#<%= "#{section[:id]}-#{subsection[:id]}" %>">
                       <%= subsection[:header] %>
                     </a>
                   </li>


### PR DESCRIPTION
OK I went a little further with https://github.com/buildkite/docs/pull/2396 and rather than just smooth scrolling (which I'm not tied to), I've also adapted the awesome work of https://lab.hakim.se/progress-nav into our table of contents.

I'll admit that I haven't produced the nicest code, but the end result is kinda cool. 

Here's a couple variations for us to discuss.

**V1 (the one in this PR)**

https://github.com/buildkite/docs/assets/656826/68b2b197-6f01-4fa2-9a27-3ab6d797ca23


**V2 (the 🐍 version)**
 
https://github.com/buildkite/docs/assets/656826/bef06831-34d4-4aa2-a646-f4e8715625e9





