### PR TITLE
[WIP] Split up some pipelines

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -113,3 +113,10 @@ steps:
         plugins:
           - docker#v3.7.0:
               image: "public.ecr.aws/docker/library/node:lts-alpine3.14"
+
+  - wait
+
+  - label: ":rocket:"
+    trigger: docs-deploy
+    if: build.branch == "main"
+    async: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,6 +117,6 @@ steps:
   - wait
 
   - label: ":rocket:"
-    trigger: docs-deploy
+    trigger: docs-preview
     if: build.branch == "main"
     async: true


### PR DESCRIPTION
I'd like to split up a few Buildkite pipelines and trigger them appropriately to make the docs builds easier to follow.

- [X] Create new [Docs (Preview)](https://buildkite.com/buildkite/docs-preview) pipeline
- [x] Run Docs (Preview) pipeline for PRs
- [ ] ~~Rename Docs (Main) pipeline -> Docs (Deploy) pipeline~~
- [ ] ~~Trigger Docs (Deploy) -> from Docs pipeline – currently they're munged together. ~~

OK not quite as straightforward. Since the public docs pipeline is running in a different cluster I'm unable to trigger builds in the private cluster – makes sense!

I'll leave this current merging of pipelines as-is for now. 