### PR TITLE
✨ Specify content keyword in front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,17 @@ Otherwise, to update the general navigation:
 
 1. Edit `nav.yml` with your changes.
 1. Restart the application.
+
+## Content keywords
+
+We render content keywords in `data-content-keywords` in the `body` tag to highlight the focus keywords of each page with content authors.
+
+This helps the content team to quickly inspect to see the types of content we're providing across different channels.
+
+Keywords are added as [Frontmatter](https://rubygems.org/gems/front_matter_parser) meta data using the `keywords` key, e.g.:
+
+```md
+keywords: docs, tutorial, pipelines, 2fa
+```
+
+If no keywords are provided it falls back to comma-separated URL path segments.

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -35,12 +35,4 @@ class PagesController < ApplicationController
   end
   helper_method :beta?
 
-  # Renders keywords to the page for content writers to inspect and use as a guide
-  # Gracefully falls back to the page's path if no keywords are specified
-  # to help reduce content workload
-  def content_keywords
-    @page.keywords || request.path.split("/").reject(&:empty?).map { |segment| segment.gsub("-", " ") }.join(", ")
-  end
-  helper_method :content_keywords
-
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -35,4 +35,12 @@ class PagesController < ApplicationController
   end
   helper_method :beta?
 
+  # Renders keywords to the page for content writers to inspect and use as a guide
+  # Gracefully falls back to the page's path if no keywords are specified
+  # to help reduce content workload
+  def content_keywords
+    @page.keywords || request.path.split("/").reject(&:empty?).map { |segment| segment.gsub("-", " ") }.join(", ")
+  end
+  helper_method :content_keywords
+
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -177,6 +177,12 @@ class Page
     front_matter.fetch(:template, "show")
   end
 
+  # Returns focus keywords to guide content writers with an overview notion of the page
+  # It's not for meta keywords, which is a deprecated practice
+  def keywords
+    front_matter.fetch(:keywords)
+  end
+
   private
 
   def front_matter
@@ -186,6 +192,7 @@ class Page
         "toc": true,
         # Default to H3s being included in the table of contents
         "toc_include_h3": true,
+        "keywords": nil,
       }
       if file.front_matter
         defaults.merge(file.front_matter.symbolize_keys)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -181,7 +181,7 @@ class Page
   # Note: it's not for meta keywords, which is a deprecated SEO practice
   def keywords
     # Gracefully falls back to the page's path if no keywords are specified to help reduce technical writer workload
-    front_matter.fetch(:keywords) || @view.request.path.split("/").reject(&:empty?).map { |segment| segment.gsub("-", " ") }.join(", ")
+    front_matter.fetch(:keywords) || keywords_from_path
   end
 
   private
@@ -224,5 +224,9 @@ class Page
     else
       title
     end
+  end
+
+  def keywords_from_path
+    @view.request.path.split("/").reject(&:empty?).map { |segment| segment.gsub("-", " ") }.join(", ")
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -181,7 +181,7 @@ class Page
   # Note: it's not for meta keywords, which is a deprecated SEO practice
   def keywords
     # Gracefully falls back to the page's path if no keywords are specified to help reduce technical writer workload
-    front_matter.fetch(:keywords) || keywords_from_path
+    front_matter.fetch(:keywords, keywords_from_path)
   end
 
   private

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -177,10 +177,11 @@ class Page
     front_matter.fetch(:template, "show")
   end
 
-  # Returns focus keywords to guide content writers with an overview notion of the page
-  # It's not for meta keywords, which is a deprecated practice
+  # Returns focus keywords to guide content writers with an overview of the page content
+  # Note: it's not for meta keywords, which is a deprecated SEO practice
   def keywords
-    front_matter.fetch(:keywords)
+    # Gracefully falls back to the page's path if no keywords are specified to help reduce technical writer workload
+    front_matter.fetch(:keywords) || @view.request.path.split("/").reject(&:empty?).map { |segment| segment.gsub("-", " ") }.join(", ")
   end
 
   private

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -193,7 +193,6 @@ class Page
         "toc": true,
         # Default to H3s being included in the table of contents
         "toc_include_h3": true,
-        "keywords": nil,
       }
       if file.front_matter
         defaults.merge(file.front_matter.symbolize_keys)

--- a/app/views/application/_meta_content.html.erb
+++ b/app/views/application/_meta_content.html.erb
@@ -1,0 +1,3 @@
+<% content_for :page_title, @page.title %>
+<% content_for :page_description, @page.description %>
+<% content_for :keywords, @page.keywords %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <%= render "head" %>
   </head>
