### PR TITLE
Clarify behaviour of group merging

### DIFF
--- a/pages/pipelines/group_step.md
+++ b/pages/pipelines/group_step.md
@@ -174,9 +174,9 @@ steps:
 
 ## Group merging
 
-If you upload a pipeline that has a `group` or `label` that matches a `group` or `label` in the pipeline that uploaded it, those groups will be merged together in the Buildkite UI.
+If you upload a pipeline that has a `group` or `label` that matches _the group of the step that uploaded it_, those groups will be merged together in the Buildkite UI.
 
-Group merging is only possible when a group in the uploaded pipeline matches the group step that uploaded this pipeline.
+This merging behavior only applies if the group step with the matching `group` or `label` is the first step within the uploaded pipeline.
 
 Note that inside a single pipeline, groups with the same `group` or `label` will not be merged in the Buildkite UI.
 


### PR DESCRIPTION
Group merging currently has a stricter criteria than the documentation suggested.

Specifically:
- The group to merge into must be the same group that the uploading step belongs to (this was in the documentation but not all that clear).
- Merging only happens if the matching group step is the first step within the uploaded pipeline YAML (not mentioned at all).