### PR TITLE
Minor improvements (mainly from feedback) to recent Buildkite Package…

### DIFF
--- a/pages/packages.md
+++ b/pages/packages.md
@@ -9,7 +9,7 @@ Buildkite Packages is a product that:
 As well as storing a collection of packages, a registry also surfaces metadata or attributes associated with a package, such as the package's description, version, contents (files and directories), checksum details, distribution type, dependencies, and so on.
 
 > 📘 Buildkite Packages is currently in public beta
-> You can enable [Buildkite Packages](https://buildkite.com/packages) through the [**Organization Settings** page](/docs/packages/permissions#manage-teams-and-permissions-organization-level-permissions).
+> You can enable [Buildkite Packages](https://buildkite.com/packages) through the [**Organization Settings** page](/docs/packages/permissions#enabling-buildkite-packages).
 
 ## An introduction to packages
 

--- a/pages/packages/permissions.md
+++ b/pages/packages/permissions.md
@@ -24,11 +24,22 @@ As an organization administrator, you can access the [**Organization Settings** 
 
     * After selecting a team, you can view and administer the member-, [pipeline-](/docs/team-management/permissions#manage-teams-and-permissions-pipeline-level-permissions), [test suite-](/docs/test-analytics/permissions#manage-teams-and-permissions-test-suite-level-permissions), [registry-](#manage-teams-and-permissions-registry-level-permissions) and [team-](/docs/team-management/permissions#manage-teams-and-permissions-team-level-permissions)level settings for that team.
 
-- Enable Buildkite Packages for your Buildkite organization. To do this, in the **Packages** section, select **Enable** to open the **Enable Packages** page > **Enable Buildkite Packages (Beta)**.
-
-    **Note:** Once enabled the **Enable** changes to **Enabled** and Buildkite Packages can only be disabled by contacting [support](https://buildkite.com/support).
+- [Enable Buildkite Packages](#enabling-buildkite-packages) for your Buildkite organization.
 
 - Configure [private storage](/docs/packages/private-storage) for your Buildkite Packages registries.
+
+<h4 id="enabling-buildkite-packages">Enabling Buildkite Packages</h4>
+
+To do this:
+
+1. As an [Buildkite organization administrator](#manage-teams-and-permissions-organization-level-permissions), access the [**Organization Settings** page](https://buildkite.com/organizations/~/settings) by selecting **Settings** in the global navigation.
+
+1. In the **Packages** section, select **Enable** to open the **Enable Packages** page.
+
+1. Select the **Enable Buildkite Packages (Beta)** button, then **Enable Buildkite Packages** in the **Ready to enable Buildkite Packages** confirmation dialog.
+
+> 📘
+> Once Buildkite Packages is enabled, the **Enable** link on the **Organization Settings** page changes to **Enabled** and Buildkite Packages can only be disabled by contacting [support](https://buildkite.com/support).
 
 ### Team-level permissions
 

--- a/pages/packages/private_storage.md
+++ b/pages/packages/private_storage.md
@@ -16,9 +16,13 @@ Buildkite Packages uses [AWS CloudFormation](https://docs.aws.amazon.com/AWSClou
 
 ## Before you start
 
-Before you can start linking your private AWS S3 storage to Buildkite Packages, you will need to have set yourself up with this storage.
+Before you can start linking your private AWS S3 storage to Buildkite Packages, you will need to have created your own AWS S3 bucket.
 
-Learn more about this process from the main [Amazon S3](https://aws.amazon.com/s3/) page, as well as the [Amazon S3 documentation](https://docs.aws.amazon.com/s3/).
+Learn more about:
+
+- AWS S3 from the main [Amazon S3](https://aws.amazon.com/s3/) page, as well as the [Amazon S3 documentation](https://docs.aws.amazon.com/s3/).
+
+- How to create an S3 bucket from the [Amazon S3 documentation's Getting started](https://docs.aws.amazon.com/AmazonS3/latest/userguide/GetStartedWithS3.html) guide.
 
 ## Link your private storage to Buildkite Packages
 


### PR DESCRIPTION
…s docs updates.

This is to address the following feedback:

- Improvements to the **Before you begin** section of the **Link private storage** page since this wasn't originally clear. Raised by @sj26 and @mbelton-buildkite .
- Create a new page subsection on the Access control page for enabling Buildkite Packages, since it was buried in a parent section **Organization-level permissions** that discussed what these provided, mainly scoped for Buildkite Packages. Raised by @mbelton-buildkite .