### PR TITLE
Fixed GitHub sync description for plugins page

### DIFF
--- a/pages/plugins/directory.md
+++ b/pages/plugins/directory.md
@@ -14,7 +14,7 @@ To have your plugin appear in the directory:
 1. Host your plugin on GitHub as a public repository.
 1. Ensure your repository contains a valid `plugin.yml` file containing at least the `name` and `description` fields.
 1. Add the `buildkite-plugin` [GitHub repository topic](https://help.github.com/en/github/administering-a-repository/classifying-your-repository-with-topics).
-1. Wait up to 1 hour for the plugins directory to sync with GitHub, and for your plugin to appear.
+1. Wait until the next occuring Sunday UTC for the plugins directory to sync with GitHub, and for your plugin to appear.
 
 For example:
 

--- a/pages/plugins/directory.md
+++ b/pages/plugins/directory.md
@@ -14,7 +14,7 @@ To have your plugin appear in the directory:
 1. Host your plugin on GitHub as a public repository.
 1. Ensure your repository contains a valid `plugin.yml` file containing at least the `name` and `description` fields.
 1. Add the `buildkite-plugin` [GitHub repository topic](https://help.github.com/en/github/administering-a-repository/classifying-your-repository-with-topics).
-1. Wait until the next occuring Sunday (UTC) for the plugins directory to sync with GitHub, and for your plugin to appear.
+1. Wait until the next Sunday (UTC) for the plugins directory to sync with GitHub, and for your plugin to appear.
 
 For example:
 

--- a/pages/plugins/directory.md
+++ b/pages/plugins/directory.md
@@ -14,7 +14,7 @@ To have your plugin appear in the directory:
 1. Host your plugin on GitHub as a public repository.
 1. Ensure your repository contains a valid `plugin.yml` file containing at least the `name` and `description` fields.
 1. Add the `buildkite-plugin` [GitHub repository topic](https://help.github.com/en/github/administering-a-repository/classifying-your-repository-with-topics).
-1. Wait until the next occuring Sunday UTC for the plugins directory to sync with GitHub, and for your plugin to appear.
+1. Wait until the next occuring Sunday (UTC) for the plugins directory to sync with GitHub, and for your plugin to appear.
 
 For example:
 


### PR DESCRIPTION
We changed how often we update the page, it is now each Sunday (UTC) instead of every hour.