### PR TITLE
Add context around [skip ci] use and builds not triggering

### DIFF
--- a/pages/pipelines/skipping.md
+++ b/pages/pipelines/skipping.md
@@ -46,6 +46,10 @@ To manually cancel a job:
 
 Some code changes, such as editing a Readme, may not require a Buildkite build. If you want Buildkite to ignore a commit, add `[ci skip]`,`[skip ci]`, `[ci-skip]`, or `[skip-ci]` anywhere in the commit message.
 
+>📘
+> When squashing commits in a merge, any commit message that contains `[skip ci]` will be included in the squashed commit message. This means that the merge will not trigger a build.
+> In order to avoid this and have the merge trigger a build, you should remove the commit containing `[skip ci]` from the squashed commit message.
+
 For example, the following commit message will cause Buildkite to ignore the commit and not create a corresponding build:
 
 ```


### PR DESCRIPTION
`[skip ci]` is a bit of a blunt instrument and recently we've seen > 1 case of confusion caused where builds haven't triggered due to its use.

I'd like to therefore add an informative message to the page which may aid in reducing the confusion.
