### PR TITLE
Add noindex to pages under badge.buildkite.com

### DIFF
--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -40,7 +40,7 @@
 
 <%= render 'analytics', application: 'docs', title: "Docs / #{content_for(:page_title)}", logged_in: probably_authenticated? %>
 
-<% if ENV.fetch("ROBOTS_NO_INDEX") { "false" } == "true" || request.base_url == "https://badge.buildkite.com" %>
+<% if ENV.fetch("ROBOTS_NO_INDEX") { "false" } == "true" || [ "https://badge.buildkite.com", "https://badge.buildbox.io"].include?(request.base_url) %>
   <meta name="robots" content="noindex, nofollow">
 <% end %>
 

--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -40,7 +40,7 @@
 
 <%= render 'analytics', application: 'docs', title: "Docs / #{content_for(:page_title)}", logged_in: probably_authenticated? %>
 
-<% if ENV.fetch("ROBOTS_NO_INDEX") { "false" } == "true" %>
+<% if ENV.fetch("ROBOTS_NO_INDEX") { "false" } == "true" || request.base_url == "https://badge.buildkite.com" %>
   <meta name="robots" content="noindex, nofollow">
 <% end %>
 


### PR DESCRIPTION
✨ I am not precious about my ruby so please correct if there's a better way to do this ✨ 

### Add noindex when served under badge.buildkite.com

- we have an issue currently where we are accidentally serving docs under badge.buildkite.com
- this actually isn't too much of an issue except that google found it, crawled it and indexed it
- there was an initial fix (https://github.com/buildkite/ops/pull/1777) to just remove badge.buildkite.com/docs, but that meant that google had indexed what was now a bunch of 404s, which is also kind of a bad look.
- that fix was reverted, and there was a change to add a canonical ref: https://github.com/buildkite/docs/pull/2452 - which is great, but our SEO consultant has recommended that we also add an explicit `noindex` to the badge.buildkite.com/docs, so google will stop indexing them at all.
- once google has removed the badge.buildkite.com/docs pages from their index, we can then do either/or of: 
  - adding badge.buildkite.com/docs as a disallow to our robots.txt in bk/site (or in badge.buildkite.com/robots.txt? subdomains might be their own thing...)
  - removing the badge.buildkite.com/docs domain as a whole
-  for both of these we'll want to wait until google has de-indexed these pages though, or they'll stick around as zombies 🧟 