### PR TITLE
Clarify metrics not on unclustered

### DIFF
--- a/pages/pipelines/cluster_queue_metrics.md
+++ b/pages/pipelines/cluster_queue_metrics.md
@@ -3,7 +3,7 @@
 Queue metrics show the most important statistics to help you optimize your agent setup and monitor a queue's performance. These statistics are updated on the page every 10 seconds.
 
 > 📘
-> `Unclustered` agents are not reported in advanced queue metrics.
+> _Unclustered agents_ are not reported in advanced queue metrics. Learn more about unclustered agents in [Unclustered agent tokens](/docs/agent/v3/unclustered-tokens).
 
 ## Metrics panels
 

--- a/pages/pipelines/cluster_queue_metrics.md
+++ b/pages/pipelines/cluster_queue_metrics.md
@@ -2,6 +2,9 @@
 
 Queue metrics show the most important statistics to help you optimize your agent setup and monitor a queue's performance. These statistics are updated on the page every 10 seconds.
 
+> 📘
+> `Unclustered` agents are not reported in advanced queue metrics.
+
 ## Metrics panels
 
 <%= image "cluster-queue-metrics.png", alt: "Screenshot of the queue metrics panel" %>


### PR DESCRIPTION
Currently we don't call out that `Unclustered` agents are not included in the advanced queue metrics. This is because they cannot be assigned to `queues` in the same way that the new clusters set us can be.

A `queue` can be targeted but that is simply an Elastic Stack tag, rather than a `queue` in the Buildkite sense.

Turning on `advanced queue metrics` will therefore have no affect on folks who only use `Unclustered`, nor do agents in that "cluster" have an impact on the metrics.