### PR TITLE
Pass Buildkite Env Variables to Rspec steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,12 @@ steps:
             - CI
             - RAILS_ENV
             - BUILDKITE_ANALYTICS_TOKEN
+            - BUILDKITE_BRANCH
+            - BUILDKITE_BUILD_ID
+            - BUILDKITE_BUILD_NUMBER
+            - BUILDKITE_BUILD_URL
+            - BUILDKITE_COMMIT
+            - BUILDKITE_MESSAGE
 
   - label: ":docker: Build image"
     depends_on: "linting"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,7 @@ steps:
             - BUILDKITE_BRANCH
             - BUILDKITE_BUILD_ID
             - BUILDKITE_BUILD_NUMBER
+            - BUILDKITE_BUILD_URL
             - BUILDKITE_COMMIT
             - BUILDKITE_JOB_ID
             - BUILDKITE_MESSAGE

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,6 @@ steps:
             - BUILDKITE_BRANCH
             - BUILDKITE_BUILD_ID
             - BUILDKITE_BUILD_NUMBER
-            - BUILDKITE_BUILD_URL
             - BUILDKITE_COMMIT
             - BUILDKITE_MESSAGE
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,15 +11,15 @@ steps:
           run: app
           dependencies: false
           env:
-            - BUILDKITE_JOB_ID
-            - CI
-            - RAILS_ENV
             - BUILDKITE_ANALYTICS_TOKEN
             - BUILDKITE_BRANCH
             - BUILDKITE_BUILD_ID
             - BUILDKITE_BUILD_NUMBER
             - BUILDKITE_COMMIT
+            - BUILDKITE_JOB_ID
             - BUILDKITE_MESSAGE
+            - CI
+            - RAILS_ENV
 
   - label: ":docker: Build image"
     depends_on: "linting"


### PR DESCRIPTION
### Description
We noticed that some env variables are missing from Rspec runs in [Docs TA suite](https://buildkite.com/organizations/buildkite/analytics/suites/docs-1?branch=main). 
<img width="445" alt="Screenshot 2023-12-15 at 9 20 57 AM" src="https://github.com/buildkite/docs/assets/21911472/32fe5add-02e0-4191-a13b-5727d6c5337c">

This PR passes Buildkite environment variables from CI env to Docker container that runs Rspec, so the Test Collector can send them to Test Analytics. ~~I exclude `BUILDKITE_BUILD_URL` to prevent linking to the private pipelines.~~

### Verification
To verify, we can check if the Rspec run has all information in [Docs TA suite](https://buildkite.com/organizations/buildkite/analytics/suites/docs-1?branch=main)
