### PR TITLE
Changing TA run issues private beta notice to beta

### DIFF
--- a/pages/test_analytics/test_suites.md
+++ b/pages/test_analytics/test_suites.md
@@ -37,8 +37,8 @@ Test Analytics reviews the test results to detect flaky tests after every test r
 
 ## Run issues
 
->🛠 Currently in private beta
-> This feature is currently in private beta. If you would like to request access to Run issues, [contact us here](mailto:support@buildite.com)
+>🛠 Beta feature
+> The run issues feature is currently in public beta and subject to change.
 
 <%= image "run-issues.png", alt: "Screenshot of a run with issues displaying in a list, including flaky, slow and failures." %>
 


### PR DESCRIPTION
Now that the run issues has moved out of private beta, we need to update the docs to say 'Beta' instead

<img width="771" alt="Screenshot 2023-09-28 at 2 50 22 PM" src="https://github.com/buildkite/docs/assets/25017977/2c969ce2-a992-437e-9ffe-36dad278fba9">
