### PR TITLE
Mount migration tool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "vendor/emojis"]
 	path = vendor/emojis
 	url = https://github.com/buildkite/emojis.git
+[submodule "vendor/migration"]
+	path = vendor/migration
+	url = https://github.com/buildkite/migration

--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,5 @@ end
 group :test do
   gem "buildkite-test_collector"
 end
+
+gem "parslet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     nokogiri (1.15.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    parslet (2.0.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -175,6 +176,7 @@ DEPENDENCIES
   graphql-client
   lograge
   matrix
+  parslet
   pry
   puma
   railties (~> 6.0)

--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -1,0 +1,20 @@
+class MigrationController < ApplicationController
+  skip_forgery_protection
+
+  def show
+    @nav = default_nav
+
+    render template: "migrate", layout: "homepage"
+  end
+
+  def migrate
+    # Some request path rewriting for the compat server to slot in.
+    request.env["REQUEST_PATH"] = "/"
+    request.env["REQUEST_URI"] = "/"
+    request.env["PATH_INFO"] = "/"
+
+    res = BK::Compat::Server.new.call(request.env)
+
+    render body: res[2].string, status: res[0], content_type: res[1]["content-type"]
+  end
+end

--- a/app/models/nav.rb
+++ b/app/models/nav.rb
@@ -15,12 +15,7 @@ class Nav
 
   # Returns the current nav item
   def current_item(request)
-    return nil if request.path == "/docs"
-
-    item = route_map[request.path.sub("/docs/", "")]
-    raise ActionController::RoutingError.new("Missing navigation for #{request.path}") unless item
-
-    item
+    route_map[request.path.sub("/docs/", "")]
   end
 
   # Returns a hash of routes, indexed by path

