### PR TITLE
Fix Algolia results 

### DIFF
--- a/config/algolia.json
+++ b/config/algolia.json
@@ -3,7 +3,10 @@
   "start_urls": ["https://buildkite.com/docs"],
   "stop_urls": ["agent/v2"],
   "selectors": {
-    "lvl0": ".Nav__link.Nav__link--level1.Nav__link--current",
+    "lvl0": {
+      "selector": ".SiteHeader__nav .Nav__link.Nav__link--level1.Nav__link--current",
+      "global": true
+    },
     "lvl1": ".Article h1",
     "lvl2": ".Article h2",
     "lvl3": ".Article h3",
@@ -11,7 +14,13 @@
     "lvl5": ".Article h5, .Article td:first-child",
     "text": ".Article p, .Article li, .Article td"
   },
-  "selectors_exclude": ["[data-algolia-exclude]", ".Toc", ".Footer", ".Nav"],
+  "selectors_exclude": [
+    "[data-algolia-exclude]",
+    ".Toc",
+    ".Footer",
+    ".Page__sidebar",
+    ".Nav__section--level2"
+  ],
   "custom_settings": {
     "synonyms": [["Pipeline.yml", "Pipeline.yaml", "config.yml", "config.yaml"]]
   }

--- a/config/algolia.json
+++ b/config/algolia.json
@@ -3,12 +3,12 @@
   "start_urls": ["https://buildkite.com/docs"],
   "stop_urls": ["agent/v2"],
   "selectors": {
-    "lvl0": ".Article h1",
-    "lvl1": ".Article h2",
-    "lvl2": ".Article h3",
-    "lvl3": ".Article h4, .Article th",
-    "lvl4": ".Article h5, .Article td:first-child",
-    "lvl5": ".Article h6",
+    "lvl0": ".Nav__link.Nav__link--level1.Nav__link--current",
+    "lvl1": ".Article h1",
+    "lvl2": ".Article h2",
+    "lvl3": ".Article h3",
+    "lvl4": ".Article h4, .Article th",
+    "lvl5": ".Article h5, .Article td:first-child",
     "text": ".Article p, .Article li, .Article td"
   },
   "selectors_exclude": ["[data-algolia-exclude]", ".Toc", ".Footer", ".Nav"],


### PR DESCRIPTION
Something isn't quite right with our Algolia doc scraper configuration. We've got lots of blank links and grouping isn't really happening.

<img width="658" alt="Screenshot 2024-03-25 at 10 59 42 am" src="https://github.com/buildkite/docs/assets/656826/5e61ec06-5a08-4a55-a008-bad866f50791">

<img width="657" alt="Screenshot 2024-03-25 at 10 59 27 am" src="https://github.com/buildkite/docs/assets/656826/cadc4cf5-7cea-43d4-9790-87efeb704ae3">


After reading the [docs](https://docsearch.algolia.com/docs/legacy/config-file/) some more and reviewing some other configurations, it occurred to me that our doc search is missing the top level grouping (ie. Packages, Test Analytics, Pipelines etc.) which I think is causing the issue since that content should live in the `header` of the page.

This PR switches up the selectors to match `lvl0` to the active nav item and removes `h6` headers which aren't being used.

Before merging, I'll manually trigger a crawl from this branch to confirm it all works as expected.
