### PR TITLE
Add a note about quota limit for slack notification services

### DIFF
--- a/pages/integrations/slack.md
+++ b/pages/integrations/slack.md
@@ -25,8 +25,8 @@ Once you have granted access to your Slack workspace, give it a description, cho
 
 <%= image "buildkite-slack-connected.png", width: 1458/2, height: 1540/2, alt: "Screenshot of Buildkite Slack Notification Settings, requesting a description, your choice of text or emoji message themes, which pipelines and branches to include, and which build states should trigger a notification" %>
 
->🚧
-> Default quota limit for number of slack notification services that can be added to an organization is 50. If you are an `Enterprise` customer and need higher quota limit, please reach out to support@buildkite.com.
+> 🚧
+> The default quota limit for the number of Slack notification services that can be added to an organization is 50. If you are an Enterprise customer and need higher quota limit, please reach out to support@buildkite.com.
 
 
 With the configuration above, you'll receive notifications at the pipeline level but not on the outcomes of individual steps. The _fixed builds_ option ensures you're notified when a failed build next passes.

--- a/pages/integrations/slack.md
+++ b/pages/integrations/slack.md
@@ -25,6 +25,10 @@ Once you have granted access to your Slack workspace, give it a description, cho
 
 <%= image "buildkite-slack-connected.png", width: 1458/2, height: 1540/2, alt: "Screenshot of Buildkite Slack Notification Settings, requesting a description, your choice of text or emoji message themes, which pipelines and branches to include, and which build states should trigger a notification" %>
 
+>🚧
+> Default quota limit for number of Slack services that can be added to an organization is 50. If you are an enterprise customer and need higher quota limit please reach out to support@buildkite.com.
+
+
 With the configuration above, you'll receive notifications at the pipeline level but not on the outcomes of individual steps. The _fixed builds_ option ensures you're notified when a failed build next passes.
 
 If you're using the [`notify` YAML attribute](/docs/pipelines/notifications) for more fine grained control over your Slack notifications, select the 'Only Some Pipelines...' option. Once you're using a Slack `notify` attribute in your `pipeline.yml`, the branch and build filtering from the Slack Notification Service will be overridden by the YAML options you choose.

--- a/pages/integrations/slack.md
+++ b/pages/integrations/slack.md
@@ -26,7 +26,7 @@ Once you have granted access to your Slack workspace, give it a description, cho
 <%= image "buildkite-slack-connected.png", width: 1458/2, height: 1540/2, alt: "Screenshot of Buildkite Slack Notification Settings, requesting a description, your choice of text or emoji message themes, which pipelines and branches to include, and which build states should trigger a notification" %>
 
 >🚧
-> Default quota limit for number of Slack services that can be added to an organization is 50. If you are an enterprise customer and need higher quota limit please reach out to support@buildkite.com.
+> Default quota limit for number of slack notification services that can be added to an organization is 50. If you are an `Enterprise` customer and need higher quota limit, please reach out to support@buildkite.com.
 
 
 With the configuration above, you'll receive notifications at the pipeline level but not on the outcomes of individual steps. The _fixed builds_ option ensures you're notified when a failed build next passes.


### PR DESCRIPTION
Through this PR we are adding a note in slack integration page about quota limit for slack notification services

