### PR TITLE
A number of updates to reflect recent UI changes to Buildkite.

### DIFF
--- a/pages/clusters/manage_queues.md
+++ b/pages/clusters/manage_queues.md
@@ -39,12 +39,12 @@ To create a new queue using the Buildkite interface:
 
 1. Select **Agents** in the global navigation to access the **Clusters** page.
 1. Select the cluster in which to create the new queue.
-1. On the **Queues** page, select **New Queue**.
+1. On the **Queues** page, select **New Queue** to open the **Create a new Queue** page.
 1. In the **Create a key** field, enter a unique _key_ for the queue, which can only contain letters, numbers, hyphens, and underscores, as valid characters.
 1. Select the **Add description** checkbox to enter an optional longer description for the queue. This description appears under the queue's key, which is listed on the **Queues** page, as well as when viewing the queue's details.
-1. In the **Select your compute** section, select between [**Hosted**](/docs/pipelines/hosted-agents/overview) or **Self hosted** for your agent infrastructure.
+1. In the **Select your agent infrastructure** section, select between [**Hosted**](/docs/pipelines/hosted-agents/overview) or **Self hosted** for your agent infrastructure.
 1. If you chose **Hosted**, complete the remaining sub-steps:
-    1. In the new **Configure your hosted compute** section, select your **Machine type** ([**Linux**](/docs/pipelines/hosted-agents/linux) or [**macOS**](/docs/pipelines/hosted-agents/mac)).
+    1. In the new **Configure your hosted agent infrastructure** section, select your **Machine type** ([**Linux**](/docs/pipelines/hosted-agents/linux) or [**macOS**](/docs/pipelines/hosted-agents/mac)).
     1. If you selected **Linux**, within **Architecture**, you can choose between **AMD64** (the default and recommended) or **ARM64** architectures for the Linux machines running as hosted agents. To switch to **ARM64**, select **Change**, followed by **ARM64 (AArch64)**.
     1. Select the appropriate **Capacity** for your hosted agent machine type (**Small**, **Medium** or **Large**). Take note of the additional information provided in the new **Hosted agents trial** section, which changes based on your selected **Capacity**.
 1. Select **Create Queue**.

