### PR TITLE
Update managing_log_output.md

### DIFF
--- a/pages/pipelines/managing_log_output.md
+++ b/pages/pipelines/managing_log_output.md
@@ -133,7 +133,7 @@ To further tighten the security in a Buildkite organization, you can use the [AP
 
 Agents can redact the values of environment variables whose names match common patterns for passwords and other secure information before the build log is uploaded to Buildkite.
 
-If the environment variable is shorter than the minimum length of 6 bytes, it will not be redacted.
+If the environment variable's value is shorter than the minimum length of 6 bytes, then this value will not be redacted.
 
 The default environment variable name patterns are:
 

--- a/pages/pipelines/managing_log_output.md
+++ b/pages/pipelines/managing_log_output.md
@@ -133,6 +133,8 @@ To further tighten the security in a Buildkite organization, you can use the [AP
 
 Agents can redact the values of environment variables whose names match common patterns for passwords and other secure information before the build log is uploaded to Buildkite.
 
+If the environment variable is shorter than the minimum length of 6 bytes, it will not be redacted.
+
 The default environment variable name patterns are:
 
 - `*_PASSWORD`


### PR DESCRIPTION
This PR adds information about the minimum byte length for redacted environment variables

`Warning: Some variables have values below minimum length (6 bytes) and will not be redacted: K_SECRET 
`