### PR TITLE
Add Cypress to Test Analytics Javascript collectors

### DIFF
--- a/pages/test_analytics.md
+++ b/pages/test_analytics.md
@@ -23,6 +23,7 @@ Test Analytics helps you track and analyze the steps in that pipeline that invol
   <%= button ":ruby: minitest", "/docs/test-analytics/ruby-collectors#minitest-collector" %>
   <%= button ":jest: Jest", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-jest" %>
   <%= button ":mocha: Mocha", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-mocha" %>
+  <%= button ":cypress: Cypress", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-cypress" %>
   <%= button ":jasmine: Jasmine", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-jasmine" %>
   <%= button ":playwright: Playwright", "/docs/test-analytics/javascript-collectors#configure-the-test-framework-playwright" %>
   <%= button ":swift: Swift", "/docs/test-analytics/swift-collectors" %>

--- a/pages/test_analytics/javascript_collectors.md
+++ b/pages/test_analytics/javascript_collectors.md
@@ -126,7 +126,7 @@ To configure Mocha:
 To configure Cypress:
 
 1. Make sure Cypress runs with access to [CI environment variables](/docs/test-analytics/ci-environments).
-1. Update your [Cypress Configuration](https://docs.cypress.io/guides/references/configuration)
+1. Update your [Cypress configuration](https://docs.cypress.io/guides/references/configuration).
 
     ```js
     // cypress.config.js
@@ -135,7 +135,7 @@ To configure Cypress:
     reporter: "buildkite-test-collector/cypress/reporter",
     ```
 
-1. If you would like to pass in the API token using a custom environment variable, you can do so using the `reporterOptions`.
+    **Note:** To pass in the API token using a custom environment variable, add the `reporterOptions` option to your Cypress configuration:
 
     ```js
     // cypress.config.js

--- a/pages/test_analytics/javascript_collectors.md
+++ b/pages/test_analytics/javascript_collectors.md
@@ -5,6 +5,7 @@ To use Test Analytics with your JavaScript (npm) projects, use the :github: [`te
 - [Jest](https://jestjs.io/)
 - [Jasmine](https://jasmine.github.io/)
 - [Mocha](https://mochajs.org/)
+- [Cypress](https://www.cypress.io)
 - [Playwright](https://playwright.dev)
 
 You can also upload test results by importing [JSON](/docs/test-analytics/importing-json) or [JUnit XML](/docs/test-analytics/importing-junit-xml).
@@ -118,6 +119,30 @@ To configure Mocha:
       "buildkiteTestCollectorMochaReporterReporterOptions": {
         "token_name": "CUSTOM_ENV_VAR_NAME"
       }
+    }
+    ```
+
+### Cypress
+To configure Cypress:
+
+1. Make sure Cypress runs with access to [CI environment variables](/docs/test-analytics/ci-environments).
+1. Update your [Cypress Configuration](https://docs.cypress.io/guides/references/configuration)
+    
+    ```js
+    // cypress.config.js
+
+    // Send results to Test Analytics
+    reporter: "buildkite-test-collector/cypress/reporter",
+    ```
+
+1. If you would like to pass in the API token using a custom environment variable, you can do so using the `reporterOptions`.
+    
+    ```js
+    // cypress.config.js
+
+    // Send results to Test Analytics
+    reporterOptions: {
+      token_name: "CUSTOM_ENV_VAR_NAME"
     }
     ```
 

--- a/pages/test_analytics/javascript_collectors.md
+++ b/pages/test_analytics/javascript_collectors.md
@@ -127,7 +127,7 @@ To configure Cypress:
 
 1. Make sure Cypress runs with access to [CI environment variables](/docs/test-analytics/ci-environments).
 1. Update your [Cypress Configuration](https://docs.cypress.io/guides/references/configuration)
-    
+
     ```js
     // cypress.config.js
 
@@ -136,7 +136,7 @@ To configure Cypress:
     ```
 
 1. If you would like to pass in the API token using a custom environment variable, you can do so using the `reporterOptions`.
-    
+
     ```js
     // cypress.config.js
 


### PR DESCRIPTION
We have added Cypress support to JavaScript collectors. This PR adds how to configure Cypress with Test Analytics.
