### PR TITLE
Sup 2161 - Update Artifactory docs wording for Uploading/Downloading via Buildkite-Agent 

### DIFF
--- a/pages/integrations/artifactory.md
+++ b/pages/integrations/artifactory.md
@@ -59,6 +59,9 @@ steps:
 
 <%= image "artifactory-go-local-repository.png", width: 1484/2, height: 674/2, alt: "Screenshot of an artifact in the go-local repository in Artifactory" %>
 
+> 📘 Retiving Artifacts with Buildkite Agent 
+> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs in order to download artifacts from Artifactory. The default behaviour of the agent is to look for the <code>BUILDKITE_BUILD_ID</code> from the job environment causing it look for an artifact uploaded in the same Build, resulting in an error if the artifact was uploaded in another build. To do this using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), it needs the <code>BUILDKITE_BUILD_ID</code> of the job through which the artifact was uploaded, passed as an additional information to the <code>--build</code> argument. 
+
 ## Using Artifactory for package management
 
 To help cache and secure your build dependencies, you can use [Artifactory's package management](https://www.jfrog.com/confluence/display/RTF/Package+Management) features in your Buildkite pipelines. Each package management platform is configured differently.

--- a/pages/integrations/artifactory.md
+++ b/pages/integrations/artifactory.md
@@ -59,8 +59,8 @@ steps:
 
 <%= image "artifactory-go-local-repository.png", width: 1484/2, height: 674/2, alt: "Screenshot of an artifact in the go-local repository in Artifactory" %>
 
-> 📘 Retiving Artifacts with Buildkite Agent 
-> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs in order to download artifacts from Artifactory. The default behaviour of the agent is to look for the <code>BUILDKITE_BUILD_ID</code> from the job environment causing it look for an artifact uploaded in the same Build, resulting in an error if the artifact was uploaded in another build. To do this using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), it needs the <code>BUILDKITE_BUILD_ID</code> of the job through which the artifact was uploaded, passed as an additional information to the <code>--build</code> argument. 
+> 📘 Retrieving Artifacts with Buildkite Agent 
+> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs to download artifacts from Artifactory. By default, the agent searches for the <code>BUILDKITE_BUILD_ID</code> in the job environment, which directs it to locate an artifact uploaded within the same build. If the artifact was uploaded in a different build, it will encounter an error. To download artifacts that were uploaded in different builds using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), we need to pass the <code>BUILDKITE_BUILD_ID</code> of the job through which the artifact was uploaded, as additional information to the <code>--build</code> argument. 
 
 ## Using Artifactory for package management
 

--- a/pages/integrations/artifactory.md
+++ b/pages/integrations/artifactory.md
@@ -59,8 +59,8 @@ steps:
 
 <%= image "artifactory-go-local-repository.png", width: 1484/2, height: 674/2, alt: "Screenshot of an artifact in the go-local repository in Artifactory" %>
 
