### PR TITLE
Correct build export expiry from 12 months to 18 months

### DIFF
--- a/pages/pipelines/build_exports.md
+++ b/pages/pipelines/build_exports.md
@@ -5,11 +5,11 @@
 
 If you need to retain build data beyond the [retention period](/docs/pipelines/build-retention) in your [Buildkite plan](https://buildkite.com/pricing), you can export the data to your own [Amazon S3 bucket](https://aws.amazon.com/s3/) or [Google Cloud Storage (GCS) bucket](https://cloud.google.com/storage).
 
-If you don't configure a bucket, Buildkite stores the build data for 12 months in case you need it. You cannot access this build data through the API or Buildkite dashboard, but you can request the data by contacting support.
+If you don't configure a bucket, Buildkite stores the build data for 18 months in case you need it. You cannot access this build data through the API or Buildkite dashboard, but you can request the data by contacting support.
 
 ## How it works
 
-Builds older than the build retention limit are automatically exported as JSON using the build export strategy (S3 or GCS) you have configured. If you haven't configured a bucket for build exports, Buildkite stores that build data as JSON in our own Amazon S3 bucket for a further 12 months in case you need it. The following diagram outlines this process.
+Builds older than the build retention limit are automatically exported as JSON using the build export strategy (S3 or GCS) you have configured. If you haven't configured a bucket for build exports, Buildkite stores that build data as JSON in our own Amazon S3 bucket for a further 18 months in case you need it. The following diagram outlines this process.
 
 <%= image "build-exports-flow-chart.png", alt: "Simplified flow chart of the build exports process" %>
 


### PR DESCRIPTION
Fix an inconsistency in the build exports docs: builds that are exported to the shared buildkite bucket are held for 18 months, not 12 months. This is correct in the flow chart, but incorrect in the text. This corrects the text

![CleanShot 2024-06-19 at 10 21 54](https://github.com/buildkite/docs/assets/11305534/0b915205-b8cb-4821-af7d-2473f95cd69a)
