### PR TITLE
Improve padding on responsive tables with faux table headings

### DIFF
--- a/app/frontend/css/components/_responsive_table.scss
+++ b/app/frontend/css/components/_responsive_table.scss
@@ -10,13 +10,13 @@
 
   th {
     overflow-wrap: anywhere;
-    padding: 16px;
+    padding: 4px;
   }
 
   td {
     overflow-wrap: anywhere;
-    margin-bottom: 15px;
-    padding: 16px;
+    margin-bottom: 8px;
+    padding: 4px;
 
     @media (min-width: $screen-sm) {
       margin-bottom: 0;
@@ -37,6 +37,13 @@
       &:last-child {
         margin-bottom: 0;
       }
+    }
+  }
+
+  @media (min-width: $screen-md) {
+    th,
+    td {
+      padding: 16px;
     }
   }
 
@@ -70,14 +77,12 @@
     tr {
       display: grid;
       grid-template-columns: 1fr;
-      padding-bottom: 15px;
-      padding-top: 15px;
+      padding: 1rem;
 
       @media (min-width: $screen-sm) and (max-width: ($screen-md - 1)) {
-        gap: ($gutter / 2) $gutter;
+        gap: 0;
         grid-template-columns: 20ch 1fr;
-        padding-bottom: 1rem;
-        padding-top: 1rem;
+        padding: 0.5rem;
       }
 
       @media (min-width: $screen-md) {
@@ -121,15 +126,6 @@
 
     @media (min-width: $screen-md) {
       display: none;
-    }
-
-    &:first-child {
-      + th,
-      + td {
-        @media (min-width: $screen-md) {
-          padding-left: 0;
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
This PR fixes an issue occurring where we were removing padding on adjacent `th` and `td` elements when there was a faux  table header in place.

**Desktop:** Before / after
<img width="1493" alt="desktop @2x" src="https://github.com/buildkite/docs/assets/677025/0644beac-7996-4a48-a45e-093dab2401d3">

When reviewing the tablet/mobile designs, I noticed that the padding between elements was not well resolved; leading to large amounts of negative space and making it a bit difficult to infer the proximity and relationship between elements. These updates lead to a more comfortable reading experience, with greater information density.

**Tablet** Before / after
<img width="1525" alt="tablet @2x" src="https://github.com/buildkite/docs/assets/677025/6bdd9a58-31d0-444b-be09-a6d194f44822">

**Mobile** Before / after
<img width="1149" alt="mobile @2x" src="https://github.com/buildkite/docs/assets/677025/b039b0df-baa3-46bf-a628-2303ec559568">

