### PR TITLE
Fix '- wait:' syntax for pipeline dependencies page (and wait step page too).

### DIFF
--- a/pages/pipelines/dependencies.md
+++ b/pages/pipelines/dependencies.md
@@ -16,7 +16,7 @@ A wait step, as in the example below, is dependent on all previous steps complet
 steps:
   - command: "one.sh"
   - command: "two.sh"
-  - wait:
+  - wait: ~
   - command: "three.sh"
   - command: "four.sh"
 ```
@@ -88,7 +88,7 @@ To ensure that a step is not dependent on any other step, add an explicit empty 
 ```yml
 steps:
   - command: "tests.sh"
-  - wait:
+  - wait: ~
   - command: "lint.sh"
     depends_on: ~
 ```

--- a/pages/pipelines/dependencies.md
+++ b/pages/pipelines/dependencies.md
@@ -16,7 +16,7 @@ A wait step, as in the example below, is dependent on all previous steps complet
 steps:
   - command: "one.sh"
   - command: "two.sh"
-  - wait
+  - wait:
   - command: "three.sh"
   - command: "four.sh"
 ```
@@ -88,7 +88,7 @@ To ensure that a step is not dependent on any other step, add an explicit empty 
 ```yml
 steps:
   - command: "tests.sh"
-  - wait
+  - wait:
   - command: "lint.sh"
     depends_on: ~
 ```

--- a/pages/pipelines/wait_step.md
+++ b/pages/pipelines/wait_step.md
@@ -6,7 +6,7 @@ A wait step can be defined in your pipeline settings, or in your [pipeline.yml](
 
 ```yml
 - command: "command.sh"
-- wait
+- wait:
 - command: "echo The command passed"
 ```
 {: codeblock-file="pipeline.yml"}
@@ -68,7 +68,7 @@ steps:
   - wait: ~
     continue_on_failure: true
   - command: "echo This runs regardless of the success or failure"
-  - wait
+  - wait:
   - command: "echo The command passed"
 ```
 

--- a/pages/pipelines/wait_step.md
+++ b/pages/pipelines/wait_step.md
@@ -6,7 +6,7 @@ A wait step can be defined in your pipeline settings, or in your [pipeline.yml](
 
 ```yml
 - command: "command.sh"
-- wait:
+- wait: ~
 - command: "echo The command passed"
 ```
 {: codeblock-file="pipeline.yml"}
@@ -68,7 +68,7 @@ steps:
   - wait: ~
     continue_on_failure: true
   - command: "echo This runs regardless of the success or failure"
-  - wait:
+  - wait: ~
   - command: "echo The command passed"
 ```
 
@@ -77,7 +77,7 @@ If there's a failure followed by a regular wait step, nothing after the wait ste
 ```yml
 steps:
   - command: "exit -1"
-  - wait:
+  - wait: ~
   - command: "echo SECOND command"
   - wait: ~
     continue_on_failure: true

--- a/pages/pipelines/wait_step.md
+++ b/pages/pipelines/wait_step.md
@@ -77,7 +77,7 @@ If there's a failure followed by a regular wait step, nothing after the wait ste
 ```yml
 steps:
   - command: "exit -1"
-  - wait
+  - wait:
   - command: "echo SECOND command"
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
There was some discussion about clarifying the code examples depicting `wait` step syntax in our docs.

This PR should also hopefully address this piece of direct page feedback we got here:

![Screenshot 2024-05-13 at 9 19 07 AM](https://github.com/buildkite/docs/assets/23667807/0cb05e0a-ba80-4706-8658-3e8087d210b3)
