### PR TITLE
add: visibility to deprecation of unclustered agents message

### DIFF
--- a/pages/agent/v3/unclustered_tokens.md
+++ b/pages/agent/v3/unclustered_tokens.md
@@ -4,7 +4,6 @@
 > _It is not be possible to create and work with unclustered agents for any new Buildkite organizations created after the official release of clusters on February 26, 2024._ Therefore, unclustered agent tokens are not relevant to these organizations.
 > Previously, agents only connected directly to Buildkite via a token which was created and managed by the processes described on this page. These tokens are now a deprecated feature of Buildkite, and are referred to as _unclustered agent tokens_. Unclustered agent tokens, however, are still available to customers who have not yet migrated their pipelines to a [cluster](/docs/clusters/overview).
 > _Agent tokens_ are now associated with clusters, and connect to Buildkite through a specific cluster within an organization. Learn more about how to manage agent tokens for clusters in [Agent tokens](/docs/agent/v3/tokens) and how to [move your unclustered agents across to a cluster](/docs/clusters/manage-clusters#move-unclustered-agents-to-a-cluster).
-> **It is not be possible to create and work with unclustered agents for any new Buildkite organizations created after the official release of clusters on February 26, 2024.** Therefore, unclustered agent tokens are not relevant to these organizations.
 
 Any Buildkite organization created before February 26, 2024 has an _Unclustered_ area for managing _unclustered agents_, accessible through _Agents_ (from the global navigation) > _Unclustered_ of the Buildkite interface, where an _unclustered agent_ refers to any agent that is not associated with a cluster.
 

--- a/pages/agent/v3/unclustered_tokens.md
+++ b/pages/agent/v3/unclustered_tokens.md
@@ -3,7 +3,7 @@
 > 🚧 This page documents a deprecated Buildkite feature
 > Previously, agents only connected directly to Buildkite via a token which was created and managed by the processes described on this page. These tokens are now a deprecated feature of Buildkite, and are referred to as _unclustered agent tokens_. Unclustered agent tokens, however, are still available to customers who have not yet migrated their pipelines to a [cluster](/docs/clusters/overview).
 > _Agent tokens_ are now associated with clusters, and connect to Buildkite through a specific cluster within an organization. Learn more about how to manage agent tokens for clusters in [Agent tokens](/docs/agent/v3/tokens) and how to [move your unclustered agents across to a cluster](/docs/clusters/manage-clusters#move-unclustered-agents-to-a-cluster).
-> It is not be possible to create and work with unclustered agents for any new Buildkite organizations created after the official release of clusters on February 26, 2024. Therefore, unclustered agent tokens are not relevant to these organizations.
+> **It is not be possible to create and work with unclustered agents for any new Buildkite organizations created after the official release of clusters on February 26, 2024.** Therefore, unclustered agent tokens are not relevant to these organizations.
 
 Any Buildkite organization created before February 26, 2024 has an _Unclustered_ area for managing _unclustered agents_, accessible through _Agents_ (from the global navigation) > _Unclustered_ of the Buildkite interface, where an _unclustered agent_ refers to any agent that is not associated with a cluster.
 

--- a/pages/agent/v3/unclustered_tokens.md
+++ b/pages/agent/v3/unclustered_tokens.md
@@ -1,6 +1,7 @@
 # Unclustered agent tokens
 
 > 🚧 This page documents a deprecated Buildkite feature
+> _It is not be possible to create and work with unclustered agents for any new Buildkite organizations created after the official release of clusters on February 26, 2024._ Therefore, unclustered agent tokens are not relevant to these organizations.
 > Previously, agents only connected directly to Buildkite via a token which was created and managed by the processes described on this page. These tokens are now a deprecated feature of Buildkite, and are referred to as _unclustered agent tokens_. Unclustered agent tokens, however, are still available to customers who have not yet migrated their pipelines to a [cluster](/docs/clusters/overview).
 > _Agent tokens_ are now associated with clusters, and connect to Buildkite through a specific cluster within an organization. Learn more about how to manage agent tokens for clusters in [Agent tokens](/docs/agent/v3/tokens) and how to [move your unclustered agents across to a cluster](/docs/clusters/manage-clusters#move-unclustered-agents-to-a-cluster).
 > **It is not be possible to create and work with unclustered agents for any new Buildkite organizations created after the official release of clusters on February 26, 2024.** Therefore, unclustered agent tokens are not relevant to these organizations.


### PR DESCRIPTION
This PR bolds the text for: 
> It is not be possible to create and work with unclustered agents for any new Buildkite organizations created after the official release of clusters on February 26, 2024.

I feel this is an important piece of information that may get skipped as it is part of the paragraph that describes the deprecation.