### PR TITLE
Skip initialising table of contents for some pages

### DIFF
--- a/app/frontend/components/toc.js
+++ b/app/frontend/components/toc.js
@@ -1,5 +1,10 @@
 export function initToc() {
   const nav = document.querySelector(".Toc");
+
+  if (!nav) {
+    return;
+  }
+
   const visibleClass = "Toc__list-item--visible";
   const navPath = nav.querySelector("svg path");
   const navListItems = [...document.querySelectorAll(".Toc__list-item")];


### PR DESCRIPTION
This fixes an error that pops on pages that don't include a table of contents.