### PR TITLE
Fix broken navigation from docs back to app

### DIFF
--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -19,6 +19,9 @@
 
 <meta name="referrer" content="origin-when-cross-origin" />
 
+<%# Links to pages on the same origin, but outside /docs site shouldn't use Turbo %>
+<meta name="turbo-root" content="/docs">
+
 <%= tag :link, rel: "shortcut icon", href: vite_asset_path("images/favicon.png"), type: "image/x-icon" %>
 <%= tag :link, rel: "apple-touch-icon", href: vite_asset_path("images/appicon.png") %>
 <%= tag :link, rel: "mask-icon", href: vite_asset_path("images/logo-pinned.svg"), color: "#14CC80" %>


### PR DESCRIPTION
### Reproduction steps
1. Visit https://buildkite.com/docs/apis/graphql/graphql-tutorial
2. Follow the link to “GraphQL console”

### Expected behaviour
The GraphQL console page loads

### Actual behaviour
It does a Turbo Drive navigation and fails on a blank page. There's a JS error trying to execute the [turbo:render callback for the docs site](https://github.com/buildkite/docs/blob/b6d31cbdb6caed91f05d266112f0bdace16a671d/app/frontend/entrypoints/application.js#L9).

https://github.com/buildkite/docs/assets/1201065/7b65889f-b6a3-477c-baf0-093115b5ca6e

### Changes

By default, Turbo Drive try to load all URLs on the same origin (ie. all of buildkite.com). The [turbo-root](https://turbo.hotwired.dev/handbook/drive#setting-a-root-location) option lets us scope this instance of Turbo to the `/docs` prefix only, so it doesn't attempt to handle any navigation from the docs back to the app.

Associated [support esclation](https://coda.io/d/_dHnUHNps1YO#Escalations-Table_tuS42/r372&view=modal)