### PR TITLE
Fix cookbook example query

### DIFF
--- a/pages/apis/graphql/cookbooks/jobs.md
+++ b/pages/apis/graphql/cookbooks/jobs.md
@@ -114,7 +114,7 @@ To get UUIDs of the jobs in a build, you can use the following query.
 
 ```graphql
 query GetJobsUUID {
-  build(slug: "org-slug/build-slug/build-number") {
+  build(slug: "org-slug/pipeline-slug/build-number") {
     jobs(first: 1) {
       edges {
         node {


### PR DESCRIPTION
This is to fix the cookbook example query https://buildkite.com/docs/apis/graphql/cookbooks/jobs#get-a-jobs-uuid