### PR TITLE
SUP-2072: Add example of using GraphQL to get the Download URL for Artifacts from a Build

### DIFF
--- a/data/nav_graphql.yml
+++ b/data/nav_graphql.yml
@@ -9,6 +9,8 @@
     path: apis/graphql/graphql-cookbook
   - name: Agents
     path: apis/graphql/cookbooks/agents
+  - name: Artifacts
+    path: apis/graphql/cookbooks/artifacts
   - name: Builds
     path: apis/graphql/cookbooks/builds
   - name: Clusters

--- a/pages/apis/graphql/cookbooks/artifacts.md
+++ b/pages/apis/graphql/cookbooks/artifacts.md
@@ -1,0 +1,30 @@
+# Artifacts
+
+A collection of common tasks with artifacts using the GraphQL API.
+
+## List download URLs for artifacts from a build
+
+To get the download URLs for artifacts from a build.
+If the artifact is stored on Buildkite-managed artifact storage, the download URL will be valid for only 10 minutes.
+
+```graphql
+query GetDownloadURLsForArtifactsFromBuild {
+  build(uuid: "build-uuid") {
+    jobs(first: 500) {
+      edges {
+        node {
+          ... on JobTypeCommand {
+            artifacts {
+              edges {
+                node {
+                  downloadURL
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/pages/apis/graphql/cookbooks/artifacts.md
+++ b/pages/apis/graphql/cookbooks/artifacts.md
@@ -17,6 +17,7 @@ query GetDownloadURLsForArtifactsFromBuild {
             artifacts {
               edges {
                 node {
+                  path
                   downloadURL
                 }
               }


### PR DESCRIPTION
We have it documented how to get the Download URLs for Artifacts via the REST API but missing an example of using GraphQL to get them.
In addition mentining the URLs from Buildkite Artifacts expire after 10 minutes rather than 60 seconds with the REST API.

Using GraphQL to get the multiple Download URLs is faster than the REST API.