-> 📘 Retrieving Artifacts with Buildkite Agent  
-> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs to download artifacts from Artifactory. By default, the agent searches for artifacts uploaded within the same build. To download artifacts that were uploaded in different builds using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), we need to pass the [BUILDKITE_BUILD_ID] (https://buildkite.com/docs/agent/v3/cli-artifact#build) of the job through which the artifact was uploaded, as additional information to the <code>--build</code> argument.  
+> 📘 Retrieving artifacts using the Buildkite Agent  
+> The Buildkite Agent uses Buildkite's APIs to fetch the correct URLs to download artifacts from Artifactory. By default, the agent searches for artifacts uploaded within the same build. To download artifacts that were uploaded in different builds using [`buildkite-agent artifact download`](/docs/agent/v3/cli-artifact#downloading-artifacts) or [artifacts-buildkite-plugin](https://github.com/buildkite-plugins/artifacts-buildkite-plugin), pass the [`BUILDKITE_BUILD_ID`](/docs/agent/v3/cli-artifact#downloading-artifacts-options) of the job through which the artifact was uploaded, as additional information to the `--build` option's argument.
 
 ## Using Artifactory for package management
 

--- a/pages/integrations/artifactory.md
+++ b/pages/integrations/artifactory.md
@@ -60,7 +60,7 @@ steps:
 <%= image "artifactory-go-local-repository.png", width: 1484/2, height: 674/2, alt: "Screenshot of an artifact in the go-local repository in Artifactory" %>
 
 > 📘 Retrieving Artifacts with Buildkite Agent 
-> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs to download artifacts from Artifactory. By default, the agent searches for artifacts uploaded within the same build. To download artifacts that were uploaded in different builds using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), we need to pass the <code>BUILDKITE_BUILD_ID</code> of the job through which the artifact was uploaded, as additional information to the <code>--build</code> argument. 
+> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs to download artifacts from Artifactory. By default, the agent searches for artifacts uploaded within the same build. To download artifacts that were uploaded in different builds using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), we need to pass the [BUILDKITE_BUILD_ID] (https://buildkite.com/docs/agent/v3/cli-artifact#build) of the job through which the artifact was uploaded, as additional information to the <code>--build</code> argument. 
 
 ## Using Artifactory for package management
 

--- a/pages/integrations/artifactory.md
+++ b/pages/integrations/artifactory.md
@@ -60,7 +60,7 @@ steps:
 <%= image "artifactory-go-local-repository.png", width: 1484/2, height: 674/2, alt: "Screenshot of an artifact in the go-local repository in Artifactory" %>
 
 > 📘 Retrieving Artifacts with Buildkite Agent  
-> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs to download artifacts from Artifactory. By default, the agent searches for artifacts uploaded within the same build. To download artifacts that were uploaded in different builds using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), we need to pass the [BUILDKITE_BUILD_ID] (https://buildkite.com/docs/agent/v3/cli-artifact#build) of the job through which the artifact was uploaded, as additional information to the <code>--build</code> argument.   
+> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs to download artifacts from Artifactory. By default, the agent searches for artifacts uploaded within the same build. To download artifacts that were uploaded in different builds using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), we need to pass the [BUILDKITE_BUILD_ID] (https://buildkite.com/docs/agent/v3/cli-artifact#build) of the job through which the artifact was uploaded, as additional information to the <code>--build</code> argument.  
 
 ## Using Artifactory for package management
 

--- a/pages/integrations/artifactory.md
+++ b/pages/integrations/artifactory.md
@@ -60,7 +60,7 @@ steps:
 <%= image "artifactory-go-local-repository.png", width: 1484/2, height: 674/2, alt: "Screenshot of an artifact in the go-local repository in Artifactory" %>
 
 > 📘 Retrieving Artifacts with Buildkite Agent 
-> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs to download artifacts from Artifactory. By default, the agent searches for the <code>BUILDKITE_BUILD_ID</code> in the job environment, which directs it to locate an artifact uploaded within the same build. If the artifact was uploaded in a different build, it will encounter an error. To download artifacts that were uploaded in different builds using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), we need to pass the <code>BUILDKITE_BUILD_ID</code> of the job through which the artifact was uploaded, as additional information to the <code>--build</code> argument. 
+> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs to download artifacts from Artifactory. By default, the agent searches for artifacts uploaded within the same build. To download artifacts that were uploaded in different builds using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), we need to pass the <code>BUILDKITE_BUILD_ID</code> of the job through which the artifact was uploaded, as additional information to the <code>--build</code> argument. 
 
 ## Using Artifactory for package management
 

--- a/pages/integrations/artifactory.md
+++ b/pages/integrations/artifactory.md
@@ -59,8 +59,8 @@ steps:
 
 <%= image "artifactory-go-local-repository.png", width: 1484/2, height: 674/2, alt: "Screenshot of an artifact in the go-local repository in Artifactory" %>
 
-> 📘 Retrieving Artifacts with Buildkite Agent 
-> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs to download artifacts from Artifactory. By default, the agent searches for artifacts uploaded within the same build. To download artifacts that were uploaded in different builds using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), we need to pass the [BUILDKITE_BUILD_ID] (https://buildkite.com/docs/agent/v3/cli-artifact#build) of the job through which the artifact was uploaded, as additional information to the <code>--build</code> argument. 
+> 📘 Retrieving Artifacts with Buildkite Agent  
+> The Buildkite Agent uses the Buildkite API to fetch the correct download URLs to download artifacts from Artifactory. By default, the agent searches for artifacts uploaded within the same build. To download artifacts that were uploaded in different builds using <code>buildkite-agent artifact download</code> or [artifacts-buildkite-plugin] (https://github.com/buildkite-plugins/artifacts-buildkite-plugin), we need to pass the [BUILDKITE_BUILD_ID] (https://buildkite.com/docs/agent/v3/cli-artifact#build) of the job through which the artifact was uploaded, as additional information to the <code>--build</code> argument.   
 
 ## Using Artifactory for package management
 


### PR DESCRIPTION
We had a customer have an issue when trying to download artifacts across builds when using their Artifactory storage. They thought as they configured their environment variables to use their Artifactory that it would be able to download directly from Artifactory, without specifying the Build ID where the artifact was uploaded.

Updating the document elaborating the same as above.