### PR TITLE
Blocked build webhook event wording touchup

### DIFF
--- a/pages/apis/webhooks/build_events.md
+++ b/pages/apis/webhooks/build_events.md
@@ -58,7 +58,7 @@ Example request body:
 ```
 ## Finding out if a build is blocked
 
-To if a build is blocked, look for `blocked: true` in the `build.finished` event
+If a build is blocked, look for `blocked: true` in the `build.finished` event
 
 Example request body for blocked build:
 


### PR DESCRIPTION
Added a small tweak to the wording of blocked build webhook events (with `build.blocked` in the payload)

"To if a build..." -> "If a build is blocked" 