### PR TITLE
A little more docker housekeeping

### DIFF
--- a/.buildkite/pipeline.preview.yml
+++ b/.buildkite/pipeline.preview.yml
@@ -7,6 +7,8 @@ steps:
 
   - label: "Deploy preview"
     command: bin/deploy-preview
+    env:
+      RAILS_ENV: "production"
     plugins:
       - ailohq/github-deployment#v1.0.10:
           token-env: GH_TOKEN
@@ -15,7 +17,7 @@ steps:
           transient_environment: true
       - docker-compose#v3.9.0:
           run: app
-          config: docker-compose.production.yml
+          dependencies: false
           mount-buildkite-agent: true
           env:
             - GH_TOKEN

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,14 +16,15 @@ steps:
             - RAILS_ENV
             - BUILDKITE_ANALYTICS_TOKEN
 
-  - label: ":lipstick: Compile assets"
+  - label: ":vite: Compile assets"
     depends_on: "linting"
     command: bundle exec rake assets:precompile
     key: "assets"
+    env:
+      RAILS_ENV: production
     plugins:
       - docker-compose#v3.9.0:
           run: app
-          config: docker-compose.production.yml
 
   - label: ":spider: muffet"
     # We need to wait until rails has started before running muffet as otherwise it will error out

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,15 +16,14 @@ steps:
             - RAILS_ENV
             - BUILDKITE_ANALYTICS_TOKEN
 
-  - label: ":vite: Compile assets"
+  - label: ":docker: Build image"
     depends_on: "linting"
-    command: bundle exec rake assets:precompile
     key: "assets"
     env:
       RAILS_ENV: production
     plugins:
       - docker-compose#v3.9.0:
-          run: app
+          build: app
 
   - label: ":spider: muffet"
     # We need to wait until rails has started before running muffet as otherwise it will error out

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ COPY --from=bundle /usr/local/bundle/ /usr/local/bundle/
 ARG RAILS_ENV
 
 RUN if [ "$RAILS_ENV" = "production" ]; then \
-    echo "--- Precompiling assets" \
+    echo "--- :vite: Compiling assets" \
     && RAILS_ENV=production RAILS_GROUPS=assets SECRET_KEY_BASE=xxx bundle exec rake assets:precompile \
     && cp -r /app/public/docs/assets /app/public/assets; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ ARG RAILS_ENV
 ARG DD_RUM_VERSION="unknown"
 ARG DD_RUM_ENV="unknown"
 
-# Config. Don't love this.production
+# Config. Don't love this.
 ENV RAILS_ENV=$RAILS_ENV
 ENV DD_RUM_ENV=${DD_RUM_ENV}
 ENV DD_RUM_VERSION=${DD_RUM_VERSION}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,9 +1,0 @@
-version: '3'
-services:
-  app:
-    build:
-      context: .
-      args:
-        RAILS_ENV: production
-    ports:
-      - '3000:3000'


### PR DESCRIPTION
~~This PR consolidates some of the preview builder tools into a separate stage that can be targeted directly in CI. This means  we don't need to install misc tools like `curl` and jq` in the final layer.~~

Edit: The docker-compose plugin can only target stages whilst building, not when running.

This PR removes `docker-compose.production.yml` to keep things simple and replaces the production assets step with a production image build step to avoid compiling twice.