### PR TITLE
Add ids to h1 tags for search

### DIFF
--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -75,6 +75,14 @@ class Page::Renderer
     h2_ids = []
     h3s_with_manual_ids = []
 
+    # h1 headers
+    doc.search('./h1').each do |header|
+      if (id = header['id']).blank?
+        id = header['id'] = header.text.to_url
+      end
+    end
+
+    # h2 headers
     doc.search('./h2').each do |h2|
       if (id = h2['id']).blank?
         id = h2['id'] = h2.text.to_url

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Page::Renderer do
     MD
 
     html = <<~HTML
-      <h1>Page title</h1>
+      <h1 id="page-title">Page title</h1>
 
       <p>Some description</p>
     HTML


### PR DESCRIPTION
Sometimes I'm seeing search results with some blank `#main` links. 

I noted that we didn't include IDs on our h1's which I think means the default h1 indexing doesn't have anything to link to. 

Maybe this will improve things 🤷 