### PR TITLE
docs: Add GraphQL example of associating Pipeline with a Cluster

### DIFF
--- a/pages/apis/graphql/cookbooks/clusters.md
+++ b/pages/apis/graphql/cookbooks/clusters.md
@@ -186,7 +186,7 @@ query getClusterQueueAgent {
 
 ## Associate a pipeline with a cluster
 
-First, [get the Cluster ID](#get-a-pipelines-id) you want to associate the Pipeline with.
+First, [get the Cluster ID](#list-clusters) you want to associate the Pipeline with.
 Second, [get the Pipeline's ID](./pipelines#get-a-pipelines-id).
 Then, use the IDs to archive the pipelines:
 

--- a/pages/apis/graphql/cookbooks/clusters.md
+++ b/pages/apis/graphql/cookbooks/clusters.md
@@ -187,7 +187,7 @@ query getClusterQueueAgent {
 ## Associate a pipeline with a cluster
 
 First, [get the Cluster ID](#list-clusters) you want to associate the Pipeline with.
-Second, [get the Pipeline's ID](./pipelines#get-a-pipelines-id).
+Second, [get the Pipeline's ID](/docs/apis/graphql/cookbooks/pipelines#get-a-pipelines-id).
 Then, use the IDs to archive the pipelines:
 
 ```graphql

--- a/pages/apis/graphql/cookbooks/clusters.md
+++ b/pages/apis/graphql/cookbooks/clusters.md
@@ -184,7 +184,7 @@ query getClusterQueueAgent {
 }
 ```
 
-## Associate a Pipeline with a Cluster
+## Associate a pipeline with a cluster
 
 First, [get the Cluster ID](#get-a-pipelines-id) you want to associate the Pipeline with.
 Second, [get the Pipeline's ID](./pipelines#get-a-pipelines-id).

--- a/pages/apis/graphql/cookbooks/clusters.md
+++ b/pages/apis/graphql/cookbooks/clusters.md
@@ -184,3 +184,21 @@ query getClusterQueueAgent {
 }
 ```
 
+## Associate a Pipeline with a Cluster
+
+First, [get the Cluster ID](#get-a-pipelines-id) you want to associate the Pipeline with.
+Second, [get the Pipeline's ID](./pipelines#get-a-pipelines-id).
+Then, use the IDs to archive the pipelines:
+
+```graphql
+mutation AssociatePipelineWithCluster {
+  pipelineUpdate(input:{id: "pipeline-id" clusterId: "cluster-id"}) {
+    pipeline {
+      cluster {
+        name
+        id
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
As Clusters have entered General Availability, we do not have an example of how to use the GraphQL to associate Pipelines with Cluster which can be used to programmatically update multiple Pipelines