### PR TITLE
Fix list formatting in Signed Pipeline docs

### DIFF
--- a/pages/agent/v3/signed_pipelines.md
+++ b/pages/agent/v3/signed_pipelines.md
@@ -65,6 +65,7 @@ buildkite-agent tool keygen --alg EdDSA --key-id my-key-id
 The agent generates a JWKS key pair in your current directory: one private and one public. You can then use these keys to sign and verify your pipelines.
 
 Note that the value of `--alg` must be a valid [JSON Web Signing Algorithm](https://datatracker.ietf.org/doc/html/rfc7518#section-3), and that the agent does not support all JWA signing algorithms. At the time of writing, the agent supports:
+
 - `EdDSA` (the default)
 - `PS512`
 - `ES512`


### PR DESCRIPTION
There's a bug where `ul`s in markdown in the docs renderer need a newline before the beginning of the list, or they'll look broken:
![CleanShot 2023-11-29 at 16 02 05@2x](https://github.com/buildkite/docs/assets/15753101/55dc9d01-73c2-4ebf-9a32-b53f4aef5658)

This PR fixes that issue with the signed pipelines page:
![CleanShot 2023-11-29 at 16 10 03@2x](https://github.com/buildkite/docs/assets/15753101/a6b7adb4-1548-4123-9594-bfa6f8f7152b)

