### PR TITLE
Update list of job states to include expired

### DIFF
--- a/pages/pipelines/_job_states.md
+++ b/pages/pipelines/_job_states.md
@@ -1,1 +1,1 @@
-Job state can be one of `pending`, `waiting`, `waiting_failed`, `blocked`, `blocked_failed`, `unblocked`, `unblocked_failed`, `limiting`, `limited`, `scheduled`, `assigned`, `accepted`, `running`, `finished`, `canceling`, `canceled`, `timing_out`, `timed_out`, `skipped`, or `broken`.
+Job state can be one of `pending`, `waiting`, `waiting_failed`, `blocked`, `blocked_failed`, `unblocked`, `unblocked_failed`, `limiting`, `limited`, `scheduled`, `assigned`, `accepted`, `running`, `finished`, `canceling`, `canceled`, `expired`, `timing_out`, `timed_out`, `skipped`, or `broken`.


### PR DESCRIPTION
A possible job state is `expired` which is shown in our job state diagram on the same page, however the list did not include this state. This updates the list to include the `expired` state.

![image](https://github.com/buildkite/docs/assets/19416785/97bc7a28-133f-406c-8bcc-d683fd610477)
