### PR TITLE
fix: BUILDKIT -> BUILDKITE

### DIFF
--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -210,7 +210,7 @@ attributes:
   desc: |
       Do not allow this agent to run arbitrary console commands.
 - name: no-git-submodules
-  env_var: BUILDKITE_NO_GIT_SUBMODULES, BUILDKIT_DISABLE_GIT_SUBMODULES
+  env_var: BUILDKITE_NO_GIT_SUBMODULES, BUILDKITE_DISABLE_GIT_SUBMODULES
   default_value: "false"
   required: false
   desc: |


### PR DESCRIPTION
There's a typo in the no-git-submodules section of the docs where it displays the value as:

BUILDKIT_DISABLE_GIT_SUBMODULES

When it should be:
BUILDKIT**E**_DISABLE_GIT_SUBMODULES