### PR TITLE
Buildkite Packages post-beta pre-GA docs updates

### DIFF
--- a/data/nav.yml
+++ b/data/nav.yml
@@ -448,8 +448,8 @@
           children:
             - name: "Manage registries"
               path: "packages/manage-registries"
-            - name: "Link private storage"
-              path: "packages/link-private-storage"
+            - name: "Private storage"
+              path: "packages/private-storage"
         - name: "Access control"
           path: "packages/permissions"
     - name: "Package ecosystems"

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -443,9 +443,11 @@
       children:
         - name: "Getting started"
           path: "packages/getting-started"
-        - name: "Manage registries"
-          path: "packages/manage-registries"
+        - name: "Registries"
+          start_expanded: true
           children:
+            - name: "Manage registries"
+              path: "packages/manage-registries"
             - name: "Link private storage"
               path: "packages/link-private-storage"
         - name: "Access control"

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -445,6 +445,9 @@
           path: "packages/getting-started"
         - name: "Manage registries"
           path: "packages/manage-registries"
+          children:
+            - name: "Link private storage"
+              path: "packages/link-private-storage"
         - name: "Access control"
           path: "packages/permissions"
     - name: "Package ecosystems"
@@ -457,10 +460,10 @@
         - name: "Java"
           start_expanded: true
           children:
-          - name: "Maven"
-            path: "packages/maven"
-          - name: "Gradle"
-            path: "packages/gradle"
+            - name: "Maven"
+              path: "packages/maven"
+            - name: "Gradle"
+              path: "packages/gradle"
         - name: "JavaScipt"
           path: "packages/javascript"
         - name: "Python"

--- a/pages/packages.md
+++ b/pages/packages.md
@@ -9,7 +9,7 @@ Buildkite Packages is a product that:
 As well as storing a collection of packages, a registry also surfaces metadata or attributes associated with a package, such as the package's description, version, contents (files and directories), checksum details, distribution type, dependencies, and so on.
 
 > 📘 Buildkite Packages is currently in public beta
