### PR TITLE
Remove bits that aren't quite true

### DIFF
--- a/pages/packages/getting_started.md
+++ b/pages/packages/getting_started.md
@@ -1,10 +1,6 @@
 # Getting started
 
-Buildkite Packages provides a repository for your [packages](/docs/packages#an-introduction-to-packages) which, in addition to holding a collection of packages, also contains metadata describing a variety of attributes for these packages such as, package versions, supported operating system versions and processor architecture, dependencies, and so on. A Buildkite Packages repository may:
-
-- Contain packages of any supported type. For example, Debian, RPM, RubyGem, and Python packages can all coexist in the same Buildkite Packages repository
-- Have packages for multiple Linux distributions, for example, if you have a Debian package that works for two versions of Ubuntu and one version of Debian you only need one Packages repository
-- Issue _read tokens_ to identify specific nodes and control access to a repository by specific node.
+Buildkite Packages provides a repository for your [packages](/docs/packages#an-introduction-to-packages) which, in addition to holding a collection of packages, also contains metadata describing a variety of attributes for these packages such as, package versions, supported operating system versions and processor architecture, dependencies, and so on.
 
 ## Supported package ecosystems
 


### PR DESCRIPTION
These claims were true for Packagecloud, but not Buildkite Packages. Buildkite Packages repositories can only contain one package type each. We do allow any distribution to use repositories, but we don't have "sub-repositories" for each ubuntu/debian distribution etc the way Packagecloud does. And authentication tokens are still evolving in product. So it might be easiest to remove these claims for now.

/cc @gilesgas 