### PR TITLE
Switch to less-diverged branch of ECR scan plugin

### DIFF
--- a/.buildkite/ecr-scan-results-ignore.yml
+++ b/.buildkite/ecr-scan-results-ignore.yml
@@ -1,0 +1,21 @@
+ignores:
+  - id: CVE-2023-29007 # git 1:2.39.2-1.1
+  - id: CVE-2023-25652 # git 1:2.39.2-1.1
+  - id: CVE-2021-3864 # linux 6.1.55-1
+  - id: CVE-2013-7445 # linux 6.1.55-1
+  - id: CVE-2019-19814 # linux 6.1.55-1
+  - id: CVE-2019-19449 # linux 6.1.55-1
+  - id: CVE-2021-3847 # linux 6.1.55-1
+  - id: CVE-2023-35827 # linux 6.1.55-1
+  - id: CVE-2023-2953 # openldap 2.5.13+dfsg-5
+  - id: CVE-2023-31484 # perl 5.36.0-7
+  - id: CVE-2023-24329 # python3.11 3.11.2-6
+  - id: CVE-2023-3640 # linux 6.1.55-1
+  - id: CVE-2023-45853 # zlib 1:1.2.13.dfsg-1
+  - id: CVE-2023-5717 # linux 6.1.55-1
+  - id: CVE-2023-5678  # openssl 3.0.11-1~deb12u1
+  - id: CVE-2023-50495 # ncurses 6.4-4
+  - id: CVE-2024-0567 # gnutls28 3.7.9-2+deb12u1
+  - id: CVE-2023-50387 # systemd 252.17-1~deb12u1
+  - id: CVE-2024-0553 # gnutls28 3.7.9-2
+  - id: CVE-2024-0567 # gnutls28 3.7.9-2+deb12u1

--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -22,29 +22,9 @@ steps:
     plugins:
       - aws-assume-role-with-web-identity#v1.0.0:
           role-arn: arn:aws:iam::${ECR_ACCOUNT_ID}:role/pipeline-buildkite-docs-main
-      - buildkite/ecr-scan-results#v1.2.0:
+      - buildkite/ecr-scan-results#v2.0.0:
           image-name: "${ECR_REPO}:${BUILDKITE_BUILD_NUMBER}"
-          ignore:
-            - CVE-2023-29007 # git 1:2.39.2-1.1
-            - CVE-2023-25652 # git 1:2.39.2-1.1
-            - CVE-2021-3864 # linux 6.1.55-1
-            - CVE-2013-7445 # linux 6.1.55-1
-            - CVE-2019-19814 # linux 6.1.55-1
-            - CVE-2019-19449 # linux 6.1.55-1
-            - CVE-2021-3847 # linux 6.1.55-1
-            - CVE-2023-35827 # linux 6.1.55-1
-            - CVE-2023-2953 # openldap 2.5.13+dfsg-5
-            - CVE-2023-31484 # perl 5.36.0-7
-            - CVE-2023-24329 # python3.11 3.11.2-6
-            - CVE-2023-3640 # linux 6.1.55-1
-            - CVE-2023-45853 # zlib 1:1.2.13.dfsg-1
-            - CVE-2023-5717 # linux 6.1.55-1
-            - CVE-2023-5678  # openssl 3.0.11-1~deb12u1
-            - CVE-2023-50495 # ncurses 6.4-4
-            - CVE-2024-0567 # gnutls28 3.7.9-2+deb12u1
-            - CVE-2023-50387 # systemd 252.17-1~deb12u1
-            - CVE-2024-0553 # gnutls28 3.7.9-2
-            - CVE-2024-0567 # gnutls28 3.7.9-2+deb12u1
+          fail-build-on-plugin-failure: true
 
   # If the current user is part of the deploy team, then wait for everything to
   # finish before deploying


### PR DESCRIPTION
## Context

Update our ECS scanning Buildkite plugin to a version that's closer to upstream:

Depends on https://github.com/buildkite/ecr-scan-results-buildkite-plugin/pull/11

- Switch to updated plugin (closer to upstream)
- Change format of ignore list, because upstream's parallel implementation is slightly different to ours
- Add fail-build-on-plugin-failure flag, to preserve our current plugin behaviour