### PR TITLE
Rename pipeline templates to organization pipeline templates

### DIFF
--- a/pages/pipelines/templates.md
+++ b/pages/pipelines/templates.md
@@ -1,11 +1,11 @@
-# Pipeline templates
+# Organization pipeline templates
 
 > 📘 Enterprise feature
-> Pipeline templates are only available on an [Enterprise](https://buildkite.com/pricing) plan.
+> Organization pipeline templates are only available on an [Enterprise](https://buildkite.com/pricing) plan.
 
 ## Overview
 
-Pipeline templates allow you to define standard pipeline step configurations to use across all the pipelines in your organization.
+Organization pipeline templates allow you to define standard pipeline step configurations to use across all the pipelines in your organization.
 
 When a pipeline has a template assigned, the pipeline inherits its step configuration from the template.
 


### PR DESCRIPTION
Update existing docs to be more specific and remove some confusion between [public pipeline templates](https://buildkite.com/pipelines/templates).

_Note: this naming isn't confirmed, I'm just putting it up for feedback._