### PR TITLE
Fixed Aqua session type section for macOS

### DIFF
--- a/pages/agent/v3/elastic_ci_stack_for_ec2_mac/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_stack_for_ec2_mac/troubleshooting.md
@@ -21,7 +21,7 @@ configuration has a *License type* of `Cores`.
 ## My instances don't start the `buildkite-agent`
 
 Ensure your AMI has been [configured to auto-login as the `ec2-user`](/docs/agent/v3/elastic-ci-stack-for-ec2-mac/autoscaling-mac-metal#step-2-build-an-ami)
-in the GUI. 
+in the GUI.
 
 ## How do I enable use of Xcode and the iOS Simulator?
 

--- a/pages/agent/v3/elastic_ci_stack_for_ec2_mac/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_stack_for_ec2_mac/troubleshooting.md
@@ -21,9 +21,11 @@ configuration has a *License type* of `Cores`.
 ## My instances don't start the `buildkite-agent`
 
 Ensure your AMI has been [configured to auto-login as the `ec2-user`](/docs/agent/v3/elastic-ci-stack-for-ec2-mac/autoscaling-mac-metal#step-2-build-an-ami)
-in the GUI. To allow your pipelines to use Xcode and the iOS Simulator the
+in the GUI. 
 
-Buildkite Agent launchd job configuration requires an `Aqua` session type.
+## How do I enable use of Xcode and the iOS Simulator?
+
+To allow your pipelines to use Xcode and the iOS Simulator the Buildkite Agent launchd job configuration requires an `Aqua` session type.
 
 ## What user does the agent run as?
 


### PR DESCRIPTION
The Aqua session type section was broken, so I added a correct header and fixed up the formatting, as well as made it more obvious.