-  <body class="<%= beta? ? 'beta' : ''-%>" data-content-keywords="<%= content_keywords %>">
+  <body class="<%= beta? ? 'beta' : ''-%>" data-keywords="<%= content_for :keywords %>">
     <%= render "site_header" %>
 
     <main id="__main" role="main">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <%= render "head" %>
   </head>
-  <body class="<%= beta? ? 'beta' : ''-%>">
+  <body class="<%= beta? ? 'beta' : ''-%>" data-content-keywords="<%= content_keywords %>">
     <%= render "site_header" %>
 
     <main id="__main" role="main">

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -3,7 +3,7 @@
   <head>
     <%= render "head" %>
   </head>
-  <body data-content-keywords="docs">
+  <body data-keywords="docs">
     <%= render "site_header" %>
     <main id="main" role="main">
       <div class="HomePage__container">

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -3,7 +3,7 @@
   <head>
     <%= render "head" %>
   </head>
-  <body>
+  <body data-content-keywords="docs">
     <%= render "site_header" %>
     <main id="main" role="main">
       <div class="HomePage__container">

--- a/app/views/pages/landing_page.html.erb
+++ b/app/views/pages/landing_page.html.erb
@@ -1,6 +1,4 @@
-<% content_for :page_title, @page.title %>
-<% content_for :page_description, @page.description %>
-<% content_for :keywords, @page.keywords %>
+<%= render partial: "meta_content" %>
 
 <div class="Article">
   <%= @page.body %>

--- a/app/views/pages/landing_page.html.erb
+++ b/app/views/pages/landing_page.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, @page.title %>
 <% content_for :page_description, @page.description %>
+<% content_for :keywords, @page.keywords %>
 
 <div class="Article">
   <%= @page.body %>

--- a/app/views/pages/landing_page_pipelines.html.erb
+++ b/app/views/pages/landing_page_pipelines.html.erb
@@ -1,6 +1,4 @@
-<% content_for :page_title, @page.title %>
-<% content_for :page_description, @page.description %>
-<% content_for :keywords, @page.keywords %>
+<%= render partial: "meta_content" %>
 
 <%= render partial: "landing_page_pipelines/hero" %>
 <hr />

--- a/app/views/pages/landing_page_pipelines.html.erb
+++ b/app/views/pages/landing_page_pipelines.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, @page.title %>
 <% content_for :page_description, @page.description %>
+<% content_for :keywords, @page.keywords %>
 
 <%= render partial: "landing_page_pipelines/hero" %>
 <hr />

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, @page.title %>
 <% content_for :page_description, @page.description %>
+<% content_for :keywords, @page.keywords %>
 
 <article class="Article Article--prose">
   <%= @page.body %>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,6 +1,4 @@
-<% content_for :page_title, @page.title %>
-<% content_for :page_description, @page.description %>
-<% content_for :keywords, @page.keywords %>
+<%= render partial: "meta_content" %>
 
 <article class="Article Article--prose">
   <%= @page.body %>

--- a/pages/deployments.md
+++ b/pages/deployments.md
@@ -1,3 +1,7 @@
+---
+keywords: docs, pipelines, deployments
+---
+
 # Deployments with Buildkite
 
 There are many ways to set up both manual and continuous deployment workflows using Buildkite. This covers various ways of architecting deployment pipelines, common workflows, and how to integrate with external deployment systems.

--- a/pages/pipelines.md
+++ b/pages/pipelines.md
@@ -1,3 +1,4 @@
 ---
 template: landing_page_pipelines
+title: Buildkite Pipelines
 ---

--- a/pages/tutorials/2fa.md
+++ b/pages/tutorials/2fa.md
@@ -1,3 +1,7 @@
+---
+keywords: docs, pipelines, tutorials, 2fa
+---
+
 # Two-factor authentication
 
 Two-factor authentication (2FA) can be added to your Buildkite account to provide an additional layer of security and to make sure your builds are safe even if your login credentials are compromised (exposed or stolen).  

