### PR TITLE
Signed pipelines guide docs

### DIFF
--- a/data/nav.yml
+++ b/data/nav.yml
@@ -84,6 +84,8 @@
           path: "agent/v3/prioritization"
         - name: "Securing"
           path: "agent/v3/securing"
+        - name: "Signed pipelines"
+          path: "agent/v3/signed-pipelines"
         - name: "Tokens"
           path: "agent/v3/tokens"
         - name: "Tracing"

--- a/pages/agent/v3/securing.md
+++ b/pages/agent/v3/securing.md
@@ -120,7 +120,7 @@ But also remember that some [environment variables may be essential](/docs/pipel
 
 ## Signing pipelines
 
-If using plugins is crucial to your workflow and you would still like to preserve strong security guarantees, take a look at the [buildkite-signed-pipeline](https://github.com/buildkite/buildkite-signed-pipeline) tool. This tool allows uploaded steps to be signed with a secret shared by all agents, so that plugins can run without concerns of tampering by third parties.
+You can sign the steps your pipeline runs for extra security. This allows the agent to verify that the steps it runs haven't been tampered with or smuggled from one pipeline to another. For more information, see [Signed pipelines](/docs/agent/v3/signed-pipelines).
 
 ## Allowing a list of plugins
 

--- a/pages/agent/v3/signed_pipelines.md
+++ b/pages/agent/v3/signed_pipelines.md
@@ -1,0 +1,153 @@
+# Signed pipelines
+
+> 🚧 Experimental feature
+> Signed pipelines are experimental, and these docs (and the commands and arguments referenced in them) are subject to change. This is also an opt-in feature, so if you'd like to try using signed pipelines, reach out to [support](https://buildkite.com/support).
+
+Signed pipelines are a security feature where pipelines are cryptographically signed when uploaded to Buildkite. Agents then verify the signature before running the job. If an agent detects a signature mismatch, it'll refuse to run the job.
+
+Maintaining a strong security boundary is important to Buildkite and informs how we design features. It's also a key reason people choose Buildkite over other CI/CD tools. Signing pipelines improves your security posture by ensuring agents don't run jobs where a malicious actor has modified the instructions. This moves you towards zero-trust CI/CD by further isolating you from Buildkite itself being compromised.
+
+The signature guarantees the origin of jobs by asserting:
+
+- The jobs were uploaded from a trusted source.
+- The jobs haven't been modified after upload.
+
+These signatures mean that if a threat actor could modify a job in flight, the agent would refuse to run it due to mismatched signatures.
+
+<details>
+  <summary>🤔 I think I've seen this before...</summary>
+  <p>This work is inspired by the <a href="https://github.com/buildkite/buildkite-signed-pipeline"><code>buildkite-signed-pipeline</code></a> tool, which you could add to your agent instances. It had a similar idea—signing steps before they're uploaded to Buildkite, then verifying them when they're run. However, it had some limitations, including:</p>
+  <ul>
+    <li>It had to be installed on every agent instance, leading to more configuration.</li>
+    <li>It only supported symmetric HS256 signatures, meaning that every verifier could also sign uploads.</li>
+    <li>It couldn't sign <a href="/docs/pipelines/build-matrix">matrix steps</a>.</li>
+  </ul>
+  <p>This newer version of pipeline signing is built right into the agent and addresses all of these limitations. Being built into the agent, it's also easier to configure and use.</p>
+  <p>Many thanks to <a href="https://www.seek.com.au/">SEEK</a>, who we collaborated with on the older version of the tool, and whose prior art has been instrumental in the development of this newer version.</p>
+</details>
+
+## Pipeline signatures
+
+Pipeline signatures establish that important aspects of steps haven't been changed since they were uploaded.
+
+The following fields are included in the signature for each step:
+
+- **Commands.**
+- **Environment variables defined in the pipeline YAML.** Environment variables set by the agent, hooks, or the user's shell are _not_ signed, and can override the environment a step's command is started with.
+- **Plugins and plugin configuration.**
+- **Matrix configuration.** The matrix configuration is signed as a whole rather than each individual matrix job. This means the signature is the same for each job in the matrix. When signatures are verified for matrix jobs, the agent double-checks that the job it received is a valid construction of the matrix and that the signature matches the matrix configuration.
+- **The repository the commands are running in.** This prevents you from copying a signed step from one repository to another.
+
+## Enabling signed pipelines on your agents
+
+You'll need to configure your agents and update pipeline definitions to enable signed pipelines.
+
+### 1. Generate a key pair
+
+Behind the scenes, signed pipelines use [JSON Web Signing (JWS)](https://datatracker.ietf.org/doc/html/rfc7797) to generate signatures. You'll need to generate a [JSON Web Key Set (JWKS)](https://datatracker.ietf.org/doc/html/rfc7517) to sign and verify your pipelines with, then configure your agents to use those keys.
+
+Luckily, the agent has you covered! A JWKS generation tool is built into the agent, which you can use to generate a key pair. To use it, you'll need to [install the agent on your machine](/docs/agent/v3/installation), and then run:
+
+```bash
+buildkite-agent tool keygen --alg <algorithm> --key-id <key-id>
+```
+
+Replacing the following:
+
+- `<algorithm>` with the signing algorithm you want to use.
+- `<key-id>` with the key ID you want to use.
+
+For example, to generate an [EdDSA](https://en.wikipedia.org/wiki/EdDSA) key pair with a key ID of `my-key-id`, you'd run:
+
+```bash
+buildkite-agent tool keygen --alg EdDSA --key-id my-key-id
+```
+
+The agent generates a JWKS key pair in your current directory: one private and one public. You can then use these keys to sign and verify your pipelines.
+
+If no key ID is provided, the agent will generate a random one for you.
+
+Note that the value of `--alg` must be a valid [JSON Web Signing Algorithm](https://datatracker.ietf.org/doc/html/rfc7518#section-3). The agent does not support the `none` algorithm, or any signature algorithms in the `RS` series (any signing algorithms that use RSASSA-PKCS1 v1.5 signatures, `RS256` for example).
+
+<details>
+  <summary>Why doesn't the agent support RSASSA-PKCS1 v1.5 signatures?</summary>
+  <p>In short, RSASSA-PKCS1 v1.5 signatures are less secure than the newer RSA-PSS signatures. While RSASSA-PKCS1 v1.5 signatures are still relatively secure, we want to encourage our users to use the most secure algorithms possible, so when using RSA keys, we only support RSA-PSS signatures. We also recommend looking into ECDSA and EdDSA signatures, which are more secure than RSA signatures.</p>
+</details>
+
+#### Algorithm options
+
+Signed pipelines support many different signing algorithms, which you can simplify into two categories:
+
+- **Symmetric**—where signing and verification use the same keys.
+- **Asymmetric**—where signing and verification use different keys.
+
+We recommend using an asymmetric signing algorithm, as it creates a permissions boundary between the agents that upload and sign pipelines, and agents that run other jobs and can verify signatures. This means that if an attacker compromises an agent with verification keys, they can't modify the steps without detection.
+
+When using asymmetric signing algorithms, we recommend having multiple disjoint pools of agents, each using a different [queue](/docs/agent/v3/queues). One pool should be the _uploaders_ and have access to the private keys. Another pool should be the _runners_ and have access to the public keys. This creates a security boundary between the agents that upload and sign pipelines and the agents that run jobs and verify signatures.
+
+Regarding your specific algorithm choice, any of the supported asymmetric signing algorithms are fine and will be secure. If you're not sure which one to use, `EdDSA` is proven to be secure, has a modern design, wasn't designed by a Nation State Actor, and produces nice short signatures.
+
+For more information on what algorithms the agent supports, run:
+
+```sh
+buildkite-agent tool keygen --help
+```
+
+### 2. Configure the agents
+
+Next, you need to configure your agents to use the keys you generated. On agents that upload pipelines, add the following to the agent's config file:
+
+```ini
+signing-jwks-file=<path to private key set>
+signing-jwks-key-id=<the key id you generated earlier>
+verification-jwks-file=<path to public key set>
+```
+
+This ensures that whenever those agents upload steps to Buildkite, they'll generate signatures using the private key you generated earlier. It also ensures that those agents verify the signatures of any steps they run, using the public key.
+
+On instances that verify jobs, add:
+
+```ini
+verification-jwks-file=<path to verification keys>
+```
+
+### 3. Sign all steps
+
+So far, you've configured agents to sign and verify any steps they upload and run. However, you also define steps in a pipeline's settings through the Buildkite dashboard. For example, teams commonly use a single step in the Buildkite dashboard to upload a pipeline definition from [a YAML file in the repository](/docs/pipelines/defining-steps#step-defaults-pipeline-dot-yml-file). These steps should also be signed.
+
+> 🚧 Non-YAML steps
+> You must use YAML to sign steps configured in the Buildkite dashboard. If you don't use YAML, you'll need to [migrate to YAML steps](/docs/tutorials/pipeline_upgrade) before continuing.
+
+To sign steps configured in the Buildkite dashboard, you need to add static signatures to the YAML. To do this, run:
+
+```sh
+buildkite-agent tool sign \
+  --graphql-token <token> \
+  --jwks-file <path to signing jwks> \
+  --jwks-key-id <signing key id> \
+  --organization-slug <org slug> \
+  --pipeline-slug <pipeline slug> \
+  --update
+```
+
+Replacing the following:
+
+- `<token>` with a Buildkite GraphQL token that has the `write_pipelines` scope.
+- `<path to signing jwks>` with the path to the private key set you generated earlier.
+- `<signing key id>` with the key ID from earlier.
+- `<org slug>` with the slug of the organization the pipeline is in.
+- `<pipeline slug>` with the slug of the pipeline you want to sign.
+
+This will download the pipeline definition using the Buildkite GraphQL API, sign all steps, and upload the signed pipeline definition back to Buildkite.
+
+## Rotating signing keys
+
+Regularly rotating signing and verification keys is good security practice, as it reduces the impact of a compromised key. Because signed pipelines use JWKS as their key format, rotating keys is easy.
+
+To rotate your keys:
+
+1. [Generate a new key pair](#enabling-signed-pipelines-on-your-agents-1-generate-a-key-pair).
+1. Add the new keys to your existing key sets. Be careful not to mix public and private keys.
+1. Update the `signing-key-id` on your signing agents to use the new key ID.
+
+The verifying agents will automatically use the public key with the matching key ID, if it's present.

--- a/pages/agent/v3/signed_pipelines.md
+++ b/pages/agent/v3/signed_pipelines.md
@@ -1,8 +1,5 @@
 # Signed pipelines
 
-> 🚧 Experimental feature
-> Signed pipelines are experimental, and these docs (and the commands and arguments referenced in them) are subject to change. This is also an opt-in feature, so if you'd like to try using signed pipelines, reach out to [support](https://buildkite.com/support).
-
 Signed pipelines are a security feature where pipelines are cryptographically signed when uploaded to Buildkite. Agents then verify the signature before running the job. If an agent detects a signature mismatch, it'll refuse to run the job.
 
 Maintaining a strong security boundary is important to Buildkite and informs how we design features. It's also a key reason people choose Buildkite over other CI/CD tools. Signing pipelines improves your security posture by ensuring agents don't run jobs where a malicious actor has modified the instructions. This moves you towards zero-trust CI/CD by further isolating you from Buildkite itself being compromised.

--- a/pages/apis/rest_api/builds.md
+++ b/pages/apis/rest_api/builds.md
@@ -92,8 +92,8 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
         "step": {
           "id": "018c0f56-c87c-47e9-95ee-aa47397b4496",
           "signature": {
-            "value": "eyJhbGciOiJFUzI1NiIsImtpZCI6InlvdSBzbHkgZG9nISB5b3UgY2F1Z2h0IG1lIG1vbm9sb2d1aW5nISJ9..gcmV8TgY6MfAXRbD_7kyuB3JAQMH-0th5E1MmQn5ND34bEs-zNBZ3tLi6w2e_gvfqL6C1kxRhOQzAwEZMQlo5w",
-            "algorithm": "HS512",
+            "value": "eyJhbGciOiJFUzI1NiIsImtpZCI6InlvdSBzbHkgZG9nISB5b3UgY2F1Z2h0IG1lIG1vbm9sb2d1aW5nISJ9..m9LBvNgbzmO5JuZ4Bwoheyn7uqLf3TN1EdFwv_l_nMT2qh0_2EVs30SAEc-Ajjkq18MQk3cgU36AodLPl3_hBg",
+            "algorithm": "EdDSA",
             "signed_fields": [
               "command",
               "env",
@@ -227,8 +227,8 @@ curl "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pipeline.
       "step": {
         "id": "018c0f56-c87c-47e9-95ee-aa47397b4496",
         "signature": {
-          "value": "eyJhbGciOiJFUzI1NiIsImtpZCI6InlvdSBzbHkgZG9nISB5b3UgY2F1Z2h0IG1lIG1vbm9sb2d1aW5nISJ9..gcmV8TgY6MfAXRbD_7kyuB3JAQMH-0th5E1MmQn5ND34bEs-zNBZ3tLi6w2e_gvfqL6C1kxRhOQzAwEZMQlo5w",
-          "algorithm": "HS512",
+          "value": "eyJhbGciOiJFUzI1NiIsImtpZCI6InlvdSBzbHkgZG9nISB5b3UgY2F1Z2h0IG1lIG1vbm9sb2d1aW5nISJ9..m9LBvNgbzmO5JuZ4Bwoheyn7uqLf3TN1EdFwv_l_nMT2qh0_2EVs30SAEc-Ajjkq18MQk3cgU36AodLPl3_hBg",
+          "algorithm": "EdDSA",
           "signed_fields": [
             "command",
             "env",
@@ -388,8 +388,8 @@ curl -X POST "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{p
       "step": {
         "id": "018c0f56-c87c-47e9-95ee-aa47397b4496",
         "signature": {
-          "value": "eyJhbGciOiJFUzI1NiIsImtpZCI6InlvdSBzbHkgZG9nISB5b3UgY2F1Z2h0IG1lIG1vbm9sb2d1aW5nISJ9..gcmV8TgY6MfAXRbD_7kyuB3JAQMH-0th5E1MmQn5ND34bEs-zNBZ3tLi6w2e_gvfqL6C1kxRhOQzAwEZMQlo5w",
-          "algorithm": "HS512",
+          "value": "eyJhbGciOiJFUzI1NiIsImtpZCI6InlvdSBzbHkgZG9nISB5b3UgY2F1Z2h0IG1lIG1vbm9sb2d1aW5nISJ9..m9LBvNgbzmO5JuZ4Bwoheyn7uqLf3TN1EdFwv_l_nMT2qh0_2EVs30SAEc-Ajjkq18MQk3cgU36AodLPl3_hBg",
+          "algorithm": "EdDSA",
           "signed_fields": [
             "command",
             "env",
@@ -553,8 +553,8 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
       "step": {
         "id": "018c0f56-c87c-47e9-95ee-aa47397b4496",
         "signature": {
-          "value": "eyJhbGciOiJFUzI1NiIsImtpZCI6InlvdSBzbHkgZG9nISB5b3UgY2F1Z2h0IG1lIG1vbm9sb2d1aW5nISJ9..gcmV8TgY6MfAXRbD_7kyuB3JAQMH-0th5E1MmQn5ND34bEs-zNBZ3tLi6w2e_gvfqL6C1kxRhOQzAwEZMQlo5w",
-          "algorithm": "HS512",
+          "value": "eyJhbGciOiJFUzI1NiIsImtpZCI6InlvdSBzbHkgZG9nISB5b3UgY2F1Z2h0IG1lIG1vbm9sb2d1aW5nISJ9..m9LBvNgbzmO5JuZ4Bwoheyn7uqLf3TN1EdFwv_l_nMT2qh0_2EVs30SAEc-Ajjkq18MQk3cgU36AodLPl3_hBg",
+          "algorithm": "EdDSA",
           "signed_fields": [
             "command",
             "env",
@@ -692,8 +692,8 @@ curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/pipelines/{pi
       "step": {
         "id": "018c0f56-c87c-47e9-95ee-aa47397b4496",
         "signature": {
-          "value": "eyJhbGciOiJFUzI1NiIsImtpZCI6InlvdSBzbHkgZG9nISB5b3UgY2F1Z2h0IG1lIG1vbm9sb2d1aW5nISJ9..gcmV8TgY6MfAXRbD_7kyuB3JAQMH-0th5E1MmQn5ND34bEs-zNBZ3tLi6w2e_gvfqL6C1kxRhOQzAwEZMQlo5w",
-          "algorithm": "HS512",
+          "value": "eyJhbGciOiJFUzI1NiIsImtpZCI6InlvdSBzbHkgZG9nISB5b3UgY2F1Z2h0IG1lIG1vbm9sb2d1aW5nISJ9..m9LBvNgbzmO5JuZ4Bwoheyn7uqLf3TN1EdFwv_l_nMT2qh0_2EVs30SAEc-Ajjkq18MQk3cgU36AodLPl3_hBg",
+          "algorithm": "EdDSA",
           "signed_fields": [
             "command",
             "env",

--- a/vale/styles/Buildkite/h1-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h1-h6_sentence_case.yml
@@ -10,6 +10,7 @@ scope:
   - heading.h6
 match: $sentence
 exceptions:
+  - '^(\d+\.) [A-Z]\w+' # Allow numbered headings. Example: "1. Install the thing"
   - '^(Agent|Build|Job) ([A-Z]\w+(ed|ing)|Lost)$' # Exceptions for /pages/integrations/amazon_eventbridge.md
   - '^(Step|Method) \d: [A-Z]\w+' # Allow caps after colon. Examples: "Step 3: Do the thing", "Method 2: Deploy keys"
   - ADFS

--- a/vale/styles/vocab.txt
+++ b/vale/styles/vocab.txt
@@ -205,6 +205,7 @@ untrusted
 unset
 unsets
 unsetting
+uploaders
 url
 urls
 util


### PR DESCRIPTION
We're getting closish to releasing signed pipelines on the agent - it's a fairly complicated feature and needs comprehensive docs to be useful.

These docs explain what the feature is, its use cases, and how to set it up on your agents.

Issue: [PDP-1288](https://linear.app/buildkite/issue/PDP-1288/update-bk-documentation)