### PR TITLE
Removing reference to coming soon test collectors

### DIFF
--- a/pages/test_analytics/your_own_collectors.md
+++ b/pages/test_analytics/your_own_collectors.md
@@ -6,4 +6,4 @@ toc: false
 
 Test Analytics integrates directly with your test runner to provide in-depth information about your tests (including spans) in real time.
 
-If you can't find your framework in these pages, check the list of frameworks that are [coming soon](/docs/test-analytics/other-collectors), or if you're interested in building your own fully integrated analytics collector for specific test runners, have a look at our [example collector](https://github.com/buildkite/rspec-buildkite-analytics) on GitHub.
+If you're interested in building your own fully integrated analytics collector for specific test runners, have a look at our [example collector](https://github.com/buildkite/rspec-buildkite-analytics) on GitHub.


### PR DESCRIPTION
The "your own collectors" page references and links to collectors that are "coming soon". There is no such coming soon list, or active plans to add support for new frameworks and therefore incorrect.

This PR removes the line that mentions any 'coming soon' collectors and instead only mentions how to build your own collector