### PR TITLE
Exclude `buildkite.com/docs` from being crawled

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,7 @@ steps:
         sleep 0.5;
       done &&
       echo 💎🛤️🚆 Rails has started running &&
-      /muffet http://app:3000/docs --exclude=https://github.com/buildkite/docs/ --exclude="buildkite.com/docs" --max-connections=10 --color=always
+      /muffet http://app:3000/docs --exclude=https://github.com/buildkite/docs/ --exclude="buildkite.com/docs" --exclude="buildkiteassets" --max-connections=10 --color=always
     env:
       RAILS_ENV: production
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,12 @@ steps:
         sleep 0.5;
       done &&
       echo 💎🛤️🚆 Rails has started running &&
-      /muffet http://app:3000/docs --exclude=https://github.com/buildkite/docs/ --exclude="buildkite.com/docs" --exclude="buildkiteassets" --max-connections=10 --color=always
+      /muffet http://app:3000/docs \
+        --include="/docs/" \
+        --exclude="https://github.com/buildkite/docs/" \
+        --exclude="buildkite.com/docs" \
+        --max-connections=10 \
+        --color=always
     env:
       RAILS_ENV: production
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,7 @@ steps:
         sleep 0.5;
       done &&
       echo 💎🛤️🚆 Rails has started running &&
-      /muffet http://app:3000/docs --include=/docs/ --exclude=https://github.com/buildkite/docs/ --max-connections=10 --color=always
+      /muffet http://app:3000/docs --exclude=https://github.com/buildkite/docs/ --exclude="buildkite.com/docs" --max-connections=10 --color=always
     env:
       RAILS_ENV: production
     plugins:


### PR DESCRIPTION
As of https://github.com/buildkite/docs/pull/2452, all pages now include a canonical link tag with https://buildkite.com. 

An interesting side-effect of that change is that now `muffet` (the link checker we use in CI) [fails builds](https://buildkite.com/buildkite/docs/builds/6596#018a8692-c2dd-42e1-bf9a-b3f7007b2fc0) that add new routes since muffet is unable to find a valid buildkite.com/docs route – since they've yet to be shipped. 

I believe this would classify as a classic 🐔 & 🥚 problem.

This PR excludes `buildkite.com/docs` URLs from the link checker so we get green builds.

/cc @olyism 
