### PR TITLE
Add alternative keyservers for Ubuntu and Debian

### DIFF
--- a/pages/agent/v3/_alternative_keyservers.md
+++ b/pages/agent/v3/_alternative_keyservers.md
@@ -1,14 +1,13 @@
 The PGP key used to sign the Buildkite Agent package is also hosted on the following keyservers. Use these keyservers if the one in the installation instructions is down.
 
-<!-- vale off -->
+- [keyserver.ubuntu.com](https://keyserver.ubuntu.com)
 
-### [keyserver.ubuntu.com](https://keyserver.ubuntu.com)
-```shell
-curl -fsSL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x32A37959C2FA5C3C99EFBC32A79206696452D198&exact=on&options=mr' | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
-```
+    ```shell
+    curl -fsSL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x32A37959C2FA5C3C99EFBC32A79206696452D198&exact=on&options=mr' | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+    ```
 
-### [pgp.mit.edu](https://pgp.mit.edu)
-```shell
-curl -fsSL 'https://pgp.mit.edu/pks/lookup?op=get&search=0x32A37959C2FA5C3C99EFBC32A79206696452D198&exact=on&options=mr' | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
-```
-<!-- vale on -->
+- [pgp.mit.edu](https://pgp.mit.edu)
+
+    ```shell
+    curl -fsSL 'https://pgp.mit.edu/pks/lookup?op=get&search=0x32A37959C2FA5C3C99EFBC32A79206696452D198&exact=on&options=mr' | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+    ```

--- a/pages/agent/v3/_alternative_keyservers.md
+++ b/pages/agent/v3/_alternative_keyservers.md
@@ -1,5 +1,7 @@
 The PGP key used to sign the Buildkite Agent package is also hosted on the following keyservers. You may use the instructions below to download this key if the keyserver used in the installation instructions is down.
 
+<!-- vale off -->
+
 ### [keyserver.ubuntu.com](https://keyserver.ubuntu.com)
 ```shell
 curl -fsSL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x32A37959C2FA5C3C99EFBC32A79206696452D198&exact=on&options=mr' | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
@@ -9,3 +11,4 @@ curl -fsSL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x32A37959C2FA
 ```shell
 curl -fsSL 'https://pgp.mit.edu/pks/lookup?op=get&search=0x32A37959C2FA5C3C99EFBC32A79206696452D198&exact=on&options=mr' | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
+<!-- vale on -->

--- a/pages/agent/v3/_alternative_keyservers.md
+++ b/pages/agent/v3/_alternative_keyservers.md
@@ -1,4 +1,4 @@
-The PGP key used to sign the Buildkite Agent package is also hosted on the following keyservers. You may use the instructions below to download this key if the keyserver used in the installation instructions is down.
+The PGP key used to sign the Buildkite Agent package is also hosted on the following keyservers. Use these keyservers if the one in the installation instructions is down.
 
 <!-- vale off -->
 

--- a/pages/agent/v3/_alternative_keyservers.md
+++ b/pages/agent/v3/_alternative_keyservers.md
@@ -1,0 +1,11 @@
+The PGP key used to sign the Buildkite Agent package is also hosted on the following keyservers. You may use the instructions below to download this key if the keyserver used in the installation instructions is down.
+
+### [keyserver.ubuntu.com](https://keyserver.ubuntu.com)
+```shell
+curl -fsSL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x32A37959C2FA5C3C99EFBC32A79206696452D198&exact=on&options=mr' | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+```
+
+### [pgp.mit.edu](https://pgp.mit.edu)
+```shell
+curl -fsSL 'https://pgp.mit.edu/pks/lookup?op=get&search=0x32A37959C2FA5C3C99EFBC32A79206696452D198&exact=on&options=mr' | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+```

--- a/pages/agent/v3/debian.md
+++ b/pages/agent/v3/debian.md
@@ -28,7 +28,8 @@ Download the Buildkite PGP key to a directory that is only writable by `root` (c
 curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
-Note: if the [keys.openpgp.org](https://keys.openpgp.org) keyserver is down, see the [Alternative keyservers](#alternative-keyservers) section below.
+>📘 Is [keys.openpgp.org](https://keys.openpgp.org) down?
+> If you get a 404 or other error from `curl` in the command above, see the [Alternative keyservers](#alternative-keyservers) section below.
 
 Then add the signed source to your apt sources list:
 

--- a/pages/agent/v3/debian.md
+++ b/pages/agent/v3/debian.md
@@ -29,7 +29,7 @@ curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC
 ```
 
 >📘 Is [keys.openpgp.org](https://keys.openpgp.org) down?
-> If you get a 404 or other error from `curl` in the command above, see the [Alternative keyservers](#alternative-keyservers) section below.
+> If you get a 404 or other error from `curl` in the previous command, see the [Alternative keyservers](#alternative-keyservers) section.
 
 Then add the signed source to your apt sources list:
 

--- a/pages/agent/v3/debian.md
+++ b/pages/agent/v3/debian.md
@@ -28,6 +28,8 @@ Download the Buildkite PGP key to a directory that is only writable by `root` (c
 curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
+Note: if the [keys.openpgp.org](https://keys.openpgp.org) keyserver is down, see the [Alternative keyservers](#alternative-keyservers) section below.
+
 Then add the signed source to your apt sources list:
 
 ```shell
@@ -93,3 +95,7 @@ On Debian, the Buildkite agent runs as user `buildkite-agent`.
 ## Upgrading
 
 <%= render_markdown partial: 'agent/v3/apt_upgrading' %>
+
+## Alternative keyservers
+
+<%= render_markdown partial: 'agent/v3/alternative_keyservers' %>

--- a/pages/agent/v3/ubuntu.md
+++ b/pages/agent/v3/ubuntu.md
@@ -13,6 +13,8 @@ Start by downloading the Buildkite PGP key to a directory that is only writable 
 curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
+Note: if the [keys.openpgp.org](https://keys.openpgp.org) keyserver is down, see the [Alternative keyservers](#alternative-keyservers) section below.
+
 Then add the signed source to your list of apt sources:
 
 ```shell
@@ -74,3 +76,7 @@ See the [Agent SSH keys](/docs/agent/v3/ssh-keys) documentation for more details
 ## Upgrading
 
 <%= render_markdown partial: 'agent/v3/apt_upgrading' %>
+
+## Alternative keyservers
+
+<%= render_markdown partial: 'agent/v3/alternative_keyservers' %>

--- a/pages/agent/v3/ubuntu.md
+++ b/pages/agent/v3/ubuntu.md
@@ -13,7 +13,8 @@ Start by downloading the Buildkite PGP key to a directory that is only writable 
 curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 ```
 
-Note: if the [keys.openpgp.org](https://keys.openpgp.org) keyserver is down, see the [Alternative keyservers](#alternative-keyservers) section below.
+>📘 Is [keys.openpgp.org](https://keys.openpgp.org) down?
+> If you get a 404 or other error from `curl` in the command above, see the [Alternative keyservers](#alternative-keyservers) section below.
 
 Then add the signed source to your list of apt sources:
 

--- a/pages/agent/v3/ubuntu.md
+++ b/pages/agent/v3/ubuntu.md
@@ -14,7 +14,7 @@ curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC
 ```
 
 >📘 Is [keys.openpgp.org](https://keys.openpgp.org) down?
-> If you get a 404 or other error from `curl` in the command above, see the [Alternative keyservers](#alternative-keyservers) section below.
+> If you get a 404 or other error from `curl` in the previous command, see the [Alternative keyservers](#alternative-keyservers) section.
 
 Then add the signed source to your list of apt sources:
 

--- a/vale/styles/vocab.txt
+++ b/vale/styles/vocab.txt
@@ -241,6 +241,8 @@ VPCs
 XCTest
 xUnit
 dotenv
+keyserver
+keyservers
 
 # GraphQL code words
 # TODO: format these as code instead of making exceptions


### PR DESCRIPTION
At the moment, the keyserver we use in the instructions to install the agent on Ubuntu and Debian seems to be down. However, it is not the only keyserver that our PGP public key has been distributed to, so let's add an alternative keyserver to the instructions.