### PR TITLE
add example of targeting a Windows agent elastic stack

### DIFF
--- a/pages/agent/v3/elastic_ci_aws.md
+++ b/pages/agent/v3/elastic_ci_aws.md
@@ -125,7 +125,7 @@ steps:
       queue: "windows"
 ```
 
-See the [Buildkite Agent queue target docs](/docs/agent/v3/queues#targeting-a-queue) and [Buildkite Agent job queue docs](/docs/agent/v3/queues) for more info.
+For more information, see [Buildkite Agent job queues](/docs/agent/v3/queues), specifically [Targeting a queue](/docs/agent/v3/queues#targeting-a-queue).
 
 Review the parameters, see [Elastic CI Stack for AWS parameters](/docs/agent/v3/elastic_ci_aws/parameters) for more details.
 

--- a/pages/agent/v3/elastic_ci_aws.md
+++ b/pages/agent/v3/elastic_ci_aws.md
@@ -114,7 +114,18 @@ If you don't know your agent token, there is a _Reveal Agent Token_ button avail
 
 <%= image "buildkite-agent-token.png", size: "#{752/2}x#{424/2}", alt: "Reveal Agent Token" %>
 
-By default the stack uses a job queue of `default`, but you can specify any other queue name you like. See the [Buildkite Agent job queue docs](/docs/agent/v3/queues) for more info.
+By default the stack uses a job queue of `default`, but you can specify any other queue name you like. 
+
+A common example of setting a queue for a dedicated Windows agent can be achieved with the following in your `pipeline.yml` after you've set up your Windows stack:
+
+```yaml
+steps:
+  - command: echo "hello from windows"
+    agents:
+      queue: "windows"
+```
+
+See the [Buildkite Agent queue target docs](/docs/agent/v3/queues#targeting-a-queue) and [Buildkite Agent job queue docs](/docs/agent/v3/queues) for more info.
 
 Review the parameters, see [Elastic CI Stack for AWS parameters](/docs/agent/v3/elastic_ci_aws/parameters) for more details.
 

--- a/pages/agent/v3/elastic_ci_aws.md
+++ b/pages/agent/v3/elastic_ci_aws.md
@@ -114,7 +114,7 @@ If you don't know your agent token, there is a _Reveal Agent Token_ button avail
 
 <%= image "buildkite-agent-token.png", size: "#{752/2}x#{424/2}", alt: "Reveal Agent Token" %>
 
-By default the stack uses a job queue of `default`, but you can specify any other queue name you like. 
+By default the stack uses a job queue of `default`, but you can specify any other queue name you like.
 
 A common example of setting a queue for a dedicated Windows agent can be achieved with the following in your `pipeline.yml` after you've set up your Windows stack:
 


### PR DESCRIPTION
A common practice I've seen is having a specific Windows Elastic Stack agent and targeting it with a queue. This PR brings a main, simple example to the overview page as a quick reference guide on how to target a queue. I have also updated the for more information blurb to include a direct link to targeting a queue.