### PR TITLE
fix: update sender from string to object

### DIFF
--- a/pages/apis/webhooks/build_events.md
+++ b/pages/apis/webhooks/build_events.md
@@ -33,7 +33,7 @@
     </tr>
     <tr>
       <td><code>sender</code></td>
-      <td>String</td>
+      <td>Object</td>
       <td>The user who created the webhook</td>
     </tr>
   </tbody>


### PR DESCRIPTION
A minor but important change. The "_sender_" in the **request body data** section does not return a String, it returns an Object that contains two strings, as the example shows below it.

This commit corrects the distinction and provides clarity, all in one small change!