### PR TITLE
Fix an error in an example for Slack notification config

### DIFF
--- a/pages/pipelines/notifications.md
+++ b/pages/pipelines/notifications.md
@@ -264,6 +264,7 @@ steps:
           channels:
             - "buildkite-community#sre"
           message: "SRE related information here..."
+      - slack:
           channels:
             - "buildkite-community#announcements"
           message: "General announcement for the team here..."


### PR DESCRIPTION
Fixes an error that slipped through untested (the current example kinda works - the notifications DO arrive to all the channels that are mentioned, but only one custom message gets delivered).