### PR TITLE
Skip pushing GraphQL changes when an existing pull request is open

### DIFF
--- a/.buildkite/update_graphql_docs
+++ b/.buildkite/update_graphql_docs
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+. bin/utils.sh
+
 echo "+++ Fetch latest schema (via GraphQL introspection)"
 rake graphql:fetch_schema >| data/graphql/schema.graphql
 
@@ -12,14 +14,22 @@ fi
 
 echo "+++ Schema changes detected..."
 git --no-pager diff data/graphql/schema.graphql
+git add data/graphql/schema.graphql
+
+echo "-- Checking if existing pull request exists..."
+BRANCH=buildkite-docs-bot/graphql/$(git rev-parse --short :data/graphql/schema.graphql)
+PULL_REQUEST_NUMBER=$(get_branch_pull_request_number $BRANCH)
+
+if [ -n "$PULL_REQUEST_NUMBER" ]; then
+  buildkite-agent annotate  "Nothing to change, pull request [#$PULL_REQUEST_NUMBER](https://github.com/buildkite/docs/pull/$PULL_REQUEST_NUMBER) awaiting approval." --style "info"
+  exit 0
+fi
 
 echo "+++ Generate GraphQL docs"
 ./scripts/generate-graphql-api-content.sh
 
 echo "--- Commit and push changes"
 git add .
-BRANCH=buildkite-docs-bot/graphql/$(git rev-parse --short :data/graphql/schema.graphql)
-
 git config user.email $GIT_EMAIL
 git config user.name $GIT_NAME
 git checkout -b $BRANCH


### PR DESCRIPTION
I'm seeing the automated GraphQL builds [fail](https://buildkite.com/buildkite/docs-graphql/builds/272#018a9107-0bd8-4394-b718-28bfcf9752fa) on subsequent runs when the latest schema changes are yet to be merged.

This PR checks to see if an existing PR is open before progressing.