### PR TITLE
add docs on potential conflicting gems with the collector

### DIFF
--- a/pages/test_analytics/ruby_collectors.md
+++ b/pages/test_analytics/ruby_collectors.md
@@ -32,7 +32,7 @@ Before you start, make sure RSpec runs with access to [CI environment variables]
     bundle
     ```
 
-3. Add the Test Analytics code to your application in `spec/spec_helper.rb`, and set the BUILDKITE_ANALYTICS_TOKEN [securely](/docs/pipelines/secrets) on your agent or agents. Please ensure gems that patch `Net::HTTP` like `httplog` and `sniffer` are required before `buildkite/test_collector` to avoid conflicts.
+3. Add the Test Analytics code to your application in `spec/spec_helper.rb`, and set the BUILDKITE_ANALYTICS_TOKEN [securely](/docs/pipelines/secrets) on your agent or agents. Please ensure gems that patch `Net::HTTP`, like [httplog](https://github.com/trusche/httplog) and [sniffer](https://github.com/aderyabin/sniffer), are required before `buildkite/test_collector` to avoid conflicts.
 
     ```rb
     require "buildkite/test_collector"
@@ -89,7 +89,7 @@ If you're already using minitest for your tests, add the `buildkite-test_collect
     bundle
     ```
 
-3. Add the Test Analytics code to your application in `test/test_helper.rb`, and set the BUILDKITE_ANALYTICS_TOKEN [securely](/docs/pipelines/secrets) on your agent or agents. Please ensure gems that patch `Net::HTTP` like `httplog` and `sniffer` are required before `buildkite/test_collector` to avoid conflicts.
+3. Add the Test Analytics code to your application in `test/test_helper.rb`, and set the BUILDKITE_ANALYTICS_TOKEN [securely](/docs/pipelines/secrets) on your agent or agents. Please ensure gems that patch `Net::HTTP`, like [httplog](https://github.com/trusche/httplog) and [sniffer](https://github.com/aderyabin/sniffer), are required before `buildkite/test_collector` to avoid conflicts.
 
     ```rb
     require "buildkite/test_collector"

--- a/pages/test_analytics/ruby_collectors.md
+++ b/pages/test_analytics/ruby_collectors.md
@@ -32,7 +32,7 @@ Before you start, make sure RSpec runs with access to [CI environment variables]
     bundle
     ```
 
-3. Add the Test Analytics code to your application in `spec/spec_helper.rb`, and set the BUILDKITE_ANALYTICS_TOKEN [securely](/docs/pipelines/secrets) on your agent or agents.
+3. Add the Test Analytics code to your application in `spec/spec_helper.rb`, and set the BUILDKITE_ANALYTICS_TOKEN [securely](/docs/pipelines/secrets) on your agent or agents. Please ensure gems that patch `Net::HTTP` like `httplog` and `sniffer` are required before `buildkite/test_collector` to avoid conflicts.
 
     ```rb
     require "buildkite/test_collector"
@@ -89,7 +89,7 @@ If you're already using minitest for your tests, add the `buildkite-test_collect
     bundle
     ```
 
-3. Add the Test Analytics code to your application in `test/test_helper.rb`, and set the BUILDKITE_ANALYTICS_TOKEN [securely](/docs/pipelines/secrets) on your agent or agents.
+3. Add the Test Analytics code to your application in `test/test_helper.rb`, and set the BUILDKITE_ANALYTICS_TOKEN [securely](/docs/pipelines/secrets) on your agent or agents. Please ensure gems that patch `Net::HTTP` like `httplog` and `sniffer` are required before `buildkite/test_collector` to avoid conflicts.
 
     ```rb
     require "buildkite/test_collector"

--- a/vale/styles/vocab.txt
+++ b/vale/styles/vocab.txt
@@ -117,6 +117,7 @@ gzipped
 heroku
 hostname
 http
+httplog
 https
 inlining
 IPs


### PR DESCRIPTION
Adding a small note to the ruby collectors to require potential conflicting gems before the TA test collector gem

Investigation and write up in [Basecamp](https://3.basecamp.com/3453178/buckets/20365997/messages/5825135697#__recording_5840767340) 
[Resolved Github issue](https://github.com/buildkite/test-collector-ruby/issues/169#issuecomment-1430799917)