--- a/pages/pipelines/hosted_agents/terminal_access.md
+++ b/pages/pipelines/hosted_agents/terminal_access.md
@@ -32,9 +32,9 @@ To deactivate or reactivate the hosted agent terminal access feature:
 
 1. Select **Settings** in the global navigation to access the [**Organization Settings**](https://buildkite.com/organizations/~/settings) page.
 1. Select **Pipelines** > **Settings** to access your organization's [**Pipeline Settings**](https://buildkite.com/organizations/~/pipeline-settings) page.
-1. Scroll down to the **Hosted Agents SSH** and to:
-    * _Deactivate this feature_, select the **Disable SSH** button, followed by **Disable Hosted Agents SSH** in the confirmation message.
-    * _Reactivate this feature_, select the **Enable SSH** button, followed by **Enable Hosted Agents SSH** in the confirmation message.
+1. Scroll down to the **Hosted Agents Terminal Access** and to:
+    * _Deactivate this feature_, select the **Disable Terminal Access** button, followed by **Disable Hosted Agents Terminal Access** in the confirmation message.
+    * _Reactivate this feature_, select the **Enable Terminal Access** button, followed by **Enable Hosted Agents Terminal Access** in the confirmation message.
 
 Terminal access will now be either removed or made available to all Buildkite hosted agents across all clusters within your Buildkite organization.
 

--- a/pages/team_management/permissions.md
+++ b/pages/team_management/permissions.md
@@ -34,6 +34,9 @@ A user who is a _Buildkite organization administrator_ can access the [**Organiz
 
     * Create a new team, using the **New Team** button.
     * Administer (with full control) the [team-](#manage-teams-and-permissions-team-level-permissions), [pipeline-](#manage-teams-and-permissions-pipeline-level-permissions), [test suite-](/docs/test-analytics/permissions#manage-teams-and-permissions-test-suite-level-permissions) and [registry-](/docs/packages/permissions#manage-teams-and-permissions-registry-level-permissions)level settings throughout their Buildkite organization.
+
+        **Note:** Registry-level settings are only available once [Buildkite Packages has been enabled](/docs/packages/permissions#enabling-buildkite-packages).
+
     * Delete an existing team, by selecting the team > **Settings** tab > **Delete Team** button.
     * [Enable](#manage-teams-and-permissions) and disable the teams feature for their organization. This feature can only be disabled once all teams have been deleted from the organization (including the automatically-created **Everyone** team) using the **Disable Teams** button on the **Teams** page. Once the teams feature has been disabled, it can be [re-enabled](#manage-teams-and-permissions) at any time.
 
@@ -62,6 +65,8 @@ A user who is a _team maintainer_ on an existing team can:
 
         To do this, select the appropriate tab (**Pipelines**, **Test Suites** or **Package Registries**) and then select the required permission for the item, although be aware of the [caveat below](#changing-full-access-permissions-on-pipelines-test-suites-and-registries).
 
+        **Note:** Managing team permissions for registries is only available once [Buildkite Packages has been enabled](/docs/packages/permissions#enabling-buildkite-packages).
+
     * Edit the team's details and other settings using the **Settings** tab, which includes the ability to:
 
         - Change the team's **Visibility**.
@@ -79,7 +84,7 @@ A user who is a _team maintainer_ on an existing team can:
 
         - Delete the team, using the **Delete** button.
 
-As indicated in the Buildkite interface, a user who is in a team is known as a **Team Member**, and such users have fewer permissions within the team than a **Team Maintainer**.
+As indicated in the Buildkite interface, a user who is in a team is known as a **Team Member**, and such users have fewer permissions within the team (that is, no team management capabilities) than a **Team Maintainer**.
 
 All team members in a team have the same level of access to the [pipelines](#manage-teams-and-permissions-pipeline-level-permissions), [test suites](/docs/test-analytics/permissions#manage-teams-and-permissions-test-suite-level-permissions), and [registries](/docs/packages/permissions#manage-teams-and-permissions-registry-level-permissions) in the team. If you need to have more fine grained control over the pipelines, test suites or registries in a team, you can create more teams with different permissions.
 

--- a/pages/test_analytics/permissions.md
+++ b/pages/test_analytics/permissions.md
@@ -30,6 +30,8 @@ As an organization administrator, you can access the [**Organization Settings** 
 
     <%= image "team-section-test-suites-list.png", alt: "Screenshot of the Team section, showing a list of Test Suites the team has access to" %>
 
+    **Note:** Registry-level settings are only available once [Buildkite Packages has been enabled](/docs/packages/permissions#enabling-buildkite-packages).
+
 ### Team-level permissions
 
 Learn more about what _team members_ are and what _team maintainers_ can do in the [Team-level permissions section of the Pipelines documentation](/docs/team-management/permissions#manage-teams-and-permissions-team-level-permissions).

--- a/pages/tutorials/getting_started.md
+++ b/pages/tutorials/getting_started.md
@@ -58,7 +58,7 @@ To create a hosted agent:
 1. Follow the [Create a queue](/docs/clusters/manage-queues#create-a-queue) > [Using the Buildkite interface](/docs/clusters/manage-queues#create-a-queue-using-the-buildkite-interface) instructions to begin creating your hosted agent within its own queue.
 
     As part of this process:
-    * In the **Select your compute** section, choose **Hosted**.
+    * In the **Select your agent infrastructure** section, choose **Hosted**.
     * Follow the relevant sub-steps for configuring your hosted agent.
 
 1. Make your pipelines use this hosted agent by default, by ensuring its queue is the _default queue_. This should be indicated by **(default)** after the queue's key on the cluster's **Queues** page. If this is not the case and another queue is marked **(default)**:


### PR DESCRIPTION
In summary, these address the following UI changes:

- Terminal access for hosted agents in **Settings** changing from **SSH** to **Terminal Access**.
- When setting up a cluster's queue, changing the **compute** references to **agent infrastructure**.

As a bonus, also now clarified that registry permissions become available (i.e. once Buildkite Packages is enabled).