### PR TITLE
feat: add organization member REST API documentation

### DIFF
--- a/data/nav.yml
+++ b/data/nav.yml
@@ -412,6 +412,11 @@
           path: "apis/rest-api"
         - name: "Limits"
           path: "apis/rest-api/limits"
+        - name: "Organization REST API"
+          pill: "beta"
+          children:
+            - name: "Memberships"
+              path: "apis/rest-api/organization/members"
         - name: "Pipelines REST API"
           children:
             - name: "Access token"

--- a/pages/apis/rest_api/organization/members.md
+++ b/pages/apis/rest_api/organization/members.md
@@ -1,0 +1,62 @@
+# Organization members API
+
+The organization members API allows users to view all members of an organization.
+
+## Organization member data model
+
+<table class="responsive-table">
+<tbody>
+  <tr><th><code>id</code></th><td>UUID of the user</td></tr>
+  <tr><th><code>name</code></th><td>Name of the user</tr>
+  <tr><th><code>email</code></th><td>Email of the user</td></tr>
+</tbody>
+</table>
+
+## List organization members
+
+Returns a list of an organization's members.
+
+```bash
+curl --request GET \
+  --header 'Authorization: Bearer $TOKEN' \
+  --url https://api.buildkite.com/v2/organizations/{org.slug}/members \
+```
+
+```json
+[
+	{
+		"id": "0185c636-fcbf-4a6c-b49d-c4048e7b8aea",
+		"name": "Scout Finch",
+		"email": "scout@example.com"
+	},
+	{
+		"id": "0185dbbf-8447-4f72-ac7e-4ea3c2ec8381",
+		"name": "Huck Finn",
+		"email": "huck@example.com"
+	}
+]
+```
+
+Required scope: `read_organizations`
+
+Success response: `200 OK`
+
+## Get an organization member
+
+```bash
+curl --request GET \
+  --header 'Authorization: Bearer $TOKEN' \
+  --url https://api.buildkite.com/v2/organizations/{org.slug}/members/{user.uuid} \
+```
+
+```json
+{
+  "id": "0185dbbf-8447-4f72-ac7e-4ea3c2ec8381",
+  "name": "Victor Frankenstein",
+  "email": "vic@example.com"
+}
+```
+
+Required scope: `read_organizations`
+
+Success response: `200 OK`


### PR DESCRIPTION
ℹ️ Don't merge yet. This is documentation for some feature-flagged work which is yet to be released on Buildkite

We've recently done some work to uplift the REST API - exposing organization membera (PR: https://github.com/buildkite/buildkite/pull/15036)

This PR adds documentation for that feature and should only be merged once it has been released on Buildkite.