### PR TITLE
Add example GraphQL query to get retry information for a Job

### DIFF
--- a/pages/apis/graphql/cookbooks/jobs.md
+++ b/pages/apis/graphql/cookbooks/jobs.md
@@ -169,3 +169,28 @@ mutation CancelJob {
   }
 }
 ```
+
+## Get retry information for a job
+
+To get information about how a job was retried (`retryType`), who retried the job (`retriedBy`) and which job was source of the retry (`uuid`).
+`retriedBy` will be `null` if the `retryType` is `AUTOMATIC`.
+
+```graphql
+query GetJobRetryInformation {
+  job(uuid: "job-uuid") {
+    ... on JobTypeCommand {
+      retrySource {
+        ... on JobInterface {
+          uuid
+          retried
+          retryType
+          retriedBy {
+            email
+            name
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/pages/apis/graphql/cookbooks/jobs.md
+++ b/pages/apis/graphql/cookbooks/jobs.md
@@ -172,7 +172,7 @@ mutation CancelJob {
 
 ## Get retry information for a job
 
-To get information about how a job was retried (`retryType`), who retried the job (`retriedBy`) and which job was source of the retry (`uuid`).
+Gets information about how a job was retried (`retryType`), who retried the job (`retriedBy`) and which job was source of the retry (`uuid`).
 `retriedBy` will be `null` if the `retryType` is `AUTOMATIC`.
 
 ```graphql


### PR DESCRIPTION
Adding this example as it is not possible to get the information in the Job that is a result of another being retried and a customer reached out wanting to get this information to perform different decisions in a job based on how it was retried - Manually or Automatically.