### PR TITLE
Change the plan's name to the existing one

### DIFF
--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -199,7 +199,7 @@ _Optional attributes:_
     <td><code>timeout_in_minutes</code></td>
     <td>
       <p>The maximum number of minutes a job created from this step is allowed to run. If the job exceeds this time limit, or if it finishes with a non-zero exit status, the job is automatically canceled and the build fails. Jobs that time out with an exit status of <code>0</code> are marked as <code>passed</code>.</p>
-      <p>Note that on the <a href="https://buildkite.com/pricing">Developer Plan</a>, command steps have a maximum job timeout of 240 minutes.
+      <p>Note that on the <a href="https://buildkite.com/pricing">Free Plan</a>, command steps have a maximum job timeout of 240 minutes.
       <p>You can also set <a href="/docs/pipelines/build-timeouts">default and maximum timeouts</a> in the Buildkite UI.</p>
       <p><em>Example:</em> <code>60</code><p>
     </td>

--- a/pages/pipelines/job_minutes.md
+++ b/pages/pipelines/job_minutes.md
@@ -26,10 +26,10 @@ Your organization's usage is also accessible in the [GraphQL API](/docs/apis/gra
 >📘 Calculating job minutes usage
 > We store job usage data in seconds but charge by summing all the usage and rounding down to the nearest minute. Please keep in mind that when displaying usage data per pipeline in the chart and CSV download, there may be minor discrepancies due to the rounding of each individual pipeline's usage.
 
-## Limits for the Developer Plan
+## Limits for the Free Plan
 
-The Developer Plan has a limit of 5,000 job minutes per month. When this limit is reached, builds are not cancelled, but jobs will not be run. The limit is reset when your billing period rolls over, or your organization is upgraded to a different plan.
+The Free Plan has a limit of 5,000 job minutes per month. When this limit is reached, builds are not cancelled, but jobs will not be run. The limit is reset when your billing period rolls over, or your organization is upgraded to a different plan.
 
 ### Build timeouts
 
-The Developer Plan has a [command step maximum timeout](/docs/pipelines/command-step#timeout_in_minutes) of 240 minutes.
+The Free Plan has a [command step maximum timeout](/docs/pipelines/command-step#timeout_in_minutes) of 240 minutes.

--- a/vale/styles/Buildkite/h1-h6_sentence_case.yml
+++ b/vale/styles/Buildkite/h1-h6_sentence_case.yml
@@ -51,7 +51,7 @@ exceptions:
   - CloudWatch Logs
   - Datadog
   - Debian
-  - Developer Plan
+  - Free Plan
   - Docker
   - Docker Compose
   - Docker Hub


### PR DESCRIPTION
We don't have any " Developer plan" and it is confuse our customer.