### PR TITLE
Update README for generating GraphQL docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ With the development dependencies installed you can update the CLI docs using
 PATH="$HOME/Projects/buildkite/agent:$PATH" ./scripts/update-agent-help.sh
 ```
 
+
+## Updating GraphQL API docs
+
+GraphQL API documentation is generated from a local version of the [Buildkite GraphQL API schema](./data/graphql/schema.graphql).
+
+This repository is kept up-to-date with production based on a [daily scheduled build](https://buildkite.com/buildkite/docs-graphql). The build fetches the latest GraphQL schema, generates the documentation, and publishes a pull request for review.
+
+If you need to fetch the latest schema you can either:
+
+- Manually trigger a build on [`buildkite/docs-graphql`](https://buildkite.com/buildkite/docs-graphql); or
+- Run the following in your local environment:
+
+```sh
+# Fetch latest schema
+API_ACCESS_TOKEN=xxx rake graphql:fetch_schema >| data/graphql/schema.graphql
+
+# Generate docs based on latest schema
+./scripts/generate-graphql-api-content.sh
+```
+
+
 ## Linting
 
 We spell-check the docs (American English) and run a few automated checks for repeated words, common errors, and markdown and filename inconsistencies.

--- a/README.md
+++ b/README.md
@@ -116,9 +116,6 @@ To test changes to the indexing configuration:
 
 2. Run `bundle exec rake update_test_index`.
 
-## License
-
-See [LICENSE.md](LICENSE.md) (MIT)
 
 ## Updating the navigation
 
@@ -149,3 +146,8 @@ keywords: docs, tutorial, pipelines, 2fa
 ```
 
 If no keywords are provided it falls back to comma-separated URL path segments.
+
+
+## License
+
+See [LICENSE.md](LICENSE.md) (MIT)

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ or use [`rbenv`](https://github.com/rbenv/rbenv) to automatically select the cor
 Open `http://localhost:3000` to preview the docs site.
 After modifying a page, refresh to see your changes.
 
-## Updating buildkite-agent CLI Docs
+## Updating `buildkite-agent` CLI docs
 
-With the development dependencies installed you can update the CLI docs using
-`scripts/update-agent-help.sh`:
+With the development dependencies installed you can update the CLI docs with the following:
+
 
 ```bash
 # Set a custom PATH to select a locally built buildkite-agent

--- a/styleguide/STYLE.md
+++ b/styleguide/STYLE.md
@@ -484,14 +484,3 @@ Steps for adding add an image to a documentation page:
 3. Compose relevant alt text for the image file using sentence case
 4. Add your image file to the documentation page using the following code example `<%= image "your-image.png", width: 1110, height: 1110, alt: "Screenshot of Important Feature" %>`.
 For large images/screenshots taken on a retina screen, use `<%= image "your-image.png", width: 1110/2, height: 1110/2, alt: "Screenshot of Important Feature" %>`.
-
-## GraphQL API schemas
-
-There are over 300 GraphQL API schema pages and they are manually generated with a shell script.
-When there are changes to the API, we can update them with these steps:
-
-1. Starting from the [`buildkite/buildkite`](https://github.com/buildkite/buildkite) repo, pull the latest changes into the `main` branch
-2. Build the schema by running `rails api:graph:export`. The latest schema can be found in `frontend/app/graph/schema.json`
-3. Go back to [`buildkite/docs`](https://github.com/buildkite/docs) and replace `data/graphql_data_schema.json`'s content with the latest schema
-4. Run the script `./scripts/generate-graphql-api-content.sh`. This will generate and update all the schema pages under `pages/apis/graphql/schemas/`
-5. Stage and commit these changes


### PR DESCRIPTION
Based on https://github.com/buildkite/docs/pull/2479, I noted we're missing up-to-date documentation on the process for generating GraphQL API docs.

Hopefully this is a little easier to follow @jonathanly. 