### PR TITLE
Correct Header level as section was appearing as sub-section

### DIFF
--- a/pages/apis/graphql/cookbooks/pipelines.md
+++ b/pages/apis/graphql/cookbooks/pipelines.md
@@ -171,7 +171,7 @@ mutation PipelineDelete {
 }
 ```
 
-### Update pipeline schedule with multiple environment variables
+## Update pipeline schedule with multiple environment variables
 
 You can set multiple environment variables on a pipeline schedule by using the new-line value `\n` as a delimiter.
 


### PR DESCRIPTION
"Update pipeline schedule with multiple environment variables" section had a Heading level 3, instead of level 2 resulting in appearing as a sub-section of the previous Heading level 2 "Delete a pipeline"