### PR TITLE
Add references to the Buildkite Agent Stack for Kubernetes in the AWS…

### DIFF
--- a/pages/agent/v3/aws.md
+++ b/pages/agent/v3/aws.md
@@ -8,8 +8,7 @@ The Buildkite Agent can be run on AWS using our Elastic CI Stack for AWS
 CloudFormation template, or by installing the agent on your self-managed
 instances.
 
-
-## Using our Elastic CI Stack for AWS CloudFormation template
+## Using the Elastic CI Stack for AWS CloudFormation template
 
 The [Elastic CI Stack for AWS](/docs/agent/v3/elastic-ci-aws/elastic-ci-stack-overview) is a
 CloudFormation template for an autoscaling Buildkite Agent cluster. The
@@ -22,6 +21,14 @@ integration tests, or perform any AWS ops related tasks.
 You can launch an instance of the Elastic CI Stack for AWS from your
 organization's [Agents page](http://buildkite.com/organizations/-/agents) or
 the [GitHub repository](https://github.com/buildkite/elastic-ci-stack-for-aws).
+
+## Using the Buildkite Agent Stack for Kubernetes on AWS
+
+The Buildkite Agent's jobs can be run within a Kubernetes cluster on AWS.
+
+Before you start, you will require your own Kubernetes cluster running on AWS. Learn more about this from [Kubernetes on AWS](https://aws.amazon.com/kubernetes/).
+
+Once your Kubernetes cluster is running on AWS, follow the [Buildkite Agent Stack for Kubernetes](https://github.com/buildkite/agent-stack-k8s?tab=readme-ov-file#buildkite-agent-stack-for-kubernetes) instructions to set up the Buildkite Agent stack to run in Kubernetes.
 
 ## Installing the agent on your own AWS instances
 

--- a/pages/agent/v3/gcloud.md
+++ b/pages/agent/v3/gcloud.md
@@ -2,6 +2,12 @@
 
 The Buildkite Agent can be run on [Google Cloud Platform](https://cloud.google.com). For fine control over long–lived agents, you might like to run the agent using individual VM instances on Google Compute Engine. Or run Docker–based builds using a scalable cluster of agents on the Google Kubernetes Engine using Kubernetes.
 
+## Using the Buildkite Agent Stack for Kubernetes on the Google Cloud Platform
+
+The Buildkite Agent's jobs can be run within a Kubernetes cluster on Google Cloud Platform.
+
+Learn more about how to set up the Buildkite Agent stack to run in Kubernetes in [Buildkite Agent Stack for Kubernetes](https://github.com/buildkite/agent-stack-k8s?tab=readme-ov-file#buildkite-agent-stack-for-kubernetes).
+
 ## Running the agent on Google Compute Engine
 
 To run the agent on your own [Google Compute Engine](https://cloud.google.com/compute) instance use whichever installer matches your instance type. For example:

--- a/pages/agent/v3/gcloud.md
+++ b/pages/agent/v3/gcloud.md
@@ -1,10 +1,10 @@
 # Running Buildkite Agent on Google Cloud Platform
 
-The Buildkite Agent can be run on [Google Cloud Platform](https://cloud.google.com). For fine control over long–lived agents, you might like to run the agent using individual VM instances on Google Compute Engine. Or run Docker–based builds using a scalable cluster of agents on the Google Kubernetes Engine using Kubernetes.
+The Buildkite Agent can be run on [Google Cloud Platform](https://cloud.google.com) (GCP). For fine control over long–lived agents, you might like to run the agent using individual VM instances on Google Compute Engine. Or run Docker–based builds using a scalable cluster of agents on the Google Kubernetes Engine using Kubernetes.
 
 ## Using the Buildkite Agent Stack for Kubernetes on the Google Cloud Platform
 
-The Buildkite Agent's jobs can be run within a Kubernetes cluster on Google Cloud Platform.
+The Buildkite Agent's jobs can be run within a Kubernetes cluster on GCP.
 
 Once your Kubernetes cluster is running on GCP, follow the [Buildkite Agent Stack for Kubernetes](https://github.com/buildkite/agent-stack-k8s?tab=readme-ov-file#buildkite-agent-stack-for-kubernetes) instructions to set up the Buildkite Agent stack to run in Kubernetes.
 

--- a/pages/agent/v3/gcloud.md
+++ b/pages/agent/v3/gcloud.md
@@ -6,7 +6,7 @@ The Buildkite Agent can be run on [Google Cloud Platform](https://cloud.google.c
 
 The Buildkite Agent's jobs can be run within a Kubernetes cluster on Google Cloud Platform.
 
-Learn more about how to set up the Buildkite Agent stack to run in Kubernetes in [Buildkite Agent Stack for Kubernetes](https://github.com/buildkite/agent-stack-k8s?tab=readme-ov-file#buildkite-agent-stack-for-kubernetes).
+Once your Kubernetes cluster is running on GCP, follow the [Buildkite Agent Stack for Kubernetes](https://github.com/buildkite/agent-stack-k8s?tab=readme-ov-file#buildkite-agent-stack-for-kubernetes) instructions to set up the Buildkite Agent stack to run in Kubernetes.
 
 ## Running the agent on Google Compute Engine
 


### PR DESCRIPTION
… and Google Cloud installation pages.

This PR was done as merging in [this PR](https://github.com/buildkite/docs/pull/2826/files) removed the only reference to our [Buildkite Agent Stack for Kubernetes](https://github.com/buildkite/agent-stack-k8s?tab=readme-ov-file#buildkite-agent-stack-for-kubernetes) README page from within the docs.
