### PR TITLE
Add information on agent panel metrics

### DIFF
--- a/pages/pipelines/cluster_queue_metrics.md
+++ b/pages/pipelines/cluster_queue_metrics.md
@@ -14,6 +14,9 @@ _Agents Connected_ is the number of agents connected to the queue. The circular 
 
 For agent utilization, agents are considered busy if they have a job ID assigned.
 
+>📘
+> The number of agents shown in the agent panel includes agents in a `stopping` state. This may cause a variation in the number shown in the agents panel and the graph displaying `connected` agents.
+
 ### Jobs panel
 
 _Jobs Running_ shows the number of jobs assigned to agents. These are any jobs in the queue in the following states:


### PR DESCRIPTION
Currently the docus don't inform that there is potential variation in the numbers shown in the agent panel and those on the graph below.

I've added an (i) box to inform the user of this.
