### PR TITLE
Update public beta callout for Buildkite Packages.

### DIFF
--- a/pages/packages.md
+++ b/pages/packages.md
@@ -9,7 +9,7 @@ Buildkite Packages is a product that:
 As well as storing a collection of packages, a registry also surfaces metadata or attributes associated with a package, such as the package's description, version, contents (files and directories), checksum details, distribution type, dependencies, and so on.
 
 > 📘 Buildkite Packages is currently in public beta
-> Please visit the [Buildkite Packages](https://buildkite.com/packages) page on our website to join the private trial for this product.
+> You can enable [Buildkite Packages](https://buildkite.com/packages) through the **Organization Settings** page.
 
 ## An introduction to packages
 


### PR DESCRIPTION
The messaging on the [Buildkite Packages](https://buildkite.com/packages) page of the website will be updated soon.

From this revised callout, I'll also link through to the org admin section updates as part of merging them in with this PR:
https://github.com/buildkite/docs/pull/2824