### PR TITLE
Update EC2 Mac instructions for macOS Sonoma

### DIFF
--- a/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md
+++ b/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md
@@ -80,16 +80,16 @@ You do not need to install the `buildkite-agent` in your template AMI, the
 `buildkite-agent` will be installed at boot time by the launch template's
 `UserData` script.
 
-## Step 3: Associate your AMI with a customer managed license in AWS License Manager
+## Step 3: Associate your AMI with a self-managed license in AWS License Manager
 
 To launch an instance using a host resource group, the instance AMI must be
-associated with a *Customer managed license* in *AWS License Manager*.
+associated with a *Self-managed license* in *AWS License Manager*.
 
 Using the AWS Console, open the *AWS License Manager* and navigate to
-*Customer managed licenses*. Create a new *Customer managed license*, enter a
+*Self-managed licenses*. Create a new *Self-managed license*, enter a
 descriptive name and select a *License type* of `Cores`.
 
-Once your Customer managed license has been saved, open the detail view for your
+Once your self-managed license has been saved, open the detail view for your
 license. Open the *Associated AMIs* tab and choose *Associate AMI*. From the
 list of *Available AMIs*, select your macOS template AMI and then click
 *Associate*.

--- a/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md
+++ b/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md
@@ -69,9 +69,9 @@ can access the instance.
 	- Grow the AFPS container to use all the available space in your EBS root disk if needed, see the [AWS user guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-mac-instances.html#mac-instance-increase-volume)
 1. Using a VNC session (run SSH port forwarding `ssh -L 5900:localhost:5900 ec2-user@<ip-address>` if direct access is not available):
 	1. Sign in as the `ec2-user`
-	1. Enable *Automatic login* for the `ec2-user` in *System Preferences* > *Users & Accounts* > *Login Options*
-	1. Disable *Require password* in *System Preferences* > *Security & Privacy* > *General*
-	1. Disable the screen saver in *System Preferences* > *Desktop & Screen Saver* > *Show screen saver after*
+	1. Set *Automatically log in as* to `ec2-user` in *System Preferences* > *Users & Groups*
+	1. Set an empty password in *System Preferences* > *Login Password*
+	1. Set *Start Screen Saver when inactive* to `Never` in *System Preferences* > *Lock Screen*
 1. Install your required version of Xcode, and ensure you launch Xcode at least
 once so you are presented with the EULA prompt.
 1. Using the AWS EC2 Console, create an AMI from your instance.

--- a/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md
+++ b/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md
@@ -69,9 +69,9 @@ can access the instance.
 	- Grow the AFPS container to use all the available space in your EBS root disk if needed, see the [AWS user guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-mac-instances.html#mac-instance-increase-volume)
 1. Using a VNC session (run SSH port forwarding `ssh -L 5900:localhost:5900 ec2-user@<ip-address>` if direct access is not available):
 	1. Sign in as the `ec2-user`
-	1. Set *Automatically log in as* to `ec2-user` in *System Preferences* > *Users & Groups*
-	1. Set an empty password in *System Preferences* > *Login Password*
-	1. Set *Start Screen Saver when inactive* to `Never` in *System Preferences* > *Lock Screen*
+	1. Set **Automatically log in as** to `ec2-user` in **System Preferences** > **Users & Groups**
+	1. Set an empty password in **System Preferences** > **Login Password**
+	1. Set **Start Screen Saver when inactive** to `Never` in **System Preferences** > **Lock Screen**
 1. Install your required version of Xcode, and ensure you launch Xcode at least
 once so you are presented with the EULA prompt.
 1. Using the AWS EC2 Console, create an AMI from your instance.
@@ -83,11 +83,11 @@ You do not need to install the `buildkite-agent` in your template AMI, the
 ## Step 3: Associate your AMI with a self-managed license in AWS License Manager
 
 To launch an instance using a host resource group, the instance AMI must be
-associated with a *Self-managed license* in *AWS License Manager*.
+associated with a **Self-managed license** in **AWS License Manager**.
 
 Using the AWS Console, open the *AWS License Manager* and navigate to
-*Self-managed licenses*. Create a new *Self-managed license*, enter a
-descriptive name and select a *License type* of `Cores`.
+**Self-managed licenses**. Create a new **Self-managed license**, enter a
+descriptive name and select a **License type** of `Cores`.
 
 Once your self-managed license has been saved, open the detail view for your
 license. Open the *Associated AMIs* tab and choose *Associate AMI*. From the

--- a/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md
+++ b/pages/agent/v3/elastic_ci_stack_for_ec2_mac/autoscaling_mac_metal.md
@@ -90,9 +90,9 @@ Using the AWS Console, open the *AWS License Manager* and navigate to
 descriptive name and select a **License type** of `Cores`.
 
 Once your self-managed license has been saved, open the detail view for your
-license. Open the *Associated AMIs* tab and choose *Associate AMI*. From the
-list of *Available AMIs*, select your macOS template AMI and then click
-*Associate*.
+license. Open the **Associated AMIs** tab and choose **Associate AMI**. From the
+list of **Available AMIs**, select your macOS template AMI and then click
+**Associate**.
 
 ## Step 4: Deploy the CloudFormation template
 

--- a/pages/agent/v3/elastic_ci_stack_for_ec2_mac/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_stack_for_ec2_mac/troubleshooting.md
@@ -14,7 +14,7 @@ Zones of your VPC subnets. This error is likely to be a temporary one, wait for 
 Auto Scaling group to attempt to scale out again and see if the error persists.
 
 * Your launch template's AMI may not have been associated with a Customer
-Managed License in AWS License Manager. Ensure you [associate your AMI](/docs/agent/v3/elastic-ci-stack-for-ec2-mac/autoscaling-mac-metal#step-3-associate-your-ami-with-a-customer-managed-license-in-aws-license-manager)
+Managed License in AWS License Manager. Ensure you [associate your AMI](/docs/agent/v3/elastic-ci-stack-for-ec2-mac/autoscaling-mac-metal#step-3-associate-your-ami-with-a-self-managed-license-in-aws-license-manager)
 and any new AMIs with a Customer managed license. Ensure the License
 configuration has a *License type* of `Cores`.
 
@@ -30,4 +30,3 @@ To allow your pipelines to use Xcode and the iOS simulator the Buildkite Agent l
 ## What user does the agent run as?
 
 The Buildkite agent runs as `ec2-user`.
-

--- a/pages/agent/v3/elastic_ci_stack_for_ec2_mac/troubleshooting.md
+++ b/pages/agent/v3/elastic_ci_stack_for_ec2_mac/troubleshooting.md
@@ -16,7 +16,7 @@ Auto Scaling group to attempt to scale out again and see if the error persists.
 * Your launch template's AMI may not have been associated with a Customer
 Managed License in AWS License Manager. Ensure you [associate your AMI](/docs/agent/v3/elastic-ci-stack-for-ec2-mac/autoscaling-mac-metal#step-3-associate-your-ami-with-a-self-managed-license-in-aws-license-manager)
 and any new AMIs with a Customer managed license. Ensure the License
-configuration has a *License type* of `Cores`.
+configuration has a **License type** of `Cores`.
 
 ## My instances don't start the `buildkite-agent`
 


### PR DESCRIPTION
The current version of macOS has moved some settings around, and AWS have renamed theirs.

![CleanShot 2024-04-04 at 14 55 58](https://github.com/buildkite/docs/assets/535/8f66e6c9-9544-434b-8586-9e04abaf0400)
![CleanShot 2024-04-04 at 14 56 13](https://github.com/buildkite/docs/assets/535/d7e5bdc6-8fc3-4ac3-8b11-918c2839c450)
![CleanShot 2024-04-04 at 14 57 04](https://github.com/buildkite/docs/assets/535/ff5f714d-6641-4811-ad1e-7083dafd38a8)
![CleanShot 2024-04-08 at 17 30 23](https://github.com/buildkite/docs/assets/535/eb447d94-452b-4d2a-8fb0-8718efea31bc)

