### PR TITLE
Adding Java to TA language nav

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,7 @@ Rails.application.routes.draw do
   get "/docs/agent/upgrading",           to: redirect("/docs/agent/v3/upgrading",                  status: 301)
   get "/docs/agent/upgrading-to-v3",     to: redirect("/docs/agent/v3/upgrading",                  status: 301)
   get "/docs/clusters/queue-metrics", to: redirect("/docs/pipelines/cluster-queue-metrics",        status: 301)
+  get "/docs/test-analytics/java", to: redirect("/docs/test-analytics/importing-junit-xml",        status: 301)
 
   # Old docs routes that we changed around during the development of the v3 agent docs
   get "/docs/agent/upgrading-to-v2",    to: redirect("/docs/agent/v2/upgrading-to-v2",            status: 301)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,8 +125,8 @@ Rails.application.routes.draw do
   get "/docs/agent/uploading-pipelines", to: redirect("/docs/agent/v3/cli-pipeline",               status: 301)
   get "/docs/agent/upgrading",           to: redirect("/docs/agent/v3/upgrading",                  status: 301)
   get "/docs/agent/upgrading-to-v3",     to: redirect("/docs/agent/v3/upgrading",                  status: 301)
-  get "/docs/clusters/queue-metrics", to: redirect("/docs/pipelines/cluster-queue-metrics",        status: 301)
-  get "/docs/test-analytics/java", to: redirect("/docs/test-analytics/importing-junit-xml",        status: 301)
+  get "/docs/clusters/queue-metrics",    to: redirect("/docs/pipelines/cluster-queue-metrics",        status: 301)
+  get "/docs/test-analytics/java",       to: redirect("/docs/test-analytics/importing-junit-xml",        status: 301)
 
   # Old docs routes that we changed around during the development of the v3 agent docs
   get "/docs/agent/upgrading-to-v2",    to: redirect("/docs/agent/v2/upgrading-to-v2",            status: 301)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,8 +125,8 @@ Rails.application.routes.draw do
   get "/docs/agent/uploading-pipelines", to: redirect("/docs/agent/v3/cli-pipeline",               status: 301)
   get "/docs/agent/upgrading",           to: redirect("/docs/agent/v3/upgrading",                  status: 301)
   get "/docs/agent/upgrading-to-v3",     to: redirect("/docs/agent/v3/upgrading",                  status: 301)
-  get "/docs/clusters/queue-metrics",    to: redirect("/docs/pipelines/cluster-queue-metrics",        status: 301)
-  get "/docs/test-analytics/java",       to: redirect("/docs/test-analytics/importing-junit-xml",        status: 301)
+  get "/docs/clusters/queue-metrics",    to: redirect("/docs/pipelines/cluster-queue-metrics",     status: 301)
+  get "/docs/test-analytics/java",       to: redirect("/docs/test-analytics/importing-junit-xml",  status: 301)
 
   # Old docs routes that we changed around during the development of the v3 agent docs
   get "/docs/agent/upgrading-to-v2",    to: redirect("/docs/agent/v2/upgrading-to-v2",            status: 301)

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -410,7 +410,7 @@
         - name: "Rust"
           path: "test-analytics/rust-collectors"
         - name: "Java"
-          path: "test-analytics/importing-junit-xml"
+          path: "test-analytics/java"
         - name: "Other languages"
           path: "test-analytics/other-collectors"
     - name: "References"

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -409,6 +409,8 @@
           path: "test-analytics/elixir-collectors"
         - name: "Rust"
           path: "test-analytics/rust-collectors"
+        - name: "Java"
+          path: "test-analytics/importing-junit-xml"
         - name: "Other languages"
           path: "test-analytics/other-collectors"
     - name: "References"

--- a/data/tiles.yml
+++ b/data/tiles.yml
@@ -30,6 +30,8 @@ test_analytics_guides:
         url: "/docs/test-analytics/elixir-collectors"
       - text: "Rust"
         url: "/docs/test-analytics/rust-collectors"
+      - text: "Java"
+        url: "/docs/test-analytics/importing-junit-xml"
       - text: "Other languages"
         url: "/docs/test-analytics/other-collectors"
   - title: "References"

--- a/data/tiles.yml
+++ b/data/tiles.yml
@@ -31,7 +31,7 @@ test_analytics_guides:
       - text: "Rust"
         url: "/docs/test-analytics/rust-collectors"
       - text: "Java"
-        url: "/docs/test-analytics/importing-junit-xml"
+        url: "/docs/test-analytics/java"
       - text: "Other languages"
         url: "/docs/test-analytics/other-collectors"
   - title: "References"


### PR DESCRIPTION
We now have a golden path for setting up Java repos, so we should update the docs to allow customers to easily find the documentation on setup. 

At the moment a customers have to go to References -> Importing JUnit XML. It would be easier for them just to see Java in the languages and then link to this page.