### PR TITLE
Update docker push to be buildkit compatible [PLT-2470]

### DIFF
--- a/.buildkite/push-image.sh
+++ b/.buildkite/push-image.sh
@@ -10,7 +10,6 @@ docker build -t "$ECR_REPO:$TAG" \
   --build-arg="RAILS_ENV=production" \
   --build-arg="DD_RUM_VERSION=$BUILDKITE_BUILD_NUMBER" \
   --build-arg="DD_RUM_ENV=production" \
+  --push \
+  --provenance=false \
   .
-
-echo "--- :docker: Pushing docker image"
-docker push "$ECR_REPO:$TAG"


### PR DESCRIPTION
The agent that builds these images runs buildkit, and we can instruct buildkit to push the images directly to the repository rather than export them to the docker image store then push. This should s lightly speed up this step.

I've added --provenance=false so buildkit pushes a regular image, rather than an image manifest. Some parts of our deploy pipeline are not ready for image manifests yet.