### PR TITLE
Prevent dev logs from spamming hot module reloading

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,10 @@ export default defineConfig(({ mode }) => {
       __ALGOLIA_APP_ID__: JSON.stringify(env.ALGOLIA_APP_ID),
       __ALGOLIA_INDEX_NAME__: JSON.stringify(env.ALGOLIA_INDEX_NAME),
     },
+    server: {
+      watch: {
+        ignored: ['/app/log/**']
+      }
+    },
   };
 });


### PR DESCRIPTION
Remove some spam from the dev logs when running via docker.

before:
<img width="905" alt="Screenshot 2024-02-02 at 5 43 37 pm" src="https://github.com/buildkite/docs/assets/656826/7d96795b-53d3-4a97-b956-23ccda8c89c2">

after:

<img width="927" alt="Screenshot 2024-02-02 at 5 42 34 pm" src="https://github.com/buildkite/docs/assets/656826/1424e5bf-a050-4aff-a5dd-e813e0c9d60b">

