### PR TITLE
Pin ls-lint to working version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,7 +109,7 @@ steps:
               image: "public.ecr.aws/docker/library/node:lts-alpine3.14"
 
       - label: ":snake: Linting markdown files for snake case"
-        command: npx -y @ls-lint/ls-lint
+        command: npx -y @ls-lint/ls-lint@2.1.0
         plugins:
           - docker#v3.7.0:
               image: "public.ecr.aws/docker/library/node:lts-alpine3.14"


### PR DESCRIPTION
This fixes failing builds on main. 

We can bump the version once this following issue has been resolved:

https://github.com/loeffel-io/ls-lint/issues/163