### PR TITLE
Remove usage of ailohq/github-deployment plugin

### DIFF
--- a/.buildkite/pipeline.preview.yml
+++ b/.buildkite/pipeline.preview.yml
@@ -1,6 +1,3 @@
-env:
-  GITHUB_USERNAME: "buildkite-docs-bot"
-
 steps:
   - label: "Prepare preview"
     command: bin/prepare-preview
@@ -10,11 +7,6 @@ steps:
     env:
       RAILS_ENV: "production"
     plugins:
-      - ailohq/github-deployment#v1.0.10:
-          token-env: GH_TOKEN
-          environment: preview
-          production_environment: false
-          transient_environment: true
       - docker-compose#v3.9.0:
           run: app
           dependencies: false

--- a/bin/prepare-preview
+++ b/bin/prepare-preview
@@ -38,8 +38,6 @@ curl -H "Content-Type: application/zip" \
 PREVIEW_URL=$(cat netlify-deploy.json | jq -r '.deploy_ssl_url')
 PREVIEW_MESSAGE="Preview URL: $PREVIEW_URL"
 
-buildkite-agent meta-data set "environment_url" "$PREVIEW_URL"
-
 echo "--- :buildkite: Annotating build"
 buildkite-agent annotate --style "info" --context "netlify/preview-url" "$PREVIEW_MESSAGE"
 


### PR DESCRIPTION
It was nice while it lasted. Turns out the https://github.com/ailohq/github-deployment-buildkite-plugin repository has been removed and no longer exists in the buildkite plugins index.

I've sent the organization an email to see if they might bring it back and in the meantime we'll go without. 

Maybe I'll get around to reimplementing the behaviour some other time!