### PR TITLE
Update Agent Metrics API Authorization type

### DIFF
--- a/pages/apis/agent_api/metrics.md
+++ b/pages/apis/agent_api/metrics.md
@@ -11,7 +11,7 @@ The Metrics API endpoint provides information on idle and busy agents, jobs, and
 Get agent metrics
 
 ```bash
-curl -H "Authorization: Bearer $BUILDKITE_AGENT_TOKEN" \
+curl -H "Authorization: Token $BUILDKITE_AGENT_TOKEN" \
   -X GET "https://agent.buildkite.com/v3/metrics"
 ```
 


### PR DESCRIPTION
In https://github.com/buildkite/docs/pull/2612/files#diff-60af2a272ab3d6553f785ae3b4d0507b564787c977c712f4ecd0a8a76fb033efL13-L14 we made a change to the [Agent Metrics API](https://buildkite.com/docs/apis/agent-api/metrics) page.

We accidentally changed the REST API Authorization header type from `Token $BUILDKITE_AGENT_TOKEN` to `Bearer $BUILDKITE_AGENT_TOKEN`. This meant that customers using referring to the documentation were seeing a response like this from our API:

```sh
{
  "message": "Eeep! You forgot to pass an agent registration token"
}
```

This PR fixes the documentation to reflect that for this endpoint, the Authorization header type should be `Token $BUILDKITE_AGENT_TOKEN` still.