### PR TITLE
Remove broken link from Linux Lighting Group

### DIFF
--- a/pages/test_analytics/importing_junit_xml.md
+++ b/pages/test_analytics/importing_junit_xml.md
@@ -10,7 +10,7 @@ The following attributes are mandatory for the `<testcase>` element:
 * `classname`: full class name for the class the test method is in.
 * `name`: name of the test method.
 
-To learn more about the JUnit XML file format, see [JUnit XML reporting file format](https://llg.cubic.org/docs/junit/) from Linux Lighting Group.
+To learn more about the JUnit XML file format, see [JUnit XML reporting file format](https://github.com/testmoapp/junitxml#basic-junit-xml-structure).
 
 ## How to import JUnit XML in Buildkite
 

--- a/pages/test_analytics/importing_junit_xml.md
+++ b/pages/test_analytics/importing_junit_xml.md
@@ -10,7 +10,8 @@ The following attributes are mandatory for the `<testcase>` element:
 * `classname`: full class name for the class the test method is in.
 * `name`: name of the test method.
 
-To learn more about the JUnit XML file format, see [JUnit XML reporting file format](https://github.com/testmoapp/junitxml#basic-junit-xml-structure).
+To learn more about the JUnit XML file format, see [Common JUnit XML format & examples
+](https://github.com/testmoapp/junitxml).
 
 ## How to import JUnit XML in Buildkite
 


### PR DESCRIPTION
The [Importing JUnit XML](https://buildkite.com/docs/test-analytics/importing-junit-xml) page in TA linked to https://llg.cubic.org/docs/junit/. That link stopped working and caused the docs builds to fail. For example, [on this build.](https://buildkite.com/buildkite/docs/builds/7105#018d531a-5fb3-4d77-9462-f317ac26bbb8/717-756)

This change replaces the broken link with a resource recommended by @gchan in [this escalation](https://3.basecamp.com/3453178/buckets/20365997/card_tables/cards/7000544649#__recording_7000628143).