### PR TITLE
Remove 'Team' plan refs and change 'Business' plan refs to 'Pro'

### DIFF
--- a/pages/integrations/amazon_eventbridge.md
+++ b/pages/integrations/amazon_eventbridge.md
@@ -770,7 +770,7 @@ AWS EventBridge has strict limits on the size of the payload as documented in [A
 
 <h3 id="audit-event-logged">Audit Event Logged</h3>
 
-[Audit log](/docs/pipelines/audit-log) is only available to Buildkite customers on the [Enterprise](https://buildkite.com/pricing) plan
+[Audit log](/docs/pipelines/audit-log) is only available to Buildkite customers on the [Enterprise](https://buildkite.com/pricing) plan.
 
 ```json
 {

--- a/pages/integrations/bitbucket_server.md
+++ b/pages/integrations/bitbucket_server.md
@@ -2,7 +2,7 @@
 
 Buildkite integrates with Bitbucket Server to provide automated builds based on your source control. You can run a build every time you push code to Bitbucket Server, using a webhook that you create in your Bitbucket Server.
 
-Bitbucket Enterprise Server is available to customers on the Buildkite [Business and Enterprise](https://buildkite.com/pricing) plans.
+Bitbucket Enterprise Server is available to customers on the Buildkite [Pro and Enterprise](https://buildkite.com/pricing) plans.
 
 > 📘
 > This guide shows you how to set up your Bitbucket Server builds with Buildkite. It was written using Bitbucket Server version 7.11.1

--- a/pages/integrations/github_enterprise.md
+++ b/pages/integrations/github_enterprise.md
@@ -2,7 +2,7 @@
 
 Buildkite can connect to your GitHub Enterprise Server and use the [GitHub Status API](https://docs.github.com/en/rest/reference/repos#statuses) to update the status of commits in pull requests.
 
-GitHub Enterprise Server is available to Buildkite customers on Business and Enterprise plans.
+GitHub Enterprise Server is available to Buildkite customers on Pro and Enterprise plans.
 
 
 > 📘 This guide was written using GitHub Enterprise version 2.16.3.

--- a/pages/pipelines/build_retention.md
+++ b/pages/pipelines/build_retention.md
@@ -23,7 +23,6 @@ The following diagram shows the lifecycle of build data by plan.
       <td>-</td>
     </tr>
     <tr>
-    <tr>
       <td>Open source plan</td>
       <td>1 year</td>
       <td>-</td>
@@ -33,12 +32,8 @@ The following diagram shows the lifecycle of build data by plan.
       <td>1 year</td>
       <td>-</td>
     </tr>
-      <td>Team plan</td>
-      <td>1 year</td>
-      <td>-</td>
-    </tr>
     <tr>
-      <td>Business plan</td>
+      <td>Pro plan</td>
       <td>1 year</td>
       <td>-</td>
     </tr>

--- a/pages/pipelines/waterfall.md
+++ b/pages/pipelines/waterfall.md
@@ -1,7 +1,7 @@
 # Waterfall view
 
-> 📘 Business/Enterprise feature
-> Waterfall is only available on [Business or Enterprise](https://buildkite.com/pricing) plans.
+> 📘 Pro/Enterprise feature
+> Waterfall is only available on [Pro or Enterprise](https://buildkite.com/pricing) plans.
 
 ## Overview
 

--- a/pages/team_management/permissions.md
+++ b/pages/team_management/permissions.md
@@ -1,6 +1,6 @@
 # User and team permissions
 
-Customers on the Buildkite [Business and Enterprise](https://buildkite.com/pricing) plans can manage permissions using [Teams](#permissions-with-teams). Enterprise customers can set fine-grained user permissions for their organization with the [member Permissions](#member-permissions) page.
+Customers on the Buildkite [Pro and Enterprise](https://buildkite.com/pricing) plans can manage permissions using [Teams](#permissions-with-teams). Enterprise customers can set fine-grained user permissions for their organization with the [member Permissions](#member-permissions) page.
 
 ## Permissions with teams
 

--- a/pages/test_analytics/permissions.md
+++ b/pages/test_analytics/permissions.md
@@ -1,6 +1,6 @@
 # Access control for users and teams
 
-Customers on the Buildkite [Business and Enterprise](https://buildkite.com/pricing) plans can manage permissions using [Teams](#permissions-with-teams). Enterprise customers can set fine-grained user permissions for their organization with the [Member Permissions](#member-permissions) page.
+Customers on the Buildkite [Pro and Enterprise](https://buildkite.com/pricing) plans can manage permissions using [Teams](#permissions-with-teams). Enterprise customers can set fine-grained user permissions for their organization with the [Member Permissions](#member-permissions) page.
 
 For more information on enabling Teams for your organization, please see the [Users and Teams section of Pipelines documentation](/docs/team-management/permissions).
 

--- a/pages/tutorials/migrating_from_bamboo.md
+++ b/pages/tutorials/migrating_from_bamboo.md
@@ -10,7 +10,7 @@ Migrating continuous integration tools can be challenging, so we've put together
 
 <!--alex ignore easy-->
 
-You can easily map most Bamboo workflows to Buildkite. *Projects and Plans* in Bamboo are called [pipelines](/docs/pipelines) in Buildkite (and *Pipelines* in the Buildkite dashboard). Bamboo deployments also become Buildkite pipelines.
+You can easily map most Bamboo workflows to Buildkite. _Projects and Plans_ in Bamboo are called [pipelines](/docs/pipelines) in Buildkite (and **Pipelines** in the Buildkite dashboard). Bamboo deployments also become Buildkite pipelines.
 
 Buildkite pipelines consist of different types of [_steps_](/docs/pipelines/step-reference) for different tasks:
 
@@ -36,7 +36,7 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-Instead of the `wait` step above, you could use a `block` step to stop the build and require a user to manually _unblock_ the pipeline by clicking the **Continue** button in the Buildkite dashboard, or use the [Unblock Job](/docs/api/jobs#unblock-a-job) REST API endpoint. This is the equivalent of a *Manual Stage* in Bamboo.
+Instead of the `wait` step above, you could use a `block` step to stop the build and require a user to manually _unblock_ the pipeline by clicking the **Continue** button in the Buildkite dashboard, or use the [Unblock Job](/docs/api/jobs#unblock-a-job) REST API endpoint. This is the equivalent of a _Manual Stage_ in Bamboo.
 
 ```yaml
 steps:
@@ -97,7 +97,7 @@ If you have many pipelines to migrate or manage at once, you can use the [Update
 
 ## Steps and tasks
 
-`command` steps are Buildkite's version of the *Command Task* in Bamboo. They can run any commands you like on your build server, whether it's `rake test` or `make`. Buildkite doesn't have the concept of *Tasks* in general. It's up to you to write scripts that perform the same tasks that your Bamboo Jobs have.
+`command` steps are Buildkite's version of the _Command Task_ in Bamboo. They can run any commands you like on your build server, whether it's `rake test` or `make`. Buildkite doesn't have the concept of _Tasks_ in general. It's up to you to write scripts that perform the same tasks that your Bamboo Jobs have.
 
 For example, you had the following set of Bamboo Tasks:
 
@@ -123,7 +123,7 @@ To trigger builds in other pipelines, you can use `trigger` steps. This way, you
 
 ## Remote and Elastic agents
 
-The [Buildkite agent](/docs/agent/v3) replaces your Bamboo *Remote Agents*. You can install agents onto any server to run your builds.
+The [Buildkite agent](/docs/agent/v3) replaces your Bamboo _Remote Agents_. You can install agents onto any server to run your builds.
 
 In Bamboo, you can target specific agents for your jobs using their _Capabilities_, and in Buildkite, you target them using [meta-data](/docs/agent/v3/cli-meta-data).
 


### PR DESCRIPTION
As well as fix up some Markdown syntax and grammar.

This PR came about as a result of https://github.com/buildkite/docs/pull/2759.