### PR TITLE
Ignore CVE-2023-50387

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -38,6 +38,7 @@ steps:
             - CVE-2023-5678  # openssl 3.0.11-1~deb12u1
             - CVE-2023-50495 # ncurses 6.4-4
             - CVE-2024-0567 # gnutls28 3.7.9-2+deb12u1
+            - CVE-2023-50387 # systemd 252.17-1~deb12u1
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying


### PR DESCRIPTION
Ignore https://security-tracker.debian.org/tracker/CVE-2023-50387 whilst waiting for a fix.