### PR TITLE
Correct playwright config variable

### DIFF
--- a/pages/test_analytics/javascript_collectors.md
+++ b/pages/test_analytics/javascript_collectors.md
@@ -158,7 +158,7 @@ To configure Playwright:
     ```js
     // playwright.config.js
     {
-      "reporters": [
+      "reporter": [
         ["line"], 
         ["buildkite-test-collector/playwright/reporter"]
       ]


### PR DESCRIPTION
[Playwright uses "reporter"](https://playwright.dev/docs/test-reporters#multiple-reporters) rather than "reporters" for all pluralities of reporter configurations.

<img width="978" alt="image" src="https://github.com/buildkite/docs/assets/14263240/800ff0cd-888a-4429-b1b8-4ded7b001f94">
