### PR TITLE
Removing reference to Github and CircleCI plugin in TA

### DIFF
--- a/pages/test_analytics/importing_json.md
+++ b/pages/test_analytics/importing_json.md
@@ -27,8 +27,6 @@ See more configuration information in the [Test Collector plugin README](https:/
 
 Using the plugin is the recommended way as it allows for a better debugging process in case of an issue.
 
-An equivalent of Buildkite Test Collector plugin for GitHub Action and CircleCI Orb is in the works. Stay tuned!
-
 ### Without a plugin
 
 If for some reason you cannot or do not want to use the [Test Collector plugin](https://github.com/buildkite-plugins/test-collector-buildkite-plugin), or if you are looking to implement your own integration, another approach is possible.

--- a/pages/test_analytics/importing_junit_xml.md
+++ b/pages/test_analytics/importing_junit_xml.md
@@ -36,8 +36,6 @@ See more configuration information in the [Test Collector plugin README](https:/
 
 Using the plugin is the recommended way as it allows for a better debugging process in case of an issue.
 
-An equivalent of Buildkite Test Collector plugin for GitHub Actions and CircleCI Orb is in the works. Stay tuned!
-
 ### Not using a plugin
 
 If for some reason you cannot or do not want to use the [Test Collector plugin](https://github.com/buildkite-plugins/test-collector-buildkite-plugin), or if you are looking to implement your own integration, another approach is possible.


### PR DESCRIPTION
The docs say a plugin would be available for Github Actions and CircleCI but we don't have any plans to create one yet. 

We should remove this paragraph from these views to avoid customer expectation of a plugin being created soon.
- `/docs/test-analytics/importing-junit-xml`
- `/docs/test-analytics/importing-json`