### PR TITLE
Inform of custom emoji support

### DIFF
--- a/pages/agent/v3/help/_annotate.md
+++ b/pages/agent/v3/help/_annotate.md
@@ -30,7 +30,7 @@ Annotations are written in CommonMark-compliant Markdown, with &quot;GitHub
 Flavored Markdown&quot; extensions.
 
 The annotation body can be supplied as a command line argument, or by piping
-content into the command. Custom Buildkite [emojis](https://buildkite.com/docs/pipelines/emojis) are supported. The maximum size of each annotation body is 1MiB.
+content into the command. Custom Buildkite [emojis](/docs/pipelines/emojis) are supported. The maximum size of each annotation body is 1MiB.
 
 You can update an existing annotation&#39;s body by running the annotate command
 again and provide the same context as the one you want to update. Or if you

--- a/pages/agent/v3/help/_annotate.md
+++ b/pages/agent/v3/help/_annotate.md
@@ -30,7 +30,7 @@ Annotations are written in CommonMark-compliant Markdown, with &quot;GitHub
 Flavored Markdown&quot; extensions.
 
 The annotation body can be supplied as a command line argument, or by piping
-content into the command. The maximum size of each annotation body is 1MiB.
+content into the command. Custom Buildkite [emojis](https://buildkite.com/docs/pipelines/emojis) are supported. The maximum size of each annotation body is 1MiB.
 
 You can update an existing annotation&#39;s body by running the annotate command
 again and provide the same context as the one you want to update. Or if you
@@ -46,6 +46,7 @@ $ buildkite-agent annotate "All tests passed! :rocket:"
 $ cat annotation.md | buildkite-agent annotate --style "warning"
 $ buildkite-agent annotate --style "success" --context "junit"
 $ ./script/dynamic_annotation_generator | buildkite-agent annotate --style "success"
+$ buildkite-agent annotate ":one-does-not-simply: Green builds are coming." --style "success"
 ```
 
 ### Options


### PR DESCRIPTION
A user asked if Buildkite custom emojis can be used in annotations; they can.

This just makes that a little clearer as there isn't any other mention of using custom emojis in the docs that I can find.