### PR TITLE
Fix RUM tagging for production image

### DIFF
--- a/.buildkite/push-image.sh
+++ b/.buildkite/push-image.sh
@@ -6,7 +6,7 @@ echo "--- :docker: Building docker image"
 
 TAG="${BUILDKITE_BUILD_NUMBER}"
 
-docker build -t "$ECR_REPO:$TAG" --build-arg="DD_RUM_VERSION=$BUILDKITE_BUILD_NUMBER" .
+docker build -t "$ECR_REPO:$TAG" --build-arg="DD_RUM_VERSION=$BUILDKITE_BUILD_NUMBER" --build-arg="DD_RUM_ENV=production" .
 
 echo "--- :docker: Pushing docker image"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM public.ecr.aws/docker/library/ruby:3.1.4-bullseye@sha256:5bb1b8ce2f236cc264ae2f2664ec226603655b9129bd9442841a91fc6bb32313
 
 ARG RAILS_ENV
-ARG DD_RUM_VERSION="latest"
+ARG DD_RUM_VERSION="unknown"
+ARG DD_RUM_ENV="unknown"
 
+ENV DD_RUM_ENV=${DD_RUM_ENV}
 ENV DD_RUM_VERSION=${DD_RUM_VERSION}
 ENV DD_RUM_ENABLED=true
 ENV RAILS_ENV=${RAILS_ENV:-production}


### PR DESCRIPTION
This fixes the production env from `unknown` to `production`.