### PR TITLE
Small update/ammendment to managing_log_output docs 

### DIFF
--- a/pages/pipelines/managing_log_output.md
+++ b/pages/pipelines/managing_log_output.md
@@ -164,7 +164,7 @@ By default, build logs are stored in encrypted form in Buildkite's managed Amazo
 The folder structure and file format are as follows and are not customizable:
 
 ```text
-{BUILDKITE_PIPELINE_ID}/{BUILDKITE_BUILD_ID}/{BUILDKITE_JOB_ID}.log
+{ORGANIZATION_UUID}/{BUILDKITE_PIPELINE_ID}/{BUILDKITE_BUILD_ID}/{BUILDKITE_JOB_ID}.log
 ```
 
 To set up a private build log archive storage:


### PR DESCRIPTION
## Description
For private build archive storage, build logs are stored following a folder structure and file format that is not customisable:
`{ORGANIZATION_UUID}/{BUILDKITE_PIPELINE_ID}/{BUILDKITE_BUILD_ID}/{BUILDKITE_JOB_ID}.log`

It was highlighted by a customer that the `{ORGANIZATION_UUID}` part of that format was not reflected in the current documentation. 

This PR makes a small update to the docs so it accurately reflects the current behaviour.

[Escalation](https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Dispatch-Escalations_suxld?utm_source=slack&utm_content=comment_notification#Dispatch-Escalations-Board_tu-xJ/r141)


## Changes
Updated the file format representation to include `ORGANIZATION_UUID`, as that reflects the current behaviour

**Before:**
![image](https://github.com/buildkite/docs/assets/78014112/9a1921b6-8dc6-4e0c-9493-a7902baf503c)

**After:**
![image](https://github.com/buildkite/docs/assets/78014112/f48fcd1c-ccd3-4919-a375-78fb25237255)