-> You can enable [Buildkite Packages](https://buildkite.com/packages) through the **Organization Settings** page.
+> You can enable [Buildkite Packages](https://buildkite.com/packages) through the [**Organization Settings** page](/docs/packages/permissions#manage-teams-and-permissions-organization-level-permissions).
 
 ## An introduction to packages
 

--- a/pages/packages/link_private_storage.md
+++ b/pages/packages/link_private_storage.md
@@ -1,3 +1,0 @@
-# Link private storage
-
-This page provides details on how to manage registries within your Buildkite organization.

--- a/pages/packages/link_private_storage.md
+++ b/pages/packages/link_private_storage.md
@@ -1,0 +1,3 @@
+# Link private storage
+
+This page provides details on how to manage registries within your Buildkite organization.

--- a/pages/packages/permissions.md
+++ b/pages/packages/permissions.md
@@ -18,11 +18,13 @@ Once the _teams_ feature is enabled, you can see the teams that you're a member 
 
 Learn more about what a _Buildkite organization administrator_ can do in the [Organization-level permissions section of the Pipelines documentation](/docs/team-management/permissions#manage-teams-and-permissions-organization-level-permissions).
 
-As an organization administrator, you can:
+As an organization administrator, you can access the [**Organization Settings** page](https://buildkite.com/organizations/~/settings) by selecting **Settings** in the global navigation, and do the following:
 
 - Add new teams or edit existing ones in the [**Team** section](https://buildkite.com/organizations/~/teams).
 
     * After selecting a team, you can view and administer the member-, [pipeline-](/docs/team-management/permissions#manage-teams-and-permissions-pipeline-level-permissions), [test suite-](/docs/test-analytics/permissions#manage-teams-and-permissions-test-suite-level-permissions), [registry-](#manage-teams-and-permissions-registry-level-permissions) and [team-](/docs/team-management/permissions#manage-teams-and-permissions-team-level-permissions)level settings for that team.
+
+- Enable Buildkite Packages for your Buildkite organization.
 
 - Configure [private storage](/docs/packages/private-storage) for your Buildkite Packages registries.
 

--- a/pages/packages/permissions.md
+++ b/pages/packages/permissions.md
@@ -18,9 +18,13 @@ Once the _teams_ feature is enabled, you can see the teams that you're a member 
 
 Learn more about what a _Buildkite organization administrator_ can do in the [Organization-level permissions section of the Pipelines documentation](/docs/team-management/permissions#manage-teams-and-permissions-organization-level-permissions).
 
-As an organization administrator, in the [**Team** section](https://buildkite.com/organizations/~/teams), you can add new teams or edit existing ones.
+As an organization administrator, you can:
 
-After selecting a team, you can view the member-, pipeline-, test suite-, registry- and team-specific settings.
+- Add new teams or edit existing ones in the [**Team** section](https://buildkite.com/organizations/~/teams).
+
+    * After selecting a team, you can view and administer the member-, [pipeline-](/docs/team-management/permissions#manage-teams-and-permissions-pipeline-level-permissions), [test suite-](/docs/test-analytics/permissions#manage-teams-and-permissions-test-suite-level-permissions), [registry-](#manage-teams-and-permissions-registry-level-permissions) and [team-](/docs/team-management/permissions#manage-teams-and-permissions-team-level-permissions)level settings for that team.
+
+- Configure [private storage](/docs/packages/private-storage) for your Buildkite Packages registries.
 
 ### Team-level permissions
 

--- a/pages/packages/permissions.md
+++ b/pages/packages/permissions.md
@@ -18,13 +18,15 @@ Once the _teams_ feature is enabled, you can see the teams that you're a member 
 
 Learn more about what a _Buildkite organization administrator_ can do in the [Organization-level permissions section of the Pipelines documentation](/docs/team-management/permissions#manage-teams-and-permissions-organization-level-permissions).
 
-As an organization administrator, you can access the [**Organization Settings** page](https://buildkite.com/organizations/~/settings) by selecting **Settings** in the global navigation, and do the following:
+As an organization administrator, you can access the [**Organization Settings** page](https://buildkite.com/organizations/~/settings) by selecting **Settings** in the global navigation, where you can do the following:
 
 - Add new teams or edit existing ones in the [**Team** section](https://buildkite.com/organizations/~/teams).
 
     * After selecting a team, you can view and administer the member-, [pipeline-](/docs/team-management/permissions#manage-teams-and-permissions-pipeline-level-permissions), [test suite-](/docs/test-analytics/permissions#manage-teams-and-permissions-test-suite-level-permissions), [registry-](#manage-teams-and-permissions-registry-level-permissions) and [team-](/docs/team-management/permissions#manage-teams-and-permissions-team-level-permissions)level settings for that team.
 
-- Enable Buildkite Packages for your Buildkite organization.
+- Enable Buildkite Packages for your Buildkite organization. To do this, in the **Packages** section, select **Enable** to open the **Enable Packages** page > **Enable Buildkite Packages (Beta)**.
+
+    **Note:** Once enabled the **Enable** changes to **Enabled** and Buildkite Packages can only be disabled by contacting [support](https://buildkite.com/support).
 
 - Configure [private storage](/docs/packages/private-storage) for your Buildkite Packages registries.
 

--- a/pages/packages/private_storage.md
+++ b/pages/packages/private_storage.md
@@ -4,11 +4,23 @@ This page provides details on how to link your private Amazon Web Services (AWS)
 
 By default, Buildkite Packages provides its own storage to house any packages, container images and modules stored in registries. You can also link your own private AWS S3 bucket to Buildkite Packages, which allows you to:
 
-- Manage Buildkite registry packages, container images and modules stored within your private AWS S3 bucket (that is, your _private storage_). Private storage located closer to your geographical location may provide faster registry access.
+- Manage Buildkite registry packages, container images and modules stored within your private AWS S3 bucket (that is, your _private storage_). Private storage:
+    * Located closer to your geographical location may provide faster registry access.
+    * Mitigates network transmission costs.
+
 - Use Buildkite Packages' management and metadata-handling features to manage these files in registries within your private storage.
+
 - Maintain control, ownership and sovereignty over the packages, container images and modules stored within your Buildkite Packages registries.
 
 Buildkite Packages uses [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html) to provision its services within your private AWS S3 storage.
+
+## Before you start
+
+Before you can start linking your private AWS S3 storage to Buildkite Packages, you will need to have set yourself up with this storage.
+
+Learn more about this process from the main [Amazon S3](https://aws.amazon.com/s3/) page, as well as the [Amazon S3 documentation](https://docs.aws.amazon.com/s3/).
+
+## Link your private storage to Buildkite Packages
 
 To link your private AWS S3 storage to Buildkite Packages:
 

--- a/pages/packages/private_storage.md
+++ b/pages/packages/private_storage.md
@@ -38,3 +38,5 @@ To link your private AWS S3 storage to Buildkite Packages:
 1. Once the **Diagnostic Result** page indicates a **Pass** for each of these three tests, select **Create Private Storage Link** complete this linking process.
 
 1. On the **Private Storage Link** package, select **Change** to switch from using **Buildkite-hosted storage** to your private storage (beginning with **s3://...**).
+
+All subsequent packages published to any registries already configured in your Buildkite organization will be stored in your private storage.

--- a/pages/packages/private_storage.md
+++ b/pages/packages/private_storage.md
@@ -1,0 +1,9 @@
+# Link private storage
+
+This page provides details on how to link your private AWS S3 storage to Buildkite Packages within your Buildkite organization. This process can only be conducted by [Buildkite organization administrators](/docs/packages/permissions#manage-teams-and-permissions-organization-level-permissions).
+
+By default, Buildkite Packages provides its own storage to house any packages, container images and modules stored in registries. You can also link your own private AWS S3 storage to Buildkite Packages, which allows you to:
+
+- Use Buildkite Package's management and metadata-handling features to manage packages, container images and modules stored in your registries.
+- House these files within your own private AWS S3 storage, thereby allowing you to maintain full control, ownership and sovereignty over the packages, container images and modules stored within your Buildkite Packages registries.
+

--- a/pages/packages/private_storage.md
+++ b/pages/packages/private_storage.md
@@ -5,7 +5,7 @@ This page provides details on how to link your private Amazon Web Services (AWS)
 By default, Buildkite Packages provides its own storage to house any packages, container images and modules stored in registries. You can also link your own private AWS S3 bucket to Buildkite Packages, which allows you to:
 
 - Manage Buildkite registry packages, container images and modules stored within your private AWS S3 bucket (that is, your _private storage_). Private storage located closer to your geographical location may provide faster registry access.
-- Use Buildkite Package's management and metadata-handling features to manage these files in registries within your private storage.
+- Use Buildkite Packages' management and metadata-handling features to manage these files in registries within your private storage.
 - Maintain control, ownership and sovereignty over the packages, container images and modules stored within your Buildkite Packages registries.
 
 Buildkite Packages uses [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html) to provision its services within your private AWS S3 storage.

--- a/pages/packages/private_storage.md
+++ b/pages/packages/private_storage.md
@@ -1,9 +1,40 @@
 # Link private storage
 
-This page provides details on how to link your private AWS S3 storage to Buildkite Packages within your Buildkite organization. This process can only be conducted by [Buildkite organization administrators](/docs/packages/permissions#manage-teams-and-permissions-organization-level-permissions).
+This page provides details on how to link your private Amazon Web Services (AWS) Simple Storage Service (S3) storage to Buildkite Packages within your Buildkite organization. This process can only be conducted by [Buildkite organization administrators](/docs/packages/permissions#manage-teams-and-permissions-organization-level-permissions).
 
-By default, Buildkite Packages provides its own storage to house any packages, container images and modules stored in registries. You can also link your own private AWS S3 storage to Buildkite Packages, which allows you to:
+By default, Buildkite Packages provides its own storage to house any packages, container images and modules stored in registries. You can also link your own private AWS S3 bucket to Buildkite Packages, which allows you to:
 
-- Use Buildkite Package's management and metadata-handling features to manage packages, container images and modules stored in your registries.
-- House these files within your own private AWS S3 storage, thereby allowing you to maintain full control, ownership and sovereignty over the packages, container images and modules stored within your Buildkite Packages registries.
+- Manage Buildkite registry packages, container images and modules stored within your private AWS S3 bucket (that is, your _private storage_). Private storage located closer to your geographical location may provide faster registry access.
+- Use Buildkite Package's management and metadata-handling features to manage these files in registries within your private storage.
+- Maintain control, ownership and sovereignty over the packages, container images and modules stored within your Buildkite Packages registries.
 
+Buildkite Packages uses [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html) to provision its services within your private AWS S3 storage.
+
+To link your private AWS S3 storage to Buildkite Packages:
+
+1. Select **Settings** in the global navigation to access the [**Organization Settings**](https://buildkite.com/organizations/~/settings) page.
+
+1. In the **Packages** section, select **Private Storage Link** to open its page.
+
+1. Select **Add private storage link** to begin configuring your private storage for Buildkite Packages.
+
+1. Read through the process summary and select **Let's go!**
+
+1. On the **Provide your bucket's details** page, specify the **Region** (for example, `us-east-1`) and **Bucket** name for your AWS S3 bucket, followed by selecting **Next**.
+
+1. On the **Authorize Buildkite in AWS** page, select **Launch Stack** to open the **Quick create stack** page in the AWS CloudFormation interface.
+
+1. Ensure the the following fields are populated with the correct information:
+    * **Template URL**—this value should be the same as the **Amazon S3 URL** specified on the **Authorize Buildkite in AWS** page.
+    * **Stack name**—`buildkitePackagesProvisioning` by default, but can be changed if another CloudFormation stack of the same name exists in your AWS account.
+    * **YourBucketName**—the name of your AWS S3 bucket (specified on the previous **Provide your bucket's details** page in Buildkite).
+    * **YourBucketPath**—`/` by default.
+    * **IAM role - optional**—specify any **IAM role** **name** or **ARN** to restrict the actions that can be performed on your CloudFormation stack in your S3 bucket.
+
+1. Select **Create stack** to begin creating the CloudFormation stack for your S3 bucket.
+
+1. Once the stack is created, return to the Buildkite interface and select **Run diagnostic** to verify that Buildkite Packages can publish (`PUT`), download (`GET`) and delete (`DELETE`) packages to and from your S3 private storage.
+
+1. Once the **Diagnostic Result** page indicates a **Pass** for each of these three tests, select **Create Private Storage Link** complete this linking process.
+
+1. On the **Private Storage Link** package, select **Change** to switch from using **Buildkite-hosted storage** to your private storage (beginning with **s3://...**).

--- a/pages/team_management/permissions.md
+++ b/pages/team_management/permissions.md
@@ -12,7 +12,7 @@ Enabling _teams_ for your organizations provides control over each pipeline's, t
 
 To access or enable the teams feature for your organization, or both:
 
-1. Select **Settings** in the global navigation > **Teams** to access the [**Organization Settings**](https://buildkite.com/organizations/~/settings) page.
+1. Select **Settings** in the global navigation to access the [**Organization Settings**](https://buildkite.com/organizations/~/settings) page.
 
 1. Select **Teams** to access your organization's [**Teams**](https://buildkite.com/organizations/~/teams) page.
 

--- a/pages/team_management/permissions.md
+++ b/pages/team_management/permissions.md
@@ -26,7 +26,7 @@ Without the **Teams** feature activated, all users are able to access all items 
 
 ### Organization-level permissions
 
-A user who is a _Buildkite organization administrator_ can do the following throughout their Buildkite organization:
+A user who is a _Buildkite organization administrator_ can access the [**Organization Settings** page](https://buildkite.com/organizations/~/settings) by selecting **Settings** in the global navigation, and do the following throughout their Buildkite organization:
 
 - Access the **Teams** feature and page, by selecting **Settings** in the global navigation > **Teams**.
 

--- a/pages/team_management/permissions.md
+++ b/pages/team_management/permissions.md
@@ -33,9 +33,13 @@ A user who is a _Buildkite organization administrator_ can do the following thro
 - From the **Teams** page:
 
     * Create a new team, using the **New Team** button.
-    * Administer (with full control) the [team-](#manage-teams-and-permissions-team-level-permissions), [pipeline-](#manage-teams-and-permissions-pipeline-level-permissions), [test suite-](/docs/test-analytics/permissions#manage-teams-and-permissions-test-suite-level-permissions) and [registry-level](/docs/packages/permissions#manage-teams-and-permissions-registry-level-permissions) settings throughout their Buildkite organization.
+    * Administer (with full control) the [team-](#manage-teams-and-permissions-team-level-permissions), [pipeline-](#manage-teams-and-permissions-pipeline-level-permissions), [test suite-](/docs/test-analytics/permissions#manage-teams-and-permissions-test-suite-level-permissions) and [registry-](/docs/packages/permissions#manage-teams-and-permissions-registry-level-permissions)level settings throughout their Buildkite organization.
     * Delete an existing team, by selecting the team > **Settings** tab > **Delete Team** button.
     * [Enable](#manage-teams-and-permissions) and disable the teams feature for their organization. This feature can only be disabled once all teams have been deleted from the organization (including the automatically-created **Everyone** team) using the **Disable Teams** button on the **Teams** page. Once the teams feature has been disabled, it can be [re-enabled](#manage-teams-and-permissions) at any time.
+
+- Configure other organization-level settings for Buildkite Pipelines and Packages, as well as various [integrations](/docs/integrations) with Buildkite.
+
+- Access and view Buildkite Pipelines and Packages usage reports and [audit logs](/docs/pipelines/security/audit-log).
 
 ### Team-level permissions
 

--- a/pages/test_analytics/permissions.md
+++ b/pages/test_analytics/permissions.md
@@ -20,13 +20,15 @@ Once the _teams_ feature is enabled, you can see the teams that you're a member 
 
 Learn more about what a _Buildkite organization administrator_ can do in the [Organization-level permissions section of the Pipelines documentation](/docs/team-management/permissions#manage-teams-and-permissions-organization-level-permissions).
 
-As an organization administrator, in the [**Team** section](https://buildkite.com/organizations/~/teams), you can add new teams or edit existing ones.
+As an organization administrator, you can access the [**Organization Settings** page](https://buildkite.com/organizations/~/settings) by selecting **Settings** in the global navigation, and do the following:
 
-<%= image "team-section-list.png", alt: "Screenshot of the Team section, showing a list of Teams" %>
+- Add new teams or edit existing ones in the [**Team** section](https://buildkite.com/organizations/~/teams).
 
-After selecting a team, you can view and administer the member-, [pipeline-](/docs/team-management/permissions#manage-teams-and-permissions-pipeline-level-permissions), [test suite-](#manage-teams-and-permissions-test-suite-level-permissions), [registry-](/docs/packages/permissions#manage-teams-and-permissions-registry-level-permissions) and [team-](/docs/team-management/permissions#manage-teams-and-permissions-team-level-permissions)level settings for that team.
+    <%= image "team-section-list.png", alt: "Screenshot of the Team section, showing a list of Teams" %>
 
-<%= image "team-section-test-suites-list.png", alt: "Screenshot of the Team section, showing a list of Test Suites the team has access to" %>
+- After selecting a team, you can view and administer the member-, [pipeline-](/docs/team-management/permissions#manage-teams-and-permissions-pipeline-level-permissions), [test suite-](#manage-teams-and-permissions-test-suite-level-permissions), [registry-](/docs/packages/permissions#manage-teams-and-permissions-registry-level-permissions) and [team-](/docs/team-management/permissions#manage-teams-and-permissions-team-level-permissions)level settings for that team.
+
+    <%= image "team-section-test-suites-list.png", alt: "Screenshot of the Team section, showing a list of Test Suites the team has access to" %>
 
 ### Team-level permissions
 

--- a/pages/test_analytics/permissions.md
+++ b/pages/test_analytics/permissions.md
@@ -20,7 +20,7 @@ Once the _teams_ feature is enabled, you can see the teams that you're a member 
 
 Learn more about what a _Buildkite organization administrator_ can do in the [Organization-level permissions section of the Pipelines documentation](/docs/team-management/permissions#manage-teams-and-permissions-organization-level-permissions).
 
-As an organization administrator, you can access the [**Organization Settings** page](https://buildkite.com/organizations/~/settings) by selecting **Settings** in the global navigation, and do the following:
+As an organization administrator, you can access the [**Organization Settings** page](https://buildkite.com/organizations/~/settings) by selecting **Settings** in the global navigation, where you can do the following:
 
 - Add new teams or edit existing ones in the [**Team** section](https://buildkite.com/organizations/~/teams).
 

--- a/pages/test_analytics/permissions.md
+++ b/pages/test_analytics/permissions.md
@@ -24,7 +24,7 @@ As an organization administrator, in the [**Team** section](https://buildkite.co
 
 <%= image "team-section-list.png", alt: "Screenshot of the Team section, showing a list of Teams" %>
 
-After selecting a team, you can view the member-, pipeline-, test suite-, registry- and team-specific settings.
+After selecting a team, you can view and administer the member-, [pipeline-](/docs/team-management/permissions#manage-teams-and-permissions-pipeline-level-permissions), [test suite-](#manage-teams-and-permissions-test-suite-level-permissions), [registry-](/docs/packages/permissions#manage-teams-and-permissions-registry-level-permissions) and [team-](/docs/team-management/permissions#manage-teams-and-permissions-team-level-permissions)level settings for that team.
 
 <%= image "team-section-test-suites-list.png", alt: "Screenshot of the Team section, showing a list of Test Suites the team has access to" %>
 


### PR DESCRIPTION
Included in this PR:

- New [Private storage](https://buildkite.com/docs/packages/private-storage) page (preview [here](https://2824--bk-docs-preview.netlify.app/docs/packages/private-storage)).
- Minor updates to the [Access control](https://buildkite.com/docs/packages/permissions#manage-teams-and-permissions-organization-level-permissions) page on **Organization-level permissions**, adding how to activate the **Packages** product (preview [here](https://2824--bk-docs-preview.netlify.app/docs/packages/permissions#manage-teams-and-permissions-organization-level-permissions)).
    - Some minor updates to the other pages related to the changes made on this one ^ in the Pipelines and Test Analytics docs.