### PR TITLE
Update introduction to Buildkite Packages overview page

### DIFF
--- a/pages/packages.md
+++ b/pages/packages.md
@@ -1,6 +1,6 @@
 # Buildkite Packages
 
-Buildkite Packages manages artifacts and packages built from your [Buildkite pipelines](/docs/pipelines), as well as other CI/CD applications that require artifact management.
+Buildkite Packages manages artifacts and packages built from your [Buildkite Pipelines](/docs/pipelines), as well as other CI/CD applications that require artifact management.
 
 > 📘 Buildkite Packages is currently in private beta
 > Please visit the [Buildkite Packages](https://buildkite.com/packages) page on our website to join the wait list for this product.

--- a/pages/packages.md
+++ b/pages/packages.md
@@ -1,6 +1,9 @@
 # Buildkite Packages
 
-Buildkite Packages manages artifacts and packages built from your [Buildkite pipelines](/docs/pipelines).
+Buildkite Packages manages artifacts and packages built from your [Buildkite pipelines](/docs/pipelines), as well as other CI/CD applications that require artifact management.
+
+> 📘 Buildkite Packages is currently in private beta
+> Please visit the [Buildkite Packages](https://buildkite.com/packages) page on our website to join the wait list for this product.
 
 ## An introduction to packages
 

--- a/pages/packages.md
+++ b/pages/packages.md
@@ -1,6 +1,6 @@
 # Buildkite Packages
 
-Buildkite Packages manages artifacts and packages built from your [Buildkite Pipelines](/docs/pipelines), as well as other CI/CD applications that require artifact management.
+Buildkite Packages manages artifacts and packages from [Buildkite Pipelines](/docs/pipelines), as well as other CI/CD applications that require artifact management.
 
 > 📘 Buildkite Packages is currently in private beta
 > Please visit the [Buildkite Packages](https://buildkite.com/packages) page on our website to join the wait list for this product.


### PR DESCRIPTION
This PR addresses the following points (near the top of the main overview docs page for Buildkite Packages):

- Indicates up front that Buildkite Packages can be used with other CI/CD applications.
- Provides a link to the Buildkite Packages product page (https://buildkite.com/packages) indicating that people can sign up for the private beta there.