### PR TITLE
Move deploy to elastic-runners queue with OIDC role for cross account access

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -6,8 +6,10 @@ steps:
     if: |
       build.branch == "main"
     agents:
-      queue: deploy
+      queue: elastic-runners
     plugins:
+      - aws-assume-role-with-web-identity#v1.0.0:
+          role-arn: arn:aws:iam::${ECR_ACCOUNT_ID}:role/pipeline-buildkite-docs
       ecr#v2.7.0:
         login: true
         account-ids: ${ECR_ACCOUNT_ID}
@@ -15,9 +17,11 @@ steps:
   - name: ":ecr: ECR Vulnerabilities Scan"
     command: "true"
     agents:
-      queue: deploy
+      queue: elastic-runners
     depends_on: "ecr-push"
     plugins:
+      - aws-assume-role-with-web-identity#v1.0.0:
+          role-arn: arn:aws:iam::${ECR_ACCOUNT_ID}:role/pipeline-buildkite-docs
       - buildkite/ecr-scan-results#v1.2.0:
           image-name: "${ECR_REPO}:${BUILDKITE_BUILD_NUMBER}"
           ignore:
@@ -61,8 +65,11 @@ steps:
     concurrency: 1
     concurrency_group: docs-deploy
     agents:
-      queue: deploy
+      queue: elastic-runners
     command: scripts/deploy-ecs
+    plugins:
+      - aws-assume-role-with-web-identity#v1.0.0:
+          role-arn: arn:aws:iam::${ECR_ACCOUNT_ID}:role/pipeline-buildkite-docs
 
   - wait
 


### PR DESCRIPTION
Historically, we have used the `deploy` queue to manage resources in the production account. These agents run inside the account, and have fairly broad permissions that are used by several pipelines.

Instead of relying on the agents to have the permissions we need, we can use an OIDC assumable role with custom permissions. The benefits being:

- The role can be tightly scoped to the permissions needed to deploy `docs`
- The role is only assumable by the `main` branch of `docs-main` pipeline
- We can run the deploy steps on lower privilege agents

This pattern was recently used in the [site repo](https://github.com/buildkite/site/pull/2898).

The [role](https://github.com/buildkite/ops/pull/2137) has permissions to interact with ECR and ECS. However, we may need to tweak the permissions to add anything that's found to be missing.

Once the pipeline is working smoothly, we can remove buildkite/docs from the allowlist on the `deploy` agents.
