### PR TITLE
Add Playwright section to Javascript Collectors page

### DIFF
--- a/pages/test_analytics.md
+++ b/pages/test_analytics.md
@@ -22,8 +22,9 @@ Test Analytics helps you track and analyze the steps in that pipeline that invol
   <%= button ":rspec: RSpec", "/docs/test-analytics/ruby-collectors#rspec-collector" %>
   <%= button ":ruby: minitest", "/docs/test-analytics/ruby-collectors#minitest-collector" %>
   <%= button ":jest: Jest", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-jest" %>
-  <%= button ":mocha: Mocha", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-mocha-collector" %>
-  <%= button ":jasmine: Jasmine", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-jasmine-collector" %>
+  <%= button ":mocha: Mocha", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-mocha" %>
+  <%= button ":jasmine: Jasmine", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-jasmine" %>
+  <%= button ":playwright: Playwright", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-playwright" %>
   <%= button ":swift: Swift", "/docs/test-analytics/swift-collectors" %>
   <%= button ":android: Android", "/docs/test-analytics/android-collectors" %>
   <%= button ":pytest: pytest", "/docs/test-analytics/python-collectors" %>

--- a/pages/test_analytics/javascript_collectors.md
+++ b/pages/test_analytics/javascript_collectors.md
@@ -5,6 +5,7 @@ To use Test Analytics with your JavaScript (npm) projects, use the :github: [`te
 - [Jest](https://jestjs.io/)
 - [Jasmine](https://jasmine.github.io/)
 - [Mocha](https://mochajs.org/)
+- [Playwright](https://playwright.dev)
 
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
 
@@ -44,7 +45,7 @@ With the test collector installed, you need to configure it in the test framewor
 
 ### Jest
 
-If you're already using Jest, you can add `buildkite-collector/jest/reporter` to the list of reporters to collect test results into your Test Analytics dashboard.
+If you're already using Jest, you can add `buildkite-test-collector/jest/reporter` to the list of reporters to collect test results into your Test Analytics dashboard.
 
 To configure Jest:
 
@@ -57,7 +58,7 @@ To configure Jest:
     }
     ```
 
-### Jasmine collector
+### Jasmine
 
 To configure Jasmine:
 
@@ -80,7 +81,7 @@ To configure Jasmine:
     });
     ```
 
-### Mocha collector
+### Mocha
 
 To configure Mocha:
 
@@ -117,6 +118,25 @@ To configure Mocha:
       "buildkiteTestCollectorMochaReporterReporterOptions": {
         "token_name": "CUSTOM_ENV_VAR_NAME"
       }
+    }
+    ```
+
+### Playwright
+
+If you're already using Playwright, you can add `buildkite-test-collector/playright/reporter` to the list of reporters to collect test results into your Test Analytics dashboard.
+
+To configure Playwright:
+
+1. Make sure Playwright runs with access to [CI environment variables](/docs/test-analytics/ci-environments).
+1. Add `"buildkite-test-collector/playwright/reporter"` to [Playwright's `reporters` configuration array](https://playwright.dev/docs/test-reporters#multiple-reporters) (typically found in `playwright.config.js`):
+
+    ```js
+    // playwright.config.js
+    {
+      "reporters": [
+        ["line"], 
+        ["buildkite-test-collector/playwright/reporter"]
+      ]
     }
     ```
 


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
We have added Playwright support to our [JavaScript test collector](https://github.com/buildkite/test-collector-javascript). This PR adds an instruction to configure test collector with Playwright in JavaScript collectors page.

### Context

<!--
Link to a Linear ticket/Basecamp post.
-->
https://linear.app/buildkite/issue/PIE-2029
https://github.com/buildkite/test-collector-javascript/pull/72

### Verification

<!--
- How will we be able to assert that this change was successful?
- Is there a relevant Datadog dashboard to watch?
-->
<img width="1323" alt="Screenshot 2023-10-06 at 2 06 33 PM" src="https://github.com/buildkite/docs/assets/21911472/54ceaf66-493f-483d-99fa-ee2d36e230d2">
<img width="1323" alt="Screenshot 2023-10-06 at 2 06 40 PM" src="https://github.com/buildkite/docs/assets/21911472/d21ffeaa-af55-46cb-9a26-a6920af7bcbe">



### Deployment

<!--
- What is the level of risk associated with this change?
- Does that level of risk necessitate any deployment considerations, such as merging at a low-traffic time?
- Does this PR need to be deployed in sequence with any others?
- Does this PR contain migrations?
-->
We need to release this after we release [buildkite-test-collector v1.6.0](https://github.com/buildkite/test-collector-javascript/pull/76)
