### PR TITLE
Update docs to talk about per pipeline settings removed

### DIFF
--- a/pages/pipelines/build_retention.md
+++ b/pages/pipelines/build_retention.md
@@ -50,6 +50,8 @@ The following diagram shows the lifecycle of build data by plan.
   </tbody>
 </table>
 
+Per pipeline retention settings have been retired and all pipelines are now in organisation specific retention settings specified above.
+
 ## Exporting build data
 
 > 📘 Enterprise feature

--- a/pages/pipelines/build_retention.md
+++ b/pages/pipelines/build_retention.md
@@ -50,7 +50,7 @@ The following diagram shows the lifecycle of build data by plan.
   </tbody>
 </table>
 
-Per pipeline retention settings have been retired and all pipelines are now in organisation specific retention settings specified above.
+Retention periods are set according to an organization's plan, as shown in the previous table. Per-pipeline retention settings are not supported.
 
 ## Exporting build data
 


### PR DESCRIPTION
We got a few customers that asked us about the per pipeline retention settings. So adding it to the docs so it is more clear

https://linear.app/buildkite/issue/PDP-1497/update-docs-to-talk-about-per-pipeline-settings-removed