### PR TITLE
Attempt to fix blank search records

### DIFF
--- a/app/models/page/renderer.rb
+++ b/app/models/page/renderer.rb
@@ -75,13 +75,6 @@ class Page::Renderer
     h2_ids = []
     h3s_with_manual_ids = []
 
-    # h1 headers
-    doc.search('./h1').each do |header|
-      if (id = header['id']).blank?
-        id = header['id'] = header.text.to_url
-      end
-    end
-
     # h2 headers
     doc.search('./h2').each do |h2|
       if (id = h2['id']).blank?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
   <body class="<%= beta? ? 'beta' : ''-%>">
     <%= render "site_header" %>
 
-    <main id="main" role="main">
+    <main id="__main" role="main">
       <div class="PageContainer">
         <div class="Page">
           <div class="Page__sidebar">

--- a/pages/agent/v3/gcloud.md
+++ b/pages/agent/v3/gcloud.md
@@ -52,7 +52,7 @@ Metrics-server is running at https://34.71.166.83/api/v1/namespaces/kube-system/
 To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 ```
 
-Create a [secret](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) with your [agent registration token](/docs/agent/v3/tokens#main):
+Create a [secret](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) with your [agent registration token](/docs/agent/v3/tokens):
 
 ```shell
 $ kubectl create secret generic buildkite-agent --from-literal=token=INSERT-YOUR-AGENT-TOKEN-HERE

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Page::Renderer do
     MD
 
     html = <<~HTML
-      <h1 id="page-title">Page title</h1>
+      <h1>Page title</h1>
 
       <p>Some description</p>
     HTML


### PR DESCRIPTION
This is another crack at removing some empty anchor links from showing up the search results. It doesn't look like https://github.com/buildkite/docs/pull/2438 helped so I'm looking at using a `__` prefixed id similar to what docusaurus does. I'm guessing the algolia search excludes these 😬 

I need a better way of testing this stuff in dev. 

This is what I'm trying to fix. You can see it uses the new ID but it's still displaying weird. 

<img width="636" alt="Screenshot 2023-08-28 at 12 59 55 pm" src="https://github.com/buildkite/docs/assets/656826/5a0a41f3-b1d6-469e-9ad4-063149c5aa5a">
