### PR TITLE
🔍 Canonical URL

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,4 +55,8 @@ module ApplicationHelper
       name.titleize
     end
   end
+
+  def seo_canonical_url
+    "https://buildkite.com#{request.path}"
+  end
 end

--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -11,6 +11,8 @@
 <meta name="description" content="<%= description %>" />
 <% end %>
 
+<%= tag :link, rel: "canonical", href: seo_canonical_url %>
+
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <%= stylesheet_link_tag "application", media: "all" %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -48,4 +48,13 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe "#seo_canonical_url" do
+    it "returns the correct canonical URL" do
+      # Mocking the request object's path method
+      allow(helper).to receive_message_chain(:request, :path).and_return("/docs/agent/v3")
+
+      expect(helper.seo_canonical_url).to eq("https://buildkite.com/docs/agent/v3")
+    end
+  end
 end


### PR DESCRIPTION
Specify canonical URL on every page as `https://buildkite.com/docs/*/**` (without www).
