### PR TITLE
Call out that signed pipelines are not compatible with pipeline templates

### DIFF
--- a/pages/agent/v3/signed_pipelines.md
+++ b/pages/agent/v3/signed_pipelines.md
@@ -35,6 +35,9 @@ The following fields are included in the signature for each step:
 - **Matrix configuration.** The matrix configuration is signed as a whole rather than each individual matrix job. This means the signature is the same for each job in the matrix. When signatures are verified for matrix jobs, the agent double-checks that the job it received is a valid construction of the matrix and that the signature matches the matrix configuration.
 - **The repository the commands are running in.** This prevents you from copying a signed step from one repository to another.
 
+> 📘 Compatibility with [pipeline templates](/docs/pipelines/templates)
+> Due to the inclusion of repository in step signatures, they are unable to be used with pipeline templates. This is because templates are designed to be used across multiple pipelines, and therefore repositories.
+
 ## Enabling signed pipelines on your agents
 
 You'll need to configure your agents and update pipeline definitions to enable signed pipelines.

--- a/pages/agent/v3/signed_pipelines.md
+++ b/pages/agent/v3/signed_pipelines.md
@@ -36,7 +36,7 @@ The following fields are included in the signature for each step:
 - **The repository the commands are running in.** This prevents you from copying a signed step from one repository to another.
 
 > 📘 Compatibility with [pipeline templates](/docs/pipelines/templates)
-> Due to the inclusion of repository in step signatures, they are unable to be used with pipeline templates. This is because templates are designed to be used across multiple pipelines, and therefore repositories.
+> Due to the inclusion of repository in step signatures, signed steps cannot be used with pipeline templates. This is because templates are designed to be used across multiple pipelines, and therefore repositories.
 
 ## Enabling signed pipelines on your agents
 

--- a/pages/agent/v3/signed_pipelines.md
+++ b/pages/agent/v3/signed_pipelines.md
@@ -35,8 +35,8 @@ The following fields are included in the signature for each step:
 - **Matrix configuration.** The matrix configuration is signed as a whole rather than each individual matrix job. This means the signature is the same for each job in the matrix. When signatures are verified for matrix jobs, the agent double-checks that the job it received is a valid construction of the matrix and that the signature matches the matrix configuration.
 - **The repository the commands are running in.** This prevents you from copying a signed step from one repository to another.
 
-> 📘 Compatibility with [pipeline templates](/docs/pipelines/templates)
-> Due to the inclusion of repository in step signatures, signed steps cannot be used with pipeline templates. This is because templates are designed to be used across multiple pipelines, and therefore repositories.
+> 📘 Compatibility with pipeline templates
+> [Pipeline templates](/docs/pipelines/templates) are designed to be used across multiple pipelines and therefore, repositories. Due to the inclusion of repositories in step signatures, signed steps cannot be used with pipeline templates.
 
 ## Enabling signed pipelines on your agents
 


### PR DESCRIPTION
Signed pipelines are not compatible with pipeline templates, so we should call that out in docs to make it clear.

![CleanShot 2024-02-29 at 11 08 54](https://github.com/buildkite/docs/assets/11305534/60c7ee06-518e-4667-921c-f25ac02d86c1)
