### PR TITLE
Added `id` to cluster Update / PUT endpoint

### DIFF
--- a/pages/apis/rest_api/clusters.md
+++ b/pages/apis/rest_api/clusters.md
@@ -174,7 +174,7 @@ Error responses:
 ### Update a cluster
 
 ```bash
-curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/clusters" \
+curl -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/clusters/{id}" \
   -H "Content-Type: application/json" \
   -d '{ "name": "Open Source" }'
 ```


### PR DESCRIPTION
The `id` (UUID) of a Cluster is needed in the request URL for a PUT to update it using the REST API - missing in the current docs release.

Was noticed by a few folks - and have added it in 👍