### PR TITLE
Add GraphQL Cookbook Mutation for Enforcing 2FA

### DIFF
--- a/pages/apis/graphql/cookbooks/organizations.md
+++ b/pages/apis/graphql/cookbooks/organizations.md
@@ -126,6 +126,27 @@ mutation UpdateSessionIPAddressPinning {
 }
 ```
 
+## Enforce 2FA for your organization
+
+Require users to have 2FA enabled before they can access your organization Buildkite dashboard.
+
+```graphql
+mutation EnableEnforced2FA {
+  organizationEnforceTwoFactorAuthenticationForMembersUpdate(
+    input: {
+      organizationId: "organization-id",
+      membersRequireTwoFactorAuthentication: true
+    }
+  ) {
+    organization {
+      id
+      membersRequireTwoFactorAuthentication
+      uuid
+    }
+  }
+}
+```
+
 ## Query the usage API
 
 Use the usage API to query your organization's usage by pipeline or test suite at daily granularity.


### PR DESCRIPTION
Enforce 2FA has now gone GA, and will be publicised in the upcoming release event. 
We can add some additional documentation around the GraphQL Mutation to enable the flag programmatically. 
This PR adds a snippet to the GraphQL cookbook.

- 📝  [Internal Release Notes](https://docs.google.com/document/d/1yFG7MGF97OOPOipsRG5JO-_WpxOAaDbFAuRiAzGSQ4U/edit)
- :basecamp: [Project Thread](https://3.basecamp.com/3453178/buckets/23328660/messages/6543585015)
- View the new docs on the preview here: https://2480--bk-docs-preview.netlify.app/docs/apis/graphql/cookbooks/organizations#enforce-2fa-for-your-organization