### PR TITLE
Hard fail ECR check

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -14,7 +14,6 @@ steps:
 
   - name: ":ecr: ECR Vulnerabilities Scan"
     command: "true"
-    soft_fail: true
     agents:
       queue: deploy
     depends_on: "ecr-push"


### PR DESCRIPTION
Now that all CVEs have been triaged and we have 0 reported in the pipeline - we are ready to switch off Vanta checks. Before we do that - we need to make ECR scan results check hard-fail.

The plugin has support for providing inline help text to triage vulnerabilities. In the meantime - have a look at this PR for how we propose to triage CVEs: https://github.com/buildkite/guide/pull/285

### Verification

New High and Critical CVEs will start failing builds.

### Deployment

No risk, pipeline change only.

### Rollback

Revert this PR (make the step soft-fail).
