### PR TITLE
Fix table of contents selector error

### DIFF
--- a/app/frontend/components/toc.js
+++ b/app/frontend/components/toc.js
@@ -92,7 +92,6 @@ export function initToc() {
   }
 
   const initCurrentLinkListener = () => {
-    drawPath();
     const content = document.querySelector(".Page");
 
     const observer = new IntersectionObserver(

--- a/app/frontend/components/toc.js
+++ b/app/frontend/components/toc.js
@@ -100,6 +100,10 @@ export function initToc() {
           const id = entry.target.getAttribute("id");
 
           const link = document.querySelector(`.Toc__link[href="#${id}"]`);
+          if (!link) {
+            return;
+          }
+
           if (entry.intersectionRatio >= 0.25) {
             link.parentElement.classList.add(visibleClass);
           } else {


### PR DESCRIPTION
This PR fixes a JS console error that pops on when a user navigates to another page. It's caused by the table of contents element no longer existing in the DOM. 