### PR TITLE
Fix typo when replacing go test with gotestsum

### DIFF
--- a/pages/test_analytics/golang_collectors.md
+++ b/pages/test_analytics/golang_collectors.md
@@ -12,7 +12,7 @@ To use Test Analytics with your [Go](https://go.dev/) language projects use [got
     go install gotest.tools/gotestsum@latest
     ```
 
-2. Use gotestsum to run your tests and output JUnit XML, by replacing `go test` with `go testsum`, for example:
+2. Use gotestsum to run your tests and output JUnit XML, by replacing `go test` with `gotestsum`, for example:
 
     ```sh
     gotestsum --junitfile junit.xml ./...


### PR DESCRIPTION
Very minor change to update the `go testsum` command to `gotestsum` (no space). Without it Go will complain about the `testsum` command not being found.

This is correct in the example underneath, so this is just a consistency change. Caught me off-guard, might catch others too.