### PR TITLE
Fixes to clusters overview page.

### DIFF
--- a/pages/agent/v3/unclustered_tokens.md
+++ b/pages/agent/v3/unclustered_tokens.md
@@ -5,7 +5,7 @@
 > _Agent tokens_ are now associated with clusters, and connect to Buildkite through a specific cluster within an organization. Learn more about how to manage agent tokens for clusters in [Agent tokens](/docs/agent/v3/tokens) and how to [move your unclustered agents across to a cluster](/docs/clusters/manage-clusters#move-unclustered-agents-to-a-cluster).
 > It is not be possible to create and work with unclustered agents for any new Buildkite organizations created after the official release of clusters on February 26, 2024. Therefore, unclustered agent tokens are not relevant to these organizations.
 
-Any Buildkite organization created before February 26, 2024 has an _Unclustered_ area for managing _unclustered agents_ (accessible through _Agents_ > _Unclustered_ of the Buildkite interface), where an _unclustered agent_ refers to any agent that is not associated with a cluster.
+Any Buildkite organization created before February 26, 2024 has an _Unclustered_ area for managing _unclustered agents_, accessible through _Agents_ (from the global navigation) > _Unclustered_ of the Buildkite interface, where an _unclustered agent_ refers to any agent that is not associated with a cluster.
 
 A Buildkite agent requires a token to connect to Buildkite and register for work. If you need to connect an _unclustered agent_ to Buildkite, then you need to create an _unclustered agent token_ to do so.
 
@@ -13,7 +13,7 @@ A Buildkite agent requires a token to connect to Buildkite and register for work
 
 <!-- Is this section still valid? Should this instead be called the 'initial unclustered agent token'? -->
 
-Your Buildkite organization's unclustered agent tokens area (accessible through _Agents_ > _Unclustered_ > _Agent Tokens_) may have the _Default agent registration token_, which is the original default token when your organization was created. If you had previously saved this token's value in a safe place, this token can be used for testing and development. However, it's recommended that you [create new, specific tokens](#create-a-token) for each new environment.
+Your Buildkite organization's unclustered agent tokens page, accessible through _Agents_ (from the global navigation) > _Unclustered_ > _Agent Tokens_, may have the _Default agent registration token_, which is the original default token when your organization was created. If you had previously saved this token's value in a safe place, this token can be used for testing and development. However, it's recommended that you [create new, specific tokens](#create-a-token) for each new environment.
 
 ## Using and storing tokens
 
@@ -59,7 +59,7 @@ query GetOrgID {
 
 <!--alex ignore clearly-->
 
-The token description should clearly identify the environment the token is intended to be used for (for example, `Read-only token for static site generator`), and is listed on the _Agent tokens_ page of the _Agents_ > _Unclustered_ area. (This page is accessible through _Agents_ > _Unclustered_ > _Agent Tokens_.)
+The token description should clearly identify the environment the token is intended to be used for (for example, `Read-only token for static site generator`), and is listed on the _Agent tokens_ page of the _Agents_ (from the global navigation) > _Unclustered_ area.
 
 It is possible to create multiple unclustered agent tokens using the GraphQL API.
 

--- a/pages/clusters/overview.md
+++ b/pages/clusters/overview.md
@@ -49,15 +49,11 @@ Having individual queues according to these breakdowns allows you to scale a set
 
 Clusters provides additional, easy to access queue metrics that are available only for queues within a cluster. Learn more in [Cluster queue metrics](/docs/pipelines/cluster-queue-metrics).
 
-## Accessing clusters and agents
-
-If you only have one Cluster with one Queue selecting _Agents_ in the global navigation will take you to your single queue.
-
-If you have multiple clusters, or unclustered pipelines and agents, selecting _Agents_ in the global navigation will take you to the _Clusters_ page. Once on this page, you can navigate to your agents by selecting the cluster the agents are part of, or _Unclustered_ for agents that were not created as part of a cluster.
-
-### Accessing clustered and unclustered agents, and pipelines
+## Accessing your agents and pipelines
 
 Any agents and pipelines which are not associated with a cluster are known as _unclustered agents_ and _pipelines_, respectively.
+
+If you have multiple clusters, or unclustered pipelines and agents, selecting _Agents_ in the global navigation takes you to the _Clusters_ page. Once on this page, you can navigate to your agents by selecting the cluster the agents are part of, or _Unclustered_ for agents that were not created as part of a cluster.
 
 To view and manage your all of your agents, their (unclustered) agent tokens, and pipelines, select _Agents_ from the global navigation of your Buildkite organization to open the _Clusters_ page. From this page:
 

--- a/pages/clusters/overview.md
+++ b/pages/clusters/overview.md
@@ -30,6 +30,8 @@ The most common patterns seen for cluster configurations are based on stage setu
 
 You can create as many clusters as your require for your setup.
 
+Learn more about working with clusters in [Manage clusters](/docs/clusters/manage-clusters).
+
 >📘 Pipeline triggering
 > Pipelines associated with one cluster cannot trigger pipelines associated with another cluster
 
@@ -44,6 +46,8 @@ The most common queue attributes are based on infrastructure set-ups, such as:
 Therefore, an example queue would be `small_mac_silicon`.
 
 Having individual queues according to these breakdowns allows you to scale a set of similar agents, which Buildkite can then report on.
+
+Learn more about working with queues in [Manage queues](/docs/clusters/manage-queues).
 
 ## Queue metrics
 

--- a/pages/clusters/overview.md
+++ b/pages/clusters/overview.md
@@ -7,7 +7,7 @@ Clusters is a Buildkite feature used to manage and organize agents and queues, w
 - helps make agents and queues more discoverable across your organization, and
 - provides easily accessible queue metrics.
 
-The following diagram shows the architecture with cluster enabled.
+The following diagram shows the architecture of a Buildkite organization's clusters, along with their pipelines and queues.
 
 <%= image "clusters-architecture.png", alt: "Diagram showing existing architecture and architecture with clusters" %>
 
@@ -51,9 +51,7 @@ Clusters provides additional, easy to access queue metrics that are available on
 
 ## Accessing your agents and pipelines
 
-Any agents and pipelines which are not associated with a cluster are known as _unclustered agents_ and _pipelines_, respectively.
-
-If you have multiple clusters, or unclustered pipelines and agents, selecting _Agents_ in the global navigation takes you to the _Clusters_ page. Once on this page, you can navigate to your agents by selecting the cluster the agents are part of, or _Unclustered_ for agents that were not created as part of a cluster.
+Any agents and pipelines which are not yet associated with a cluster are known as _unclustered agents_ and _pipelines_, respectively.
 
 To view and manage your all of your agents, their (unclustered) agent tokens, and pipelines, select _Agents_ from the global navigation of your Buildkite organization to open the _Clusters_ page. From this page:
 

--- a/pages/clusters/overview.md
+++ b/pages/clusters/overview.md
@@ -55,9 +55,13 @@ Clusters provides additional, easy to access queue metrics that are available on
 
 ## Accessing your agents and pipelines
 
+If you only have one cluster with one queue, selecting _Agents_ in the global navigation takes you directly to your single queue in this cluster. This is typically the case with newly created organizations.
+
+If you have multiple clusters, selecting _Agents_ in the global navigation takes you to the _Clusters_ page, where you can access your individual clusters and within each one, the details and configurations of the cluster's individual queues, agents tokens, pipelines and other settings.
+
 Any agents and pipelines which are not yet associated with a cluster are known as _unclustered agents_ and _pipelines_, respectively.
 
-To view and manage your all of your agents, their (unclustered) agent tokens, and pipelines, select _Agents_ from the global navigation of your Buildkite organization to open the _Clusters_ page. From this page:
+From the _Clusters_ page:
 
 - To access a specific cluster's agents, their associated agent tokens, as well as the cluster's queues and pipelines, select the relevant cluster (or its _queue_ or _pipelines_ link) from this page.
 


### PR DESCRIPTION
The current [Clusters overview](https://buildkite.com/docs/clusters/overview#accessing-clusters-and-agents) page (near the top of **Accessing clusters and agents** section) in the Buildkite Docs site has content which appears to have documented a snapshot of clusters behaviour before clusters went GA.

The first sentence in this section now looks completely wrong! This is the sentence:

> If you only have one Cluster with one Queue selecting Agents in the global navigation will take you to your single queue.

If, however, this is still true, please do let me know

Hence, this PR fixes this Clusters overview page to remove this 'in dev' content, along with some other improvements.