### PR TITLE
docs: fix wrong pipeline template mutation example in cookbook

### DIFF
--- a/pages/apis/graphql/cookbooks/pipeline_templates.md
+++ b/pages/apis/graphql/cookbooks/pipeline_templates.md
@@ -121,7 +121,9 @@ mutation AssignPipelineTemplate {
     pipeline {
       id
       name
-      pipelineTemplateId
+      pipelineTemplate {
+        id
+      }
     }
   }
 }
@@ -140,7 +142,9 @@ mutation UnassignPipelineTemplate {
     pipeline {
       id
       name
-      pipelineTemplateId
+      pipelineTemplate {
+        id
+      }
     }
   }
 }


### PR DESCRIPTION
There is no `pipelineTemplateId` field in `pipeline` but a `pipelineTemplate` field with an `id`.

The mutation without a correct format will fail with `"Field 'pipelineTemplateId' doesn't exist on type 'Pipeline'"`