### PR TITLE
Update duration in history/span

### DIFF
--- a/data/content/test_analytics_json_fields_history.yaml
+++ b/data/content/test_analytics_json_fields_history.yaml
@@ -16,7 +16,7 @@ fields:
   required: true
   type: number
   desc: |
-      How long the test took to run. This value is microseconds stored as a float.
+      How long the test took to run. This value is seconds stored as a float.
   examples:
 - name: children
   required: false

--- a/data/content/test_analytics_json_fields_span.yaml
+++ b/data/content/test_analytics_json_fields_span.yaml
@@ -26,7 +26,7 @@ fields:
   required: true
   type: number
   desc: |
-      How long the span took to run. This value is microseconds stored as a float.
+      How long the span took to run. This value is seconds stored as a float.
   examples:
 - name: detail
   required : false


### PR DESCRIPTION
We mentioned that the value of duration is microseconds, but according to the code the value that is expected is in seconds (it converts to milliseconds and microseconds to show in the UI). I confirmed with @KatieWright26 :) 