### PR TITLE
[PIE-2406] Add new suite fields to suite apis

### DIFF
--- a/pages/apis/rest_api/analytics/suites.md
+++ b/pages/apis/rest_api/analytics/suites.md
@@ -106,7 +106,7 @@ Optional [request body properties](/docs/api#request-body-properties):
     </tr>
     <tr><th><code>application_name</code></th><td>Application name for the suite.<br><em>Example:</em> <code>"Buildkite"</code></td></tr>
     <tr><th><code>color</code></th><td>Color for the suite navatar.<br><em>Example:</em> <code>"#FFF700"</code></td></tr>
-    <tr><th><code>emoji</code></th><td>Emoji for the suite navatar.<br><em>Example:</em> <code>"🍋"</code>, <code>"\:lemon\:"</code></td></tr>
+    <tr><th><code>emoji</code></th><td>Emoji for the suite navatar. Check out our <a href="https://github.com/buildkite/emojis#emoji-reference">documentation for supported emoji</a>.<br><em>Example:</em> <code>"🍋"</code>, <code>"\:lemon\:"</code></td></tr>
   </tbody>
 </table>
 
@@ -146,7 +146,7 @@ Optional [request body properties](/docs/api#request-body-properties):
   <tr><th><code>default_branch</code></th><td>Your test suite will default to showing trends for this default branch, but collect data for all test runs.<br><em>Example:</em> <code>"main"</code> or <code>"master"</code>.</td></tr>
   <tr><th><code>application_name</code></th><td>Application name for the suite.<br><em>Example:</em> <code>"Buildkite"</code></td></tr>
   <tr><th><code>color</code></th><td>Color for the suite navatar.<br><em>Example:</em> <code>"#ffb7c5"</code></td></tr>
-  <tr><th><code>emoji</code></th><td>Emoji for the suite navatar.<br><em>Example:</em> <code>"🌸"</code>, <code>"\:cherry_blossom\:"</code></td></tr>
+  <tr><th><code>emoji</code></th><td>Emoji for the suite navatar. Check out our <a href="https://github.com/buildkite/emojis#emoji-reference">documentation for supported emoji.</a><br><em>Example:</em> <code>"🌸"</code>, <code>"\:cherry_blossom\:"</code></td></tr>
 </tbody>
 </table>
 

--- a/pages/apis/rest_api/analytics/suites.md
+++ b/pages/apis/rest_api/analytics/suites.md
@@ -59,6 +59,9 @@ curl -H "Authorization: Bearer $TOKEN" \
   -d '{
     "name": "Jasmine",
     "default_branch": "main",
+    "application_name": "Buildkite",
+    "color": "#FFF700",
+    "emoji": "🍋",
     "show_api_token": true,
     "team_ids": ["3f4aa5ee-671b-41b0-9b44-b94831db6cc8"]
   }'
@@ -73,6 +76,9 @@ curl -H "Authorization: Bearer $TOKEN" \
   "url": "https://api.buildkite.com/v2/analytics/organizations/my_great_org/suites/jasmine",
   "web_url": "https://buildkite.com/organizations/my_great_org/analytics/suites/jasmine",
   "default_branch": "main",
+  "application_name": "Buildkite",
+  "color": "#FFF700",
+  "emoji": "🍋",
   "api_token": "AAAAAAAAAAAAAAAAAAAAAAAA"
 }
 ```
@@ -98,7 +104,9 @@ Optional [request body properties](/docs/api#request-body-properties):
         <em>Example:</em> <code>"team_ids": ["3f4aa5ee-671b-41b0-9b44-b94831db6cc8"]</code></td></tr>
       </td>
     </tr>
-    <tr>
+    <tr><th><code>application_name</code></th><td>Application name for the suite.<br><em>Example:</em> <code>"Buildkite"</code></td></tr>
+    <tr><th><code>color</code></th><td>Color for the suite navatar.<br><em>Example:</em> <code>"#FFF700"</code></td></tr>
+    <tr><th><code>emoji</code></th><td>Emoji for the suite navatar.<br><em>Example:</em> <code>"🍋"</code>, <code>"\:lemon\:"</code></td></tr>
   </tbody>
 </table>
 
@@ -136,6 +144,9 @@ Optional [request body properties](/docs/api#request-body-properties):
 <tbody>
   <tr><th><code>name</code></th><td>Name of the suite.<br><em>Example:</em> <code>"Jasmine"</code>.</td></tr>
   <tr><th><code>default_branch</code></th><td>Your test suite will default to showing trends for this default branch, but collect data for all test runs.<br><em>Example:</em> <code>"main"</code> or <code>"master"</code>.</td></tr>
+  <tr><th><code>application_name</code></th><td>Application name for the suite.<br><em>Example:</em> <code>"Buildkite"</code></td></tr>
+  <tr><th><code>color</code></th><td>Color for the suite navatar.<br><em>Example:</em> <code>"#ffb7c5"</code></td></tr>
+  <tr><th><code>emoji</code></th><td>Emoji for the suite navatar.<br><em>Example:</em> <code>"🌸"</code>, <code>"\:cherry_blossom\:"</code></td></tr>
 </tbody>
 </table>
 

--- a/vale/styles/vocab.txt
+++ b/vale/styles/vocab.txt
@@ -128,6 +128,7 @@ mutex
 namespace
 namespaced
 namespaces
+navatar
 negator
 NGINX
 Noreply


### PR DESCRIPTION
## Description

We had a support request raised by a customer who noticed that terraform provider(TFP) did not have UI feature parity with `:suites`. New fields were added as a part of the suite#index uplift. TFP uses the TA suite API to update and create suites, and consequently the API has had to be updated to accept these new optional fields.

I've updated the docs for suite API to ensure Feature parity / accessibility to all customers

<img width="1373" alt="Screenshot 2024-03-27 at 12 14 22" src="https://github.com/buildkite/docs/assets/13619812/ef75b1ea-49d9-4dd6-9de0-83a8ec33287a">
<img width="1283" alt="Screenshot 2024-03-27 at 12 14 18" src="https://github.com/buildkite/docs/assets/13619812/6fd1f9d5-d1b0-46a8-9026-1334d18dde8a">

## Related links
[PIE-2406](https://linear.app/buildkite/issue/PIE-2406/auditupdate-terraform-provider-to-ensure-parity-with-suite-index)
[Escalation](https://3.basecamp.com/3453178/buckets/1713315/card_tables/cards/7225937705#__recording_7230084616)
[BK PR to add fields to API](https://github.com/buildkite/buildkite/pull/16114)