### PR TITLE
Add references to the Pipeline templates onto the docs

### DIFF
--- a/pages/pipelines/create_your_own.md
+++ b/pages/pipelines/create_your_own.md
@@ -30,7 +30,7 @@ Next, define the steps you want in your pipeline. These steps could be anything 
 To define the steps:
 
 1. Decide the goal of the pipeline.
-1. Look for an [example pipeline](/docs/pipelines/example-pipelines) closest to that goal. You can copy parts of the pipeline definition as a starting point.
+1. Look for an [example pipeline](/docs/pipelines/example-pipelines) closest to that goal or [pipeline template](https://buildkite.com/pipelines/templates) relevant your technology stack and use case. You can copy parts of the pipeline definition as a starting point.
 1. In the root of your repository, create a file named `pipeline.yml` in a `.buildkite` directory.
 1. In `pipeline.yml`, define your pipeline steps. Here's an example:
 
@@ -105,6 +105,7 @@ We recommend you continue by:
 
 - Inviting your team to see your build and try Buildkite themselves. Invite users from your [organization's user settings](https://buildkite.com/organizations/-/users/new) by pasting their email addresses into the form. Please note that to be able to start inviting other users to your Buildkite organization, your email needs to be verified. To verify your email, go to your [personal email settings](https://buildkite.com/user/emails) and select _Resend Verification_.
 - Learning to [create more complex pipelines](/docs/pipelines/defining-steps) with dynamic definitions, conditionals, and concurrency.
+- Browse [pipeline template](https://buildkite.com/pipelines/templates) to see how Buildkite is used across different technology and use cases.
 - Customizing your [agent configuration](/docs/agent/v3/configuration) and learning to use [lifecycle hooks](/docs/agent/v3/hooks).
 - Understanding how to tailor Buildkite to fit your bespoke workflows with [plugins](/docs/plugins) and the [API](/docs/apis).
 

--- a/pages/pipelines/create_your_own.md
+++ b/pages/pipelines/create_your_own.md
@@ -30,7 +30,7 @@ Next, define the steps you want in your pipeline. These steps could be anything 
 To define the steps:
 
 1. Decide the goal of the pipeline.
-1. Look for an [example pipeline](/docs/pipelines/example-pipelines) closest to that goal or [pipeline template](https://buildkite.com/pipelines/templates) relevant your technology stack and use case. You can copy parts of the pipeline definition as a starting point.
+1. Look for an [example pipeline](/docs/pipelines/example-pipelines) closest to that goal or a [pipeline template](https://buildkite.com/pipelines/templates) relevant to your technology stack and use case. (You can copy parts of the pipeline definition as a starting point.)
 1. In the root of your repository, create a file named `pipeline.yml` in a `.buildkite` directory.
 1. In `pipeline.yml`, define your pipeline steps. Here's an example:
 

--- a/pages/pipelines/create_your_own.md
+++ b/pages/pipelines/create_your_own.md
@@ -105,7 +105,7 @@ We recommend you continue by:
 
 - Inviting your team to see your build and try Buildkite themselves. Invite users from your [organization's user settings](https://buildkite.com/organizations/-/users/new) by pasting their email addresses into the form. Please note that to be able to start inviting other users to your Buildkite organization, your email needs to be verified. To verify your email, go to your [personal email settings](https://buildkite.com/user/emails) and select _Resend Verification_.
 - Learning to [create more complex pipelines](/docs/pipelines/defining-steps) with dynamic definitions, conditionals, and concurrency.
-- Browse [pipeline template](https://buildkite.com/pipelines/templates) to see how Buildkite is used across different technology and use cases.
+- Browse the [pipeline templates](https://buildkite.com/pipelines/templates) to see how Buildkite is used across different technology stacks and use cases.
 - Customizing your [agent configuration](/docs/agent/v3/configuration) and learning to use [lifecycle hooks](/docs/agent/v3/hooks).
 - Understanding how to tailor Buildkite to fit your bespoke workflows with [plugins](/docs/plugins) and the [API](/docs/apis).
 

--- a/pages/pipelines/example_pipelines.md
+++ b/pages/pipelines/example_pipelines.md
@@ -1,6 +1,6 @@
 # Example pipelines
 
-Example [pipelines](/docs/pipelines) can be found in our [pipeline template gallery](https://buildkite.com/pipelines/templates) covering a wide range of technologies (such as [JavaScript](https://buildkite.com/pipelines/templates?language=javascript)) and use cases (such as [infrastructure as code](https://buildkite.com/pipelines/templates?useCase=iac)).
+Example [pipelines](/docs/pipelines) can be found in Buildkite's [pipeline template gallery](https://buildkite.com/pipelines/templates), covering a wide range of technologies (for example, [JavaScript](https://buildkite.com/pipelines/templates?language=javascript)), and use cases (for example, [infrastructure as code](https://buildkite.com/pipelines/templates?useCase=iac)).
 
 Further example pipelines with their own repository are below.
 

--- a/pages/pipelines/example_pipelines.md
+++ b/pages/pipelines/example_pipelines.md
@@ -1,6 +1,6 @@
 # Example pipelines
 
-Example [pipelines](/docs/pipelines) can be found in our [pipeline template gallery](https://buildkite.com/pipelines/templates) covering a wide range of technologies (such as [javascript](https://buildkite.com/pipelines/templates?language=javascript)) and use cases (such as [infrastructure as code](https://buildkite.com/pipelines/templates?useCase=iac)).
+Example [pipelines](/docs/pipelines) can be found in our [pipeline template gallery](https://buildkite.com/pipelines/templates) covering a wide range of technologies (such as [JavaScript](https://buildkite.com/pipelines/templates?language=javascript)) and use cases (such as [infrastructure as code](https://buildkite.com/pipelines/templates?useCase=iac)).
 
 Further example pipelines with their own repository are below.
 

--- a/pages/pipelines/example_pipelines.md
+++ b/pages/pipelines/example_pipelines.md
@@ -1,7 +1,8 @@
 # Example pipelines
 
-A list of repositories containing example [pipelines](/docs/pipelines).
+Example [pipelines](/docs/pipelines) can be found in our [pipeline template gallery](https://buildkite.com/pipelines/templates) covering a wide range of technologies (such as [javascript](https://buildkite.com/pipelines/templates?language=javascript)) and use cases (such as [infrastructure as code](https://buildkite.com/pipelines/templates?useCase=iac)).
 
+Further example pipelines with their own repository are below.
 
 <!-- vale off -->
 <!-- this turns it off for the whole file because I can't ignore the emoji in the html :( -->
@@ -234,7 +235,6 @@ A list of repositories containing example [pipelines](/docs/pipelines).
     <span class="repo">gist.github.com/toolmantim/1337952c8b5b1e5b0b5ea10c40e9efe4</span>
   </span>
 </a>
-
 
 ## Third-party tools
 

--- a/pages/tutorials/bazel.md
+++ b/pages/tutorials/bazel.md
@@ -16,7 +16,7 @@ Bazel supports large codebases across multiple repositories, and large numbers o
 
 ## Buildkite Bazel example
 
-The [Building with Bazel](https://buildkite.com/pipelines/templates/ci/bazel-ci?queryID=2e432af39a35aeac99901b275534243c) example pipeline template demonstrates how a continuous integration pipeline might run on a Bazel project. The visualization below shows the steps in [this pipeline](https://buildkite.com/pipelines/templates/ci/bazel-ci?queryID=2e432af39a35aeac99901b275534243c).
+The [Building with Bazel](https://buildkite.com/pipelines/templates/ci/bazel-ci?queryID=2e432af39a35aeac99901b275534243c) example pipeline template demonstrates how a continuous integration pipeline might run on a Bazel project. The visualization below shows the steps in its example pipeline.
 
 <p><iframe src="https://buildkite.com/pipelines/playground/embed?tid=bazel-ci" allow="fullscreen" crossorigin="anonymous" width="100%" height="300px"></iframe></p>
 

--- a/pages/tutorials/bazel.md
+++ b/pages/tutorials/bazel.md
@@ -7,13 +7,18 @@ keywords: docs, pipelines, tutorials, bazel
 [Bazel](https://www.bazel.build/) is an open-source build and test tool similar to Make, Maven, and Gradle.
 Bazel supports large codebases across multiple repositories, and large numbers of users.
 
-
 ## Using Bazel on Buildkite
 
 1. [Install Bazel](https://docs.bazel.build/install.html) on one or more Buildkite Agents.
 2. Add an empty [`WORKSPACE` file](https://docs.bazel.build/tutorial/cpp.html#set-up-the-workspace) to your project to mark it as a Bazel workspace.
 3. Add a [`BUILD` file](https://docs.bazel.build/tutorial/cpp.html#understand-the-build-file) to your project to tell Bazel how to build it.
 4. Add the Bazel build target(s) to your Buildkite [Pipeline](/docs/pipelines/defining-steps).
+
+## Buildkite Bazel example
+
+The [Building with Bazel](https://buildkite.com/pipelines/templates/ci/bazel-ci?queryID=2e432af39a35aeac99901b275534243c) example pipeline template demonstrates how a continuous integration pipeline might run on a Bazel project. The visualization below shows the steps in [this pipeline](https://buildkite.com/pipelines/templates/ci/bazel-ci?queryID=2e432af39a35aeac99901b275534243c).
+
+<p><iframe src="https://buildkite.com/pipelines/playground/embed?tid=bazel-ci" allow="fullscreen" crossorigin="anonymous" width="100%" height="300px"></iframe></p>
 
 ## Buildkite C++ Bazel example
 
@@ -32,5 +37,5 @@ Make sure you're signed into your [Buildkite account](https://buildkite.com) and
 
 ## Further reading
 
-* The [Bazel C++ tutorial](https://docs.bazel.build/tutorial/cpp.html#refine-your-bazel-build) goes into more detail about how to configure more complex Bazel builds, covering multiple build targets and multiple packages.
-* The Bazel [external dependencies docs](https://docs.bazel.build/external.html) show you how to build other local and remote repositories.
+- The [Bazel C++ tutorial](https://docs.bazel.build/tutorial/cpp.html#refine-your-bazel-build) goes into more detail about how to configure more complex Bazel builds, covering multiple build targets and multiple packages.
+- The Bazel [external dependencies docs](https://docs.bazel.build/external.html) show you how to build other local and remote repositories.

--- a/pages/tutorials/docker_containerized_builds.md
+++ b/pages/tutorials/docker_containerized_builds.md
@@ -96,6 +96,11 @@ There are many configuration options available for the Docker plugin. For the co
 >📘 Pinning plugin versions
 > Specifying the version of your plugin using the <code>plugin-name#vx.x.x</code> format is recommended, to ensure that no changes are introduced without your knowledge.
 
+## Pipeline templates using Docker
+
+To see more examples of how Docker is used in Buildkite pipelines, browse the [Docker templates](https://buildkite.com/pipelines/templates?platform=docker).
+
+
 ## Creating your own Docker infrastructure
 
 If your team has significant Docker experience you might find it worthwhile invoking your own runner scripts rather than using the simpler built-in Docker support.


### PR DESCRIPTION
This PR makes some changes to the docs in order to reference our new pipeline templates gallery wherever possible. I've added it to some of the tutorial pages, to the integration pages and to the getting started pages. Definitely open to any wording suggestions and feedback. 

Note: if viewing the Docker tutorial page locally in dev, the iframe won't load properly and you'll need [this extension](https://chromewebstore.google.com/detail/ignore-x-frame-headers/gleekbfjekiniecknbkamfmkohkpodhe) to remove some type of header to enable loading. Or you can trust me it works :P 
![Screenshot 2024-04-08 at 3 41 23 pm](https://github.com/buildkite/docs/assets/7695209/c357fdff-ede2-4980-a6d4-9bf898010305)



Thank you!