### PR TITLE
Ignore many CVEs

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -31,6 +31,7 @@ steps:
             - CVE-2021-3847 # linux 6.1.55-1
             - CVE-2023-35827 # linux 6.1.55-1
             - CVE-2023-2953 # openldap 2.5.13+dfsg-5
+            - CVE-2023-31484 # perl 5.36.0-7
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying

--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -29,6 +29,7 @@ steps:
             - CVE-2019-19814 # linux 6.1.55-1
             - CVE-2019-19449 # linux 6.1.55-1
             - CVE-2021-3847 # linux 6.1.55-1
+            - CVE-2023-35827 # linux 6.1.55-1
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying

--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -30,6 +30,7 @@ steps:
             - CVE-2019-19449 # linux 6.1.55-1
             - CVE-2021-3847 # linux 6.1.55-1
             - CVE-2023-35827 # linux 6.1.55-1
+            - CVE-2023-2953 # openldap 2.5.13+dfsg-5
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying

--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -21,6 +21,8 @@ steps:
     plugins:
       - buildkite/ecr-scan-results#v1.2.0:
           image-name: "${ECR_REPO}:${BUILDKITE_BUILD_NUMBER}"
+          ignore:
+            - CVE-2023-29007 # git 1:2.39.2-1.1
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying

--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -32,6 +32,7 @@ steps:
             - CVE-2023-35827 # linux 6.1.55-1
             - CVE-2023-2953 # openldap 2.5.13+dfsg-5
             - CVE-2023-31484 # perl 5.36.0-7
+            - CVE-2023-24329 # python3.11 3.11.2-6
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying

--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -33,6 +33,7 @@ steps:
             - CVE-2023-2953 # openldap 2.5.13+dfsg-5
             - CVE-2023-31484 # perl 5.36.0-7
             - CVE-2023-24329 # python3.11 3.11.2-6
+            - CVE-2023-3640 # linux 6.1.55-1
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying

--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -28,6 +28,7 @@ steps:
             - CVE-2013-7445 # linux 6.1.55-1
             - CVE-2019-19814 # linux 6.1.55-1
             - CVE-2019-19449 # linux 6.1.55-1
+            - CVE-2021-3847 # linux 6.1.55-1
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying

--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -25,6 +25,7 @@ steps:
             - CVE-2023-29007 # git 1:2.39.2-1.1
             - CVE-2023-25652 # git 1:2.39.2-1.1
             - CVE-2021-3864 # linux 6.1.55-1
+            - CVE-2013-7445 # linux 6.1.55-1
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying

--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -23,6 +23,7 @@ steps:
           image-name: "${ECR_REPO}:${BUILDKITE_BUILD_NUMBER}"
           ignore:
             - CVE-2023-29007 # git 1:2.39.2-1.1
+            - CVE-2023-25652 # git 1:2.39.2-1.1
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying

--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -24,6 +24,7 @@ steps:
           ignore:
             - CVE-2023-29007 # git 1:2.39.2-1.1
             - CVE-2023-25652 # git 1:2.39.2-1.1
+            - CVE-2021-3864 # linux 6.1.55-1
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying

--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -26,6 +26,8 @@ steps:
             - CVE-2023-25652 # git 1:2.39.2-1.1
             - CVE-2021-3864 # linux 6.1.55-1
             - CVE-2013-7445 # linux 6.1.55-1
+            - CVE-2019-19814 # linux 6.1.55-1
+            - CVE-2019-19449 # linux 6.1.55-1
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying


### PR DESCRIPTION
These CVEs have been assessed individually and all deemed safe to ignore. Best to view each commit for the justification behind each.