--- a/pages/tutorials/bazel.md
+++ b/pages/tutorials/bazel.md
@@ -1,3 +1,7 @@
+---
+keywords: docs, pipelines, tutorials, bazel
+---
+
 # Using Bazel on Buildkite
 
 [Bazel](https://www.bazel.build/) is an open-source build and test tool similar to Make, Maven, and Gradle.

--- a/pages/tutorials/docker_containerized_builds.md
+++ b/pages/tutorials/docker_containerized_builds.md
@@ -1,3 +1,7 @@
+---
+keywords: docs, pipelines, tutorials, docker
+---
+
 # Containerized builds with Docker
 
 Buildkite has built-in support for running your builds in Docker containers. Running your builds with Docker allows each pipeline to define and document its testing environment, greatly simplifying your build servers, and provides build isolation when [parallelizing your build](parallel-builds).

--- a/pages/tutorials/getting_started.md
+++ b/pages/tutorials/getting_started.md
@@ -1,3 +1,7 @@
+---
+keywords: docs, pipelines, tutorials, getting started
+---
+
 # Getting started
 
 👋 Welcome to Buildkite Pipelines! You can use Pipelines to build your dream CI/CD workflows on a secure, scalable, and flexible platform. This tutorial takes you through creating a basic pipeline from an example.

--- a/pages/tutorials/github_merge_queue.md
+++ b/pages/tutorials/github_merge_queue.md
@@ -1,3 +1,7 @@
+---
+keywords: docs, pipelines, tutorials, github merge queues
+---
+
 # Using GitHub merge queues
 
 >🚧 GitHub beta feature

--- a/pages/tutorials/migrating_from_bamboo.md
+++ b/pages/tutorials/migrating_from_bamboo.md
@@ -1,3 +1,7 @@
+---
+keywords: docs, pipelines, tutorials, migration, bamboo
+---
+
 # Migrate from Bamboo
 
 Migrating continuous integration tools can be challenging, so we've put together a guide to help you transition your Bamboo skills to Buildkite.

--- a/pages/tutorials/parallel_builds.md
+++ b/pages/tutorials/parallel_builds.md
@@ -1,3 +1,7 @@
+---
+keywords: docs, pipelines, tutorials, parallel builds
+---
+
 # Parallel builds
 
 Running a build's steps in parallel is a way to decrease your build's total running time. This guide will show you how to use multiple agents and job parallelism to increase the speed of your builds.

--- a/pages/tutorials/pipeline_upgrade.md
+++ b/pages/tutorials/pipeline_upgrade.md
@@ -1,3 +1,7 @@
+---
+keywords: docs, pipelines, tutorials, upgrade to yaml
+---
+
 # Migrating to YAML steps
 
 This guide explains the differences between the web-based editor and the YAML Steps editor, and shows how to migrate your organization's pipelines to YAML Steps.

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -35,9 +35,17 @@ RSpec.describe Page do
   end
 
   describe "#keywords" do
+    let(:view_double) { double("View") }
+    let(:request_double) { double("Request", path: "/apis/agent-api") }
+
+    before do
+      # Stub the request method for the view_double to return request_double
+      allow(view_double).to receive(:request).and_return(request_double)
+    end
+
     context "when page has keywords defined in frontmatter" do
       it "returns the keywords" do
-        page = Page.new(double, "tutorials/2fa")
+        page = Page.new(view_double, "tutorials/2fa")
 
         expect(page.keywords).to eql("docs, pipelines, tutorials, 2fa")
       end
@@ -45,9 +53,9 @@ RSpec.describe Page do
 
     context "when keywords are not defined in frontmatter" do
       it "returns nil" do
-        page = Page.new(double, "apis/agent-api")
+        page = Page.new(view_double, "apis/agent-api")
 
-        expect(page.keywords).to eql(nil)
+        expect(page.keywords).to eql("apis, agent api")
       end
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -33,4 +33,22 @@ RSpec.describe Page do
       end
     end
   end
+
+  describe "#keywords" do
+    context "when page has keywords defined in frontmatter" do
+      it "returns the keywords" do
+        page = Page.new(double, "tutorials/2fa")
+
+        expect(page.keywords).to eql("docs, pipelines, tutorials, 2fa")
+      end
+    end
+
+    context "when keywords are not defined in frontmatter" do
+      it "returns nil" do
+        page = Page.new(double, "apis/agent-api")
+
+        expect(page.keywords).to eql(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Define page focus keywords with the `keywords` front matter meta data.

Render keywords in `data-content-keywords` in the `body` tag to highlight the focus keywords of each page for content authors. This helps the content team to quickly inspect to see the types of content we're providing across different channels.

Use graceful fallback when no keywords have been provided — comma separated URL path segments.
