### PR TITLE
Upgrade from debian 11 (bullseye) to debian 12 (bookworm)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/ruby:3.1.4-bullseye@sha256:ed0c89268a61c596de5952afa0440a65e9e51d3d8691d6e62b1382026cacacbd
+FROM public.ecr.aws/docker/library/ruby:3.1.4-bookworm@sha256:ce07ca486ea1589cdbc3df60a554c595b10a792e9a61a0363977d42e9de20726
 
 ARG RAILS_ENV
 ARG DD_RUM_VERSION="unknown"


### PR DESCRIPTION
[Debian 12 was released in June 2023](https://wiki.debian.org/DebianBookworm) and has a range of package updates. The vast majority will not be significant in the context of the docs app and should have no impact on the app behaviour.

Updating is useful though, mainly just so we don't fall behind. It will also avoid some CVEs being detected by scanning software.

The critical CVE doesn't impact us, but here's the details: [CVE-2023-38408](https://security-tracker.debian.org/tracker/CVE-2023-38408).

![2023-10-09_10-02](https://github.com/buildkite/docs/assets/8132/bc5b9be5-bda8-455a-afe4-39bdb8620442)

The CVE is also fixed in bullseye so this upgrade isn't technically required, we could also install security packages . I reckon the OS bump is worth or for other reasons though. 

![2023-10-09_10-06](https://github.com/buildkite/docs/assets/8132/13770299-bdc0-4ade-8e41-df8af2a3f3ef)

/cc @buildkite/platform 