### PR TITLE
fixed capitalisation

### DIFF
--- a/pages/team_management/permissions.md
+++ b/pages/team_management/permissions.md
@@ -26,6 +26,7 @@ Users who are team maintainers can:
 - Add users to existing teams, of which they are the maintainer
 - Remove users from their teams
 - Set read, write, and edit permissions for users on pipelines in their team
+- Create pipelines
 
 All users in a team have the same level of access to the pipelines in their team. If you need to have more fine grained control over the pipelines in a team, you can create more teams with different permissions.
 


### PR DESCRIPTION
This is a very small PR to remove some confusion around team member permissions. 
It was raised through the support channel that if Team member permissions are set to not allow pipeline creation that some members of teams can still create pipelines. 

After some investigation we found that Team Maintainers are not bound by the team member pipeline creation permissions, so I'm just adding this to the documentation so it's clear that team maintainers will be able to create pipelines. 