### PR TITLE
fix broken curl command lines

### DIFF
--- a/pages/apis/rest_api/agents.md
+++ b/pages/apis/rest_api/agents.md
@@ -6,8 +6,8 @@
 Returns a [paginated list](<%= paginated_resource_docs_url %>) of an organization's agents. The list only includes connected agents - agents in a disconnected state are not returned.
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" \
-  -X "https://api.buildkite.com/v2/organizations/{org.slug}/agents"
+curl -H "Authorization: Bearer $TOKEN" -X GET \
+  "https://api.buildkite.com/v2/organizations/{org.slug}/agents"
 ```
 
 ```json
@@ -80,8 +80,8 @@ Success response: `200 OK`
 Returns the details for a single agent, looked up by unique ID. Any valid agents can be returned, including running and disconnected agents.
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" \
-  -X "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}"
+curl -H "Authorization: Bearer $TOKEN" -X GET \
+  "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}"
 ```
 
 ```json
@@ -148,8 +148,8 @@ Success response: `200 OK`
 Instruct an agent to stop accepting new build jobs and shut itself down.
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" \
-  -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}/stop" \
+curl -H "Authorization: Bearer $TOKEN" -X PUT \
+  "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}/stop" \
   -H "Content-Type: application/json" \
   -d '{
     "force": true

--- a/pages/apis/rest_api/agents.md
+++ b/pages/apis/rest_api/agents.md
@@ -148,8 +148,8 @@ Success response: `200 OK`
 Instruct an agent to stop accepting new build jobs and shut itself down.
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" -X PUT \
-  "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}/stop" \
+curl -H "Authorization: Bearer $TOKEN" \
+  -X PUT "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}/stop" \
   -H "Content-Type: application/json" \
   -d '{
     "force": true

--- a/pages/apis/rest_api/agents.md
+++ b/pages/apis/rest_api/agents.md
@@ -6,8 +6,8 @@
 Returns a [paginated list](<%= paginated_resource_docs_url %>) of an organization's agents. The list only includes connected agents - agents in a disconnected state are not returned.
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" -X GET \
-  "https://api.buildkite.com/v2/organizations/{org.slug}/agents"
+curl -H "Authorization: Bearer $TOKEN" \
+  -X GET "https://api.buildkite.com/v2/organizations/{org.slug}/agents"
 ```
 
 ```json

--- a/pages/apis/rest_api/agents.md
+++ b/pages/apis/rest_api/agents.md
@@ -80,8 +80,8 @@ Success response: `200 OK`
 Returns the details for a single agent, looked up by unique ID. Any valid agents can be returned, including running and disconnected agents.
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" -X GET \
-  "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}"
+curl -H "Authorization: Bearer $TOKEN" \
+  -X GET "https://api.buildkite.com/v2/organizations/{org.slug}/agents/{id}"
 ```
 
 ```json


### PR DESCRIPTION
The curl command lines were missing arguments to the `-X` flag.