### PR TITLE
Fix center alignment of footer paragraph

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -4,6 +4,9 @@
   margin-bottom: 30px;
   margin-top: 60px;
   text-align: center;
+  p {
+    margin-inline: auto;
+  }
 }
 
 .Footer__heading {

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -4,9 +4,6 @@
   margin-bottom: 30px;
   margin-top: 60px;
   text-align: center;
-  p {
-    margin-inline: auto;
-  }
 }
 
 .Footer__heading {

--- a/app/assets/stylesheets/components/_page.scss
+++ b/app/assets/stylesheets/components/_page.scss
@@ -87,16 +87,5 @@ $lg-screen-margin-top: map-get($header-height, "one-row");
     &:nth-child(2) {
       max-width: 1074px;
     }
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    p,
-    ul {
-      max-width: map-get($max-w, "prose");
-    }
   }
 }


### PR DESCRIPTION
Max width is applied so in certain contexts, the footer paragraph text looks misaligned:

**Before:**
<img width="1157" alt="CleanShot 2023-09-01 at 08 00 01@2x" src="https://github.com/buildkite/docs/assets/677025/e62abe60-c9ab-4113-b439-9a0b20a58b24">


**After:**
<img width="1133" alt="CleanShot 2023-09-01 at 08 00 17@2x" src="https://github.com/buildkite/docs/assets/677025/cc13f52c-3c78-4b00-8748-c37b51d22bf2">
