### PR TITLE
docs: include sleep command in hosted agent terminal access docs

### DIFF
--- a/pages/pipelines/hosted_agents/terminal_access.md
+++ b/pages/pipelines/hosted_agents/terminal_access.md
@@ -22,7 +22,7 @@ As a pipeline is being built, expand the relevant step and as its job is being b
 
 <%= image "terminal-button-on-job.png", alt: "Accessing the SSH button through the Buildkite UI" %>
 
-To extend the terminal session time, it is recommended to include a `sleep` [command](/docs/pipelines/command-step) within your job steps. This can help maintain an active terminal connection and prevent the session from timing out too quickly, allowing you to debug your job or investigate the environment the job is running in.
+To extend the terminal session time, it is recommended that you include a `sleep` [command](/docs/pipelines/command-step) within your job steps. This can help maintain an active terminal connection and prevent the session from timing out too quickly, allowing you to debug your job or investigate the environment the job is running in.
 
 In the example below, the job will pause for 10 minutes before continuing. Adjust the sleep duration according to your specific needs.
 

--- a/pages/pipelines/hosted_agents/terminal_access.md
+++ b/pages/pipelines/hosted_agents/terminal_access.md
@@ -22,6 +22,19 @@ As a pipeline is being built, expand the relevant step and as its job is being b
 
 <%= image "terminal-button-on-job.png", alt: "Accessing the SSH button through the Buildkite UI" %>
 
+To extend the terminal session time, it is recommended to include a `sleep` [command](/docs/pipelines/command-step) within your job steps. This can help maintain an active terminal connection and prevent the session from timing out too quickly. 
+
+In the example below, the job will pause for 10 minutes before continuing. Adjust the sleep duration according to your specific needs
+
+```yml
+steps:
+  - label: "Extend Terminal Session"
+    command: |
+      echo "Starting job..."
+      sleep 600  # Sleep for 10 minutes
+      echo "Job complete."
+```
+
 ## Deactivate and reactivate terminal access on hosted agents
 
 By default, the terminal access feature for Buildkite hosted agents is active.

--- a/pages/pipelines/hosted_agents/terminal_access.md
+++ b/pages/pipelines/hosted_agents/terminal_access.md
@@ -22,7 +22,7 @@ As a pipeline is being built, expand the relevant step and as its job is being b
 
 <%= image "terminal-button-on-job.png", alt: "Accessing the SSH button through the Buildkite UI" %>
 
-To extend the terminal session time, it is recommended to include a `sleep` [command](/docs/pipelines/command-step) within your job steps. This can help maintain an active terminal connection and prevent the session from timing out too quickly.
+To extend the terminal session time, it is recommended to include a `sleep` [command](/docs/pipelines/command-step) within your job steps. This can help maintain an active terminal connection and prevent the session from timing out too quickly, allowing you to debug your job or investigate the environment the job is running in.
 
 In the example below, the job will pause for 10 minutes before continuing. Adjust the sleep duration according to your specific needs.
 

--- a/pages/pipelines/hosted_agents/terminal_access.md
+++ b/pages/pipelines/hosted_agents/terminal_access.md
@@ -22,9 +22,9 @@ As a pipeline is being built, expand the relevant step and as its job is being b
 
 <%= image "terminal-button-on-job.png", alt: "Accessing the SSH button through the Buildkite UI" %>
 
-To extend the terminal session time, it is recommended to include a `sleep` [command](/docs/pipelines/command-step) within your job steps. This can help maintain an active terminal connection and prevent the session from timing out too quickly. 
+To extend the terminal session time, it is recommended to include a `sleep` [command](/docs/pipelines/command-step) within your job steps. This can help maintain an active terminal connection and prevent the session from timing out too quickly.
 
-In the example below, the job will pause for 10 minutes before continuing. Adjust the sleep duration according to your specific needs
+In the example below, the job will pause for 10 minutes before continuing. Adjust the sleep duration according to your specific needs.
 
 ```yml
 steps:


### PR DESCRIPTION
COMP-464

Add recommendation to `sleep` in a job, to extend terminal session time when using hosted agents.