--- a/app/views/migrate.html.erb
+++ b/app/views/migrate.html.erb
@@ -1,0 +1,181 @@
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Buildkite-ification!</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Helvetica, sans-serif;
+        padding: 0;
+        margin: 0;
+      }
+      .flex {
+        display: flex;
+      }
+      .flex-column {
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+      .flex-auto {
+        -webkit-box-flex: 1;
+        -ms-flex: 1 1 auto;
+        flex: 1 1 auto;
+        min-width: 0;
+        min-height: 0;
+      }
+      .items-center {
+        align-items: center;
+      }
+      .items-stretch {
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+      }
+      .justify-center {
+        justify-content: center;
+      }
+      .center {
+        text-align: center;
+      }
+      input[type=submit] {
+        border-radius: 4px;
+        background-color: #14cc80;
+        border: 1px solid transparent;
+        color: white;
+        font-size: 1em;
+        padding: .75em 1em;
+        line-height: 1.2;
+        font-weight: bold;
+        font-family: inherit;
+        cursor: pointer;
+      }
+      input[type=submit]:hover {
+        box-shadow: inset 0 0 0 20rem rgba(0, 0, 0, .0625);
+      }
+      input[type=submit]:disabled {
+        opacity: 0.5;
+      }
+      textarea {
+        display: block;
+        width: 100%;
+        padding: 15px;
+        font-size: 12px;
+        font-family: "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", Courier, monospace;
+        line-height: 1.42857143;
+        color: #555555;
+        background-color: #fff;
+        background-image: none;
+        border: 1px solid #ccc;
+        border-radius: .3em;
+        resize: none;
+        -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+                box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+
+        /* disable iOS' extra inner shadows */
+        -webkit-appearance: none;
+           -moz-appearance: none;
+                appearance: none
+      }
+      textarea:focus {
+        border-color: #888;
+        outline: 0;
+      }
+      textarea[readonly] {
+        background: #f9fafb;
+      }
+      .error {
+        background: #ff000044 !important;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="flex items-stretch justify-center" style="min-height: 100%">
+      <form onSubmit="return transform(event)" class="flex items-stretch center flex-column" style="width: 100%; padding: 5%;">
+        <div class="flex flex-auto" style="margin-bottom: 20px;">
+          <textarea rows="20" style="width: 50%; margin-right: 20px" placeholder="👋 Paste or drag a config file here!" id="config" class="flex-auto"></textarea>
+          <textarea rows="20" style="width: 50%" readonly="true" id="results" placeholder="👈 Look over there" class="flex-auto"></textarea>
+        </div>
+        <div>
+          <input type="submit" value="Buildkite-ify!" id="button" />
+        </div>
+      </form>
+    </div>
+
+    <script>
+      function transform() {
+        var button = document.getElementById("button");
+
+        var configTextarea = document.getElementById("config");
+        var formData = new FormData();
+        formData.append("file", new Blob([configTextarea.value], { type: "text/plain" }));
+
+        button.disabled = true;
+
+        var resultsTextarea = document.getElementById("results");
+
+        fetch("<%= migrate_url %>", {
+          method: "POST",
+          credentials: 'same-origin',
+          body: formData
+        }).then(function(response) {
+          button.disabled = false;
+          if (!response.ok) {
+            resultsTextarea.classList.add('error')
+          } else {
+            resultsTextarea.classList.remove('error')
+          }
+          return response;
+        }).then(function(response) {
+          response.text().then(function(text) {
+            resultsTextarea.value = text;
+          });
+        }).catch((function(error) {
+          alert(error.message);
+          resultsTextarea.value = '';
+        }));
+
+        return false;
+      }
+
+      function handleFormSubmit() {
+        event.preventDefault();
+
+        transform();
+      }
+
+      function handleFileSelect(evt) {
+        evt.stopPropagation();
+        evt.preventDefault();
+
+        var file = evt.dataTransfer.files[0];
+
+        if (file) {
+          if (file.type == "application/x-yaml") {
+            var reader = new FileReader();
+
+            reader.onload = function(e) {
+              document.getElementById("config").value = e.target.result;
+              transform();
+            };
+
+            reader.readAsText(file);
+          } else {
+            alert("Only YAML files are supported - you uploaded a: " + file.type);
+          }
+        }
+      }
+
+      function handleDragOver(evt) {
+        evt.stopPropagation();
+        evt.preventDefault();
+        evt.dataTransfer.dropEffect = 'copy'; // Explicitly show this is a copy.
+      }
+
+      // Setup the dnd listeners.
+      var dropZone = document.body;
+      dropZone.addEventListener('dragover', handleDragOver, false);
+      dropZone.addEventListener('drop', handleFileSelect, false);
+    </script>
+  </body>
+</html>

--- a/app/views/migrate.html.erb
+++ b/app/views/migrate.html.erb
@@ -1,181 +1,175 @@
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <title>Buildkite-ification!</title>
-    <style>
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Helvetica, sans-serif;
-        padding: 0;
-        margin: 0;
-      }
-      .flex {
-        display: flex;
-      }
-      .flex-column {
-        -webkit-box-orient: vertical;
-        -webkit-box-direction: normal;
-        -ms-flex-direction: column;
-        flex-direction: column;
-      }
-      .flex-auto {
-        -webkit-box-flex: 1;
-        -ms-flex: 1 1 auto;
-        flex: 1 1 auto;
-        min-width: 0;
-        min-height: 0;
-      }
-      .items-center {
-        align-items: center;
-      }
-      .items-stretch {
-        -webkit-box-align: stretch;
-        -ms-flex-align: stretch;
-        align-items: stretch;
-      }
-      .justify-center {
-        justify-content: center;
-      }
-      .center {
-        text-align: center;
-      }
-      input[type=submit] {
-        border-radius: 4px;
-        background-color: #14cc80;
-        border: 1px solid transparent;
-        color: white;
-        font-size: 1em;
-        padding: .75em 1em;
-        line-height: 1.2;
-        font-weight: bold;
-        font-family: inherit;
-        cursor: pointer;
-      }
-      input[type=submit]:hover {
-        box-shadow: inset 0 0 0 20rem rgba(0, 0, 0, .0625);
-      }
-      input[type=submit]:disabled {
-        opacity: 0.5;
-      }
-      textarea {
-        display: block;
-        width: 100%;
-        padding: 15px;
-        font-size: 12px;
-        font-family: "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", Courier, monospace;
-        line-height: 1.42857143;
-        color: #555555;
-        background-color: #fff;
-        background-image: none;
-        border: 1px solid #ccc;
-        border-radius: .3em;
-        resize: none;
-        -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-                box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Helvetica, sans-serif;
+    padding: 0;
+    margin: 0;
+  }
+  .flex {
+    display: flex;
+  }
+  .flex-column {
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+  .flex-auto {
+    -webkit-box-flex: 1;
+    -ms-flex: 1 1 auto;
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+  }
+  .items-center {
+    align-items: center;
+  }
+  .items-stretch {
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+  .justify-center {
+    justify-content: center;
+  }
+  .center {
+    text-align: center;
+  }
+  input[type=submit] {
+    border-radius: 4px;
+    background-color: #14cc80;
+    border: 1px solid transparent;
+    color: white;
+    font-size: 1em;
+    padding: .75em 1em;
+    line-height: 1.2;
+    font-weight: bold;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  input[type=submit]:hover {
+    box-shadow: inset 0 0 0 20rem rgba(0, 0, 0, .0625);
+  }
+  input[type=submit]:disabled {
+    opacity: 0.5;
+  }
+  textarea {
+    display: block;
+    width: 100%;
+    padding: 15px;
+    font-size: 12px;
+    font-family: "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", Courier, monospace;
+    line-height: 1.42857143;
+    color: #555555;
+    background-color: #fff;
+    background-image: none;
+    border: 1px solid #ccc;
+    border-radius: .3em;
+    resize: none;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+            box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 
-        /* disable iOS' extra inner shadows */
-        -webkit-appearance: none;
-           -moz-appearance: none;
-                appearance: none
-      }
-      textarea:focus {
-        border-color: #888;
-        outline: 0;
-      }
-      textarea[readonly] {
-        background: #f9fafb;
-      }
-      .error {
-        background: #ff000044 !important;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="flex items-stretch justify-center" style="min-height: 100%">
-      <form onSubmit="return transform(event)" class="flex items-stretch center flex-column" style="width: 100%; padding: 5%;">
-        <div class="flex flex-auto" style="margin-bottom: 20px;">
-          <textarea rows="20" style="width: 50%; margin-right: 20px" placeholder="👋 Paste or drag a config file here!" id="config" class="flex-auto"></textarea>
-          <textarea rows="20" style="width: 50%" readonly="true" id="results" placeholder="👈 Look over there" class="flex-auto"></textarea>
-        </div>
-        <div>
-          <input type="submit" value="Buildkite-ify!" id="button" />
-        </div>
-      </form>
+    /* disable iOS' extra inner shadows */
+    -webkit-appearance: none;
+        -moz-appearance: none;
+            appearance: none
+  }
+  textarea:focus {
+    border-color: #888;
+    outline: 0;
+  }
+  textarea[readonly] {
+    background: #f9fafb;
+  }
+  .error {
+    background: #ff000044 !important;
+  }
+</style>
+
+
+<div class="flex items-stretch justify-center" style="min-height: 100%">
+  <form onSubmit="return transform(event)" class="flex items-stretch center flex-column" style="width: 100%; padding: 5%;">
+    <div class="flex flex-auto" style="margin-bottom: 20px;">
+      <textarea rows="20" style="width: 50%; margin-right: 20px" placeholder="👋 Paste or drag a config file here!" id="config" class="flex-auto"></textarea>
+      <textarea rows="20" style="width: 50%" readonly="true" id="results" placeholder="👈 Look over there" class="flex-auto"></textarea>
     </div>
+    <div>
+      <input type="submit" value="Buildkite-ify!" id="button" />
+    </div>
+  </form>
+</div>
 
-    <script>
-      function transform() {
-        var button = document.getElementById("button");
+<script>
+  function transform() {
+    var button = document.getElementById("button");
 
-        var configTextarea = document.getElementById("config");
-        var formData = new FormData();
-        formData.append("file", new Blob([configTextarea.value], { type: "text/plain" }));
+    var configTextarea = document.getElementById("config");
+    var formData = new FormData();
+    formData.append("file", new Blob([configTextarea.value], { type: "text/plain" }));
 
-        button.disabled = true;
+    button.disabled = true;
 
-        var resultsTextarea = document.getElementById("results");
+    var resultsTextarea = document.getElementById("results");
 
-        fetch("<%= migrate_url %>", {
-          method: "POST",
-          credentials: 'same-origin',
-          body: formData
-        }).then(function(response) {
-          button.disabled = false;
-          if (!response.ok) {
-            resultsTextarea.classList.add('error')
-          } else {
-            resultsTextarea.classList.remove('error')
-          }
-          return response;
-        }).then(function(response) {
-          response.text().then(function(text) {
-            resultsTextarea.value = text;
-          });
-        }).catch((function(error) {
-          alert(error.message);
-          resultsTextarea.value = '';
-        }));
-
-        return false;
+    fetch("<%= migrate_url %>", {
+      method: "POST",
+      credentials: 'same-origin',
+      body: formData
+    }).then(function(response) {
+      button.disabled = false;
+      if (!response.ok) {
+        resultsTextarea.classList.add('error')
+      } else {
+        resultsTextarea.classList.remove('error')
       }
+      return response;
+    }).then(function(response) {
+      response.text().then(function(text) {
+        resultsTextarea.value = text;
+      });
+    }).catch((function(error) {
+      alert(error.message);
+      resultsTextarea.value = '';
+    }));
 
-      function handleFormSubmit() {
-        event.preventDefault();
+    return false;
+  }
 
-        transform();
+  function handleFormSubmit() {
+    event.preventDefault();
+
+    transform();
+  }
+
+  function handleFileSelect(evt) {
+    evt.stopPropagation();
+    evt.preventDefault();
+
+    var file = evt.dataTransfer.files[0];
+
+    if (file) {
+      if (file.type == "application/x-yaml") {
+        var reader = new FileReader();
+
+        reader.onload = function(e) {
+          document.getElementById("config").value = e.target.result;
+          transform();
+        };
+
+        reader.readAsText(file);
+      } else {
+        alert("Only YAML files are supported - you uploaded a: " + file.type);
       }
+    }
+  }
 
-      function handleFileSelect(evt) {
-        evt.stopPropagation();
-        evt.preventDefault();
+  function handleDragOver(evt) {
+    evt.stopPropagation();
+    evt.preventDefault();
+    evt.dataTransfer.dropEffect = 'copy'; // Explicitly show this is a copy.
+  }
 
-        var file = evt.dataTransfer.files[0];
-
-        if (file) {
-          if (file.type == "application/x-yaml") {
-            var reader = new FileReader();
-
-            reader.onload = function(e) {
-              document.getElementById("config").value = e.target.result;
-              transform();
-            };
-
-            reader.readAsText(file);
-          } else {
-            alert("Only YAML files are supported - you uploaded a: " + file.type);
-          }
-        }
-      }
-
-      function handleDragOver(evt) {
-        evt.stopPropagation();
-        evt.preventDefault();
-        evt.dataTransfer.dropEffect = 'copy'; // Explicitly show this is a copy.
-      }
-
-      // Setup the dnd listeners.
-      var dropZone = document.body;
-      dropZone.addEventListener('dragover', handleDragOver, false);
-      dropZone.addEventListener('drop', handleFileSelect, false);
-    </script>
-  </body>
-</html>
+  // Setup the dnd listeners.
+  var dropZone = document.body;
+  dropZone.addEventListener('dragover', handleDragOver, false);
+  dropZone.addEventListener('drop', handleFileSelect, false);
+</script>

--- a/config/initializers/migration.rb
+++ b/config/initializers/migration.rb
@@ -1,0 +1,2 @@
+require Rails.root.join('vendor/migration/app/lib/bk/compat').to_s
+require Rails.root.join('vendor/migration/app/lib/bk/compat/server').to_s

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,10 @@ Rails.application.routes.draw do
   # Homepage
   get "/docs" => "pages#index", as: :home_page
 
+  # Hosted migration/transform tool
+  get "/docs/migrate" => "migration#show"
+  post "/docs/migrate" => "migration#migrate", as: :migrate
+
   # All other standard docs pages
   get "/docs/*path" => "pages#show", as: :docs_page
 


### PR DESCRIPTION
I had a think about https://github.com/buildkite/buildkite/pull/14388 and I thought perhaps our docs is good place for hosting the migration tool. 

This PR renders a hosted version of the https://github.com/buildkite/migration under `/docs/migrate`. 

It's a _little_ hacky using a submodule, since there's some dependencies required, but it also seems totally fine as an interim solution for giving this tool a home. Long term, I wouldn't expect the API to live in the docs.

I replicated all the markup into docs primarily to control the form endpoint, but it now gives us full control over the styling etc if we want to play around with this.

<img width="1512" alt="Screenshot 2023-11-02 at 12 29 18 pm" src="https://github.com/buildkite/docs/assets/656826/c272226c-12df-46ff-b626-fe4444b0921a">

Thoughts @MelissaKaulfuss @mbelton-buildkite?!

Worth noting that for this PR the static preview will render the page but the transform won't work since that requires a backend. 