### PR TITLE
[CORE-6] Specify that agent API is internal

### DIFF
--- a/pages/apis/agent_api.md
+++ b/pages/apis/agent_api.md
@@ -4,6 +4,8 @@ The Agent REST API is used for agent registration, agent deregistration, startin
 
 The only publicly available endpoint is `/metrics`. The [Buildkite metrics agent](https://github.com/buildkite/buildkite-agent-metrics) uses the data returned by the metrics endpoint for agent autoscaling.
 
+All other endpoints in the Agent API are intended only for use by the Buildkite Agent, therefore stability and backwards compatibility are not guaranteed, and changes won't be announced.
+
 The current version of the Agent API is v3.
 
 


### PR DESCRIPTION
Explicitly state that the non-metrics endpoints in the agent API are not public endpoints, and that we don't guarantee stability. This is implicit in `The only publicly available endpoint is /metrics.`, but this makes it clearer.