### PR TITLE
Ignore CVE-2023-5717

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -34,6 +34,7 @@ steps:
             - CVE-2023-24329 # python3.11 3.11.2-6
             - CVE-2023-3640 # linux 6.1.55-1
             - CVE-2023-45853 # zlib 1:1.2.13.dfsg-1
+            - CVE-2023-5717 # linux 6.1.55-1
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying


### PR DESCRIPTION
Pretty sure this one is safe to ignore. It affects the Linux Profiler `perf` tool which we don't use.