### PR TITLE
removed the experiment highlight from the k8s implementation doc

### DIFF
--- a/pages/agent/v3.md
+++ b/pages/agent/v3.md
@@ -107,9 +107,6 @@ Modifies `start` and `bootstrap` to execute in separate Kubernetes containers in
 
 The [Buildkite Agent Stack for Kubernetes](https://github.com/buildkite/agent-stack-k8s) uses this experiment to run Buildkite steps as Kubernetes jobs. It is not expected to work outside of that context. See the [README](https://github.com/buildkite/agent-stack-k8s/blob/main/README.md) for more details.
 
-> 🛠 Experimental feature
-> To use Kubernetes exec, set <code>experiment="kubernetes-exec"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.
-
 ### Job API
 
 Exposes a local API to introspect and mutate the state of a running job through environment variables. This lets you write scripts, hooks, and plugins in languages other than Bash, using them to interact with the agent.

--- a/pages/agent/v3.md
+++ b/pages/agent/v3.md
@@ -101,12 +101,6 @@ After repository checkout, resolve `BUILDKITE_COMMIT` to a commit hash. This mak
 > 🛠 Experimental feature
 > To use it, set <code>experiment="resolve-commit-after-checkout"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.
 
-### Kubernetes exec
-
-Modifies `start` and `bootstrap` to execute in separate Kubernetes containers in the same pod.
-
-The [Buildkite Agent Stack for Kubernetes](https://github.com/buildkite/agent-stack-k8s) uses this experiment to run Buildkite steps as Kubernetes jobs. It is not expected to work outside of that context. See the [README](https://github.com/buildkite/agent-stack-k8s/blob/main/README.md) for more details.
-
 ### Job API
 
 Exposes a local API to introspect and mutate the state of a running job through environment variables. This lets you write scripts, hooks, and plugins in languages other than Bash, using them to interact with the agent.


### PR DESCRIPTION
the usage of the k8s stack was been called out in the documentation as experimental and this is not the case. 
I have removed the experimental callout for the k8s service in the docs. 