### PR TITLE
Fetch security upgrades from apt [PLT-1607]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN echo "--- :package: Installing system deps" \
     # Install all the things
     && apt-get update \
     && apt-get install -y nodejs gh jq \
+    ## Pull down security updates
+    && apt-get upgrade -y \
     # Upgrade rubygems and bundler
     && gem update --system \
     && gem install bundler \


### PR DESCRIPTION
In #2517 I upgrade docs frm debian 11 to 12, but I was surprised to see that CVE-2023-38408 is sitll being detected post-upgrade.

I think it's because the patched openssh is available in the debian security repositories. If so, adding this upgrade should fetch them.

/cc @buildkite/platform 