### PR TITLE
Mention Amazon EventBridge as option to stream audit log events

### DIFF
--- a/pages/pipelines/audit_log.md
+++ b/pages/pipelines/audit_log.md
@@ -98,3 +98,5 @@ USER_TOTP_CREATED
 USER_TOTP_DELETED
 USER_UPDATED
 ```
+
+You can also set up [Amazon EventBridge](/docs/integrations/amazon-eventbridge) to stream Audit Log events.


### PR DESCRIPTION
Customers are not aware of using [Amazon EventBridge](https://buildkite.com/docs/integrations/amazon-eventbridge) as an option to stream Audit Log events, so mention it in the docs. They often reach out to us asking for a dedicated service or polling our GraphQL API.

<kbd>[Preview updated doc](https://2568--bk-docs-preview.netlify.app/docs/pipelines/audit-log)</kbd>