### PR TITLE
SUP-2343: Add lists of Attributes that can be used with `buildkite-agent step` 

### DIFF
--- a/pages/agent/v3/cli_step.md
+++ b/pages/agent/v3/cli_step.md
@@ -4,9 +4,7 @@ The Buildkite agent's `step` command provides the ability to retrieve and update
 
 ## Updating a step
 
-Use this command in your build scripts to update an attribute of a step. The following attributes can be updated:
-
-* `label`
+Use this command in your build scripts to update the `label` attribute of a step.
 
 <%= render 'agent/v3/help/step_update' %>
 

--- a/pages/agent/v3/cli_step.md
+++ b/pages/agent/v3/cli_step.md
@@ -12,7 +12,23 @@ Use this command in your build scripts to update an attribute of a step. The fol
 
 ## Getting a step
 
-Use this command in your build scripts to get the value of a particular attribute from a step.
+Use this command in your build scripts to get the value of a particular attribute from a step. The following attributes values can be retreived:
+
+* `agents`
+* `command`
+* `concurrency_key`
+* `concurrency_limit`
+* `depends_on`
+* `env`
+* `if`
+* `key`
+* `label`
+* `notify`
+* `outcome`
+* `parallelism`
+* `state`
+* `timeout`
+* `type`
 
 <%= render 'agent/v3/help/step_get' %>
 

--- a/pages/agent/v3/cli_step.md
+++ b/pages/agent/v3/cli_step.md
@@ -4,7 +4,9 @@ The Buildkite agent's `step` command provides the ability to retrieve and update
 
 ## Updating a step
 
-Use this command in your build scripts to update an attribute of a step.
+Use this command in your build scripts to update an attribute of a step. The following attributes can be updated:
+
+* `label`
 
 <%= render 'agent/v3/help/step_update' %>
 

--- a/pages/agent/v3/cli_step.md
+++ b/pages/agent/v3/cli_step.md
@@ -12,7 +12,7 @@ Use this command in your build scripts to update an attribute of a step. The fol
 
 ## Getting a step
 
-Use this command in your build scripts to get the value of a particular attribute from a step. The following attributes values can be retreived:
+Use this command in your build scripts to get the value of a particular attribute from a step. The following attributes values can be retrieved:
 
 * `agents`
 * `command`

--- a/pages/agent/v3/help/_step_get.md
+++ b/pages/agent/v3/help/_step_get.md
@@ -30,7 +30,6 @@ output the data (currently only JSON is supported).
 ```shell
 $ buildkite-agent step get "label" --step "key"
 $ buildkite-agent step get --format json
-$ buildkite-agent step get "retry" --format json
 $ buildkite-agent step get "state" --step "my-other-step"
 ```
 


### PR DESCRIPTION
Had a customer reach out checking which attributes could be used with the `buildkite-agent step [get|update]` commands as they found it unclear from the docs. So adding list of available Attributes for clarity.
Will need to also update the Agents docs - https://github.com/buildkite/agent/blob/d387c3bdd58eb3fd94906e3e400ca8e0ab230e87/clicommand/step_get.go#L26-L31 - to correct example as `retry` is not an available attribute at the time of writing.