### PR TITLE
Document filter runs by build_id

### DIFF
--- a/pages/apis/rest_api/analytics/_runs_list_query_strings.md
+++ b/pages/apis/rest_api/analytics/_runs_list_query_strings.md
@@ -1,0 +1,12 @@
+<table>
+<tbody>
+  <tr>
+    <th>
+      <code>build_id</code>
+    </th>
+    <td>
+      <span>Filters the results by the given build UUID.</span>
+    </td>
+  </tr>
+</tbody>
+</table>

--- a/pages/apis/rest_api/analytics/_runs_list_query_strings.md
+++ b/pages/apis/rest_api/analytics/_runs_list_query_strings.md
@@ -6,6 +6,7 @@
     </th>
     <td>
       <span>Filters the results by the given build UUID.</span>
+      <p class="Docs__api-param-eg"><em>Example:</em> <code>?build_id=018c133d-5419-7fe3-9e9e-3c51464490a2</code></p>
     </td>
   </tr>
 </tbody>

--- a/pages/apis/rest_api/analytics/runs.md
+++ b/pages/apis/rest_api/analytics/runs.md
@@ -23,6 +23,10 @@ curl "https://api.buildkite.com/v2/analytics/organizations/{org.slug}/suites/{su
 ]
 ```
 
+Optional [query string parameters](/docs/api#query-string-parameters):
+
+<%= render_markdown partial: 'apis/rest_api/analytics/runs_list_query_strings' %>
+
 Required scope: `read_suites`
 
 Success response: `200 OK`


### PR DESCRIPTION
We have added support for filtering Test Analytics runs by Buildkite build_id to the REST API.

I have copied the existing documentation formatting from the builds page including the link back to shared documentation on the use of query parameters.

[PIE-2128](https://linear.app/buildkite/issue/PIE-2128/filter-runs-by-build-id-in-ta-rest-api)
[Support Escalation](https://3.basecamp.com/3453178/buckets/20365997/card_tables/cards/6765942503)

![Screenshot 2023-11-28 at 9 56 33 am](https://github.com/buildkite/docs/assets/1002901/f177b94e-ab92-442d-afca-701902603f09)