### PR TITLE
Add paragraph break in "Custom hooks and environment" variables callout

### DIFF
--- a/pages/agent/v3/securing.md
+++ b/pages/agent/v3/securing.md
@@ -40,7 +40,7 @@ Command line evaluation can be disabled by setting [`no-command-eval`](/docs/age
 
 > 🚧 Custom hooks and environment variables
 > If you have a custom `command` hook, using `no-command-eval` will have no effect on your command execution. See [Allowing a list of plugins](#allowing-a-list-of-plugins) and [Custom bootstrap scripts](#customizing-the-bootstrap) for examples of how to completely lock down your agent from arbitrary code execution.
->
+><p>
 > Using `no-command-eval` only prevents command evaluation by the agent itself. Other programs such as build or test tools that run during the job could be influenced into executing arbitrary commands via environment variables (for example, `BASH_ENV` or `GIT_SSH_COMMAND`). See [Strict checks using a pre-bootstrap hook](#strict-checks-using-a-pre-bootstrap-hook) and [`enable-environment-variable-allowlist`](/docs/agent/v3/cli-start#enable-environment-variable-allowlist) for possible approaches to filtering environment variables.
 
 ## Disabling plugins


### PR DESCRIPTION
I was just having a peek at https://github.com/buildkite/docs/pull/2761 post-deploy, and I noticed that there's no break between the paragraphs in the rendered output:
![image](https://github.com/buildkite/docs/assets/1201065/a7d81af5-08e7-4ef9-8480-348ef165c3ac)

Adding a hacky `<p>` between the paragraphs makes it do the right thing. If you know a nicer way to achieve the same result, let's do that instead!

![image](https://github.com/buildkite/docs/assets/1201065/21ea8ad5-d071-43df-94a8-992b124def03)

