### PR TITLE
Add an information block for using step-level vs build-level notifications

### DIFF
--- a/pages/pipelines/notifications.md
+++ b/pages/pipelines/notifications.md
@@ -154,8 +154,8 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-> 📘Step-level vs build-level
-> A step-level notify step will ignore the requirements of a build-level notification. If a build-level notification condition is that it runs only on `main`, a step-level notification will run on all branches if no branch conditional is set.
+> 📘 Step-level vs build-level notifications
+> A step-level notify step will ignore the requirements of a build-level notification. If a build-level notification condition is that it runs only on `main`, a step-level notification without branch conditionals will run on all branches.
 
 ### Notify a user in all workspaces
 

--- a/pages/pipelines/notifications.md
+++ b/pages/pipelines/notifications.md
@@ -154,6 +154,9 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
+> 📘Step-level vs build-level
+> A step-level notify step will ignore the requirements of a build-level notification. If a build-level notification condition is that it runs only on `main`, a step-level notification will run on all branches if no branch conditional is set.
+
 ### Notify a user in all workspaces
 
 You can notify a user in all workspaces by providing their username in the `pipeline.yml`.


### PR DESCRIPTION
## Added
A small information block on using step-level notifications and how they may differ to build-level.

Step-level notifications may act differently to how people assume, eg they can ignore branch filters set at a build-level.
