### PR TITLE
Temporarily suppress bullet point indentation checking.

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -21,12 +21,12 @@ MD005: true
 MD006: true
 
 # MD007/ul-indent - Unordered list indentation
-MD007:
+# (This setting is temporarily disabled. The intention is to make its value 4, as doing this would allow the nesting of 3 bullet points and improved code block handling)
+# MD007:
   # Spaces for indent
   # indent: 2
-  # (This setting is temporarily disabled. The intention is to make its value 4, as doing this would allow the nesting of 3 bullet points and improved code block handling)
   # Whether to indent the first level of the list
-  start_indented: false
+  # start_indented: false
 
 # MD009/no-trailing-spaces - Trailing spaces
 MD009:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -23,7 +23,8 @@ MD006: true
 # MD007/ul-indent - Unordered list indentation
 MD007:
   # Spaces for indent
-  indent: 2
+  # indent: 2
+  # (This setting is temporarily disabled. The intention is to make its value 4, as doing this would allow the nesting of 3 bullet points and improved code block handling)
   # Whether to indent the first level of the list
   start_indented: false
 

--- a/styleguides/markdown-syntax-style.md
+++ b/styleguides/markdown-syntax-style.md
@@ -80,7 +80,25 @@ Refer to [Referring to UI elements in the Writing style guide](writing-style.md#
 
 ### Lists
 
-For a bulleted list item, use a single hyphen `-` at the start of a new line (that is, for a top-level list item), followed by a single space, followed by the text for that bullet point. For a nested bulleted list item, begin with a single asterisk `*` at the start of a new/indented text block.
+For a bulleted/unordered list item, use a single hyphen `-` at the start of a new line (that is, for a top-level list item), followed by a single space, followed by the text for that bullet point. For a nested bulleted list item, begin with a single asterisk `*` at the start of a new/indented text block.
+
+Nest bullet list items using exactly 4-space indent increments. For example:
+
+```markdown
+- Top-level bullet list item
+
+    * 2nd-level bullet list item
+    * Another 2nd-level item
+
+        * 3rd-level bullet list item
+        * Another 3rd-level item
+
+- Another top-level bullet list item
+- And yet another.
+...
+```
+
+Some existing bullet lists in the docs use only 2-space indent increments. This style is deprecated and over time, these will be changed to a 4-space indent increments.
 
 For a numbered list item, use the syntax `1.` at the start of a new line (or block), followed by a single space, followed by the text for that numbered list item.
 For subsequent items in a numbered list, start the new line/block with `1.` again, as the HTML will always render subsequent items sequentially. Avoid attempting to number each item sequentially (for example, `2.`, `3.`, etc.), regardless of the incremental interval (for example, `1.`, `10.`, `20.`, etc.). This makes it easier to insert items without having to renumber adjacent list numbered items.

--- a/styleguides/markdown-syntax-style.md
+++ b/styleguides/markdown-syntax-style.md
@@ -80,7 +80,7 @@ Refer to [Referring to UI elements in the Writing style guide](writing-style.md#
 
 ### Lists
 
-For a bulleted/unordered list item, use a single hyphen `-` at the start of a new line (that is, for a top-level list item), followed by a single space, followed by the text for that bullet point. For a nested bulleted list item, begin with a single asterisk `*` at the start of a new/indented text block.
+For a bulleted/unordered list item, use a single hyphen `-` at the start of a new line (that is, for a top-level list item), followed by a single space, followed by the text for that bullet point. For a nested bulleted list item, begin with an indented single asterisk `*` at the start of a new/indented text block. If a 3rd-level nested bullet list item needs to be created, begin it with a single `-` again.
 
 Nest bullet list items using exactly 4-space indent increments. For example:
 
@@ -90,8 +90,8 @@ Nest bullet list items using exactly 4-space indent increments. For example:
     * 2nd-level bullet list item
     * Another 2nd-level item
 
-        * 3rd-level bullet list item
-        * Another 3rd-level item
+        - 3rd-level bullet list item
+        - Another 3rd-level item
 
 - Another top-level bullet list item
 - And yet another.


### PR DESCRIPTION
Other than not being able to spell the word 'suppress' in branch names correctly, I'd like to make this suggested change to the Markdown linting rules around list indentation.

First, when building the docs site locally, these linting rule checks don't appear to run. I presume this is by design, to improve the performance of the local docs build environment.

When changes are pushed up to GitHub, Buidlkite runs a Markdown linter that checks to ensure that unordered list items (bullet points) are strictly indented by only 2 spaces. This prevents us from leveraging the full benefits of Markdown's HTML rendering in the docs.

For example, forcing 2 spaces, I'm unable to bring the code blocks in line with my 2nd level bullet point:

![forced 2 spaces](https://github.com/buildkite/docs/assets/23667807/befd51f5-90a7-4b02-a6ad-4d4b3b84bf82)

By indenting bullet points by 4 spaces, I'm able to get a 3rd level of indented bullet points (a very useful feature in docs), as well as bring code blocks in line with the bullet points they're meant to be associated with:

![4 spaces allowed](https://github.com/buildkite/docs/assets/23667807/289c871a-d8e8-48ac-b07d-92ea3f70a157)

Since we have a lot of bullet points currently indented by 2 spaces, I'm commenting out the lint checking for indentation. Once I've had the chance to systematically indent all other bullet points in the docs by 4-space increments (for each level), uncomment this line and change it to 4.

> [!NOTE]
> Also, it appears 'markdownlint's own documentation recommends a minimum indentation level of 3:
https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md007---unordered-list-indentation

As an interim measure to encourage new contributors to use 4-space indentation increments, I'm updating the Markdown style guide guidance on this (since no checking would be done in the meantime).