### PR TITLE
Rework intros to OIDC overview pages to make their purposes more clear.

### DIFF
--- a/pages/packages/manage_registries.md
+++ b/pages/packages/manage_registries.md
@@ -94,7 +94,7 @@ Unlike other tokens generated elsewhere in Buildkite, registry tokens can contin
 
 ### Configure registry storage
 
-When a new registry is [created](#create-a-registry), it automatically uses the [default Buildkite Packages storage](/docs/packages/private-storage#set-the-default-buildkite-packages-storage) location. However, your new registry's default storage location can be overridden to use (another private) previously configured storage location. Learn more about configuring private storage in [Private storage links](/docs/packages/private-storage).
+When a new registry is [created](#create-a-registry), it automatically uses the [default Buildkite Packages storage](/docs/packages/private-storage#set-the-default-buildkite-packages-storage) location. However, your new registry's default storage location can be overridden to use another configured storage location. Learn more about configuring private storage in [Private storage links](/docs/packages/private-storage).
 
 To configure/change your registry's current storage:
 

--- a/pages/packages/security/oidc.md
+++ b/pages/packages/security/oidc.md
@@ -4,7 +4,7 @@
 
 Buildkite Packages can be configured with OIDC-compatible policies that only permit Buildkite Agent interactions from specific Buildkite organizations, pipelines, jobs, and agents, associated with a pipeline's job. This is similar to how third-party products and services can be configured to consume Buildkite OIDC tokens from [Buildkite pipelines](/docs/pipelines/security/oidc), for deployment, or access management and security purposes.
 
-A Buildkite OIDC token, representing a Buildkite Agent interaction (containing such relevant pipeline job metadata), can be used by Buildkite Packages to allow a registry to authenticate this interaction. If the interaction does not match or comply with the registry's policy, the OIDC token and hence, subsequent interactions are rejected.
+A Buildkite OIDC token, representing a Buildkite Agent interaction (containing the relevant pipeline job metadata), can be used by Buildkite Packages to allow a registry to authenticate this interaction. If the interaction does not match or comply with the registry's policy, the OIDC token and hence, subsequent interactions are rejected.
 
 The [Buildkite Agent's `oidc` command](/docs/agent/v3/cli-oidc) allows you to request an OIDC token from Buildkite representing the pipeline's current job. These tokens are can then used by a Buildkite Packages registry to determine if the organization, pipeline and any other metadata associated with the pipeline and its job are permitted to publish/upload packages to this registry.
 

--- a/pages/packages/security/oidc.md
+++ b/pages/packages/security/oidc.md
@@ -2,11 +2,14 @@
 
 <%= render_markdown partial: 'platform/buildkite_agent_oidc_token_overview' %>
 
-Third-party products and services, such as [GitHub Actions](https://github.com/features/actions), as well as Buildkite Packages itself, can be configured with OIDC-compatible policies that only permit agent interactions from specific Buildkite organizations, pipelines, jobs, and agents, associated with a pipeline's job.
+Buildkite Packages can be configured with OIDC-compatible policies that only permit Buildkite Agent interactions from specific Buildkite organizations, pipelines, jobs, and agents, associated with a pipeline's job. This is similar to how third-party products and services can be configured to consume Buildkite OIDC tokens from [Buildkite pipelines](/docs/pipelines/security/oidc), for deployment, or access management and security purposes.
 
-A Buildkite OIDC token, representing such an agent interaction containing this metadata, can be used by these third-party services and Buildkite Packages, to allow the service to authenticate the Buildkite interaction. If one of these interactions does not match or comply with the service's policy, the OIDC token and hence, subsequent interactions are rejected.
+A Buildkite OIDC token, representing a Buildkite Agent interaction (containing such relevant pipeline job metadata), can be used by Buildkite Packages to allow a registry to authenticate this interaction. If the interaction does not match or comply with the registry's policy, the OIDC token and hence, subsequent interactions are rejected.
 
 The [Buildkite Agent's `oidc` command](/docs/agent/v3/cli-oidc) allows you to request an OIDC token from Buildkite representing the pipeline's current job. These tokens are can then used by a Buildkite Packages registry to determine if the organization, pipeline and any other metadata associated with the pipeline and its job are permitted to publish/upload packages to this registry.
+
+> 📘
+> Buildkite Packages registries also support OIDC policies that can consume OIDC tokens configured on third-party products and services, such as [GitHub Actions](https://github.com/features/actions), to authenticate interactions from these services.
 
 ## Define OIDC policies for a registry
 

--- a/pages/packages/security/oidc.md
+++ b/pages/packages/security/oidc.md
@@ -4,22 +4,22 @@
 
 Buildkite Packages can be configured with OIDC-compatible policies that only permit Buildkite Agent interactions from specific Buildkite organizations, pipelines, jobs, and agents, associated with a pipeline's job. This is similar to how third-party products and services can be configured to consume Buildkite OIDC tokens from [Buildkite pipelines](/docs/pipelines/security/oidc), for deployment, or access management and security purposes.
 
-A Buildkite OIDC token, representing a Buildkite Agent interaction (containing the relevant pipeline job metadata), can be used by Buildkite Packages to allow a registry to authenticate this interaction. If the interaction does not match or comply with the registry's policy, the OIDC token and hence, subsequent interactions are rejected.
+A Buildkite OIDC token, representing a Buildkite Agent interaction (containing the relevant pipeline job metadata), can be used by Buildkite Packages to allow a registry to authenticate this interaction. If the interaction does not match or comply with the registry's OIDC policy, the OIDC token and hence, subsequent interactions are rejected.
 
-The [Buildkite Agent's `oidc` command](/docs/agent/v3/cli-oidc) allows you to request an OIDC token from Buildkite representing the pipeline's current job. These tokens are can then used by a Buildkite Packages registry to determine if the organization, pipeline and any other metadata associated with the pipeline and its job are permitted to publish/upload packages to this registry.
+The [Buildkite Agent's `oidc` command](/docs/agent/v3/cli-oidc) allows you to request an OIDC token from Buildkite representing the pipeline's current job. These tokens are can then used by a Buildkite Packages registry to determine (through its OIDC policy) if the organization, pipeline and any other metadata associated with the pipeline and its job are permitted to publish/upload packages to this registry.
 
 > 📘
 > Buildkite Packages registries also support OIDC policies that can consume OIDC tokens configured on third-party products and services, such as [GitHub Actions](https://github.com/features/actions), to authenticate interactions from these services.
 
-## Define OIDC policies for a registry
+## Define an OIDC policy for a registry
 
 You can specify an OIDC policy for your Buildkite registry, which defines the criteria for which OIDC tokens, from the [Buildkite Agent](/docs/agent/v3/cli-oidc) or another third-party system, will be accepted by your registry and authenticate a package publication/upload action from that system.
 
-To define OIDC policies for one or more Buildkite pipeline jobs in a registry:
+To define an OIDC policy for one or more Buildkite pipeline jobs in a registry:
 
 1. Select **Packages** in the global navigation to access the [**Registries**](https://buildkite.com/organizations/~/packages) page.
 
-1. Select the registry whose OIDC policies need defining.
+1. Select the registry whose OIDC policy needs defining.
 
 1. Select **Settings** > **OIDC Policy** to access the registry's **OIDC Policy** page.
 
@@ -40,11 +40,11 @@ To define OIDC policies for one or more Buildkite pipeline jobs in a registry:
 
 Each of these OIDC policy fields acts as a _filter_ and only authenticates and accepts OIDC tokens from Buildkite Agent pipelines and jobs whose criteria match these field values. Therefore, omitting a field makes the policy less strict.
 
-You can also specify multiple policies in this **Policy** field to allow your registry to accept jobs from other pipelines, as well as OIDC tokens from other systems.
+You can also specify multiple _rules_ in this **Policy** field to allow your registry to accept jobs from other pipelines, as well as OIDC tokens from other systems.
 
-### Example OIDC policies for a registry
+### Example OIDC policy for a registry
 
-The following example OIDC policies defined on a registry:
+The following example OIDC policy defined on a registry (with two rules):
 
 ```yaml
 - iss: https://agent.buildkite.com
@@ -68,7 +68,7 @@ Will only authenticate and accept OIDC tokens (and therefore, allow package publ
 
 ## Configure a Buildkite pipeline to authenticate to a registry
 
-Configuring a Buildkite pipeline [`command` step](/docs/pipelines/command-step) to request an OIDC token from Buildkite to interact with your Buildkite registry [configured with an OIDC policy](#define-oidc-policies-for-a-registry), is a two-part process.
+Configuring a Buildkite pipeline [`command` step](/docs/pipelines/command-step) to request an OIDC token from Buildkite to interact with your Buildkite registry [configured with an OIDC policy](#define-an-oidc-policy-for-a-registry), is a two-part process.
 
 ### Part 1: Request an OIDC token from Buildkite
 

--- a/pages/pipelines/security/oidc.md
+++ b/pages/pipelines/security/oidc.md
@@ -8,8 +8,8 @@ keywords: oidc, authentication, IAM, roles
 
 Third-party products and services, such as [AWS](https://aws.amazon.com/), [GCP](https://cloud.google.com/), [Azure](https://azure.microsoft.com/) and many others, as well as Buildkite products, such as [Packages](/docs/packages/security/oidc), can be configured with OIDC-compatible policies that only permit Buildkite Agent interactions from specific Buildkite organizations, pipelines, jobs, and agents, associated with a pipeline's job.
 
-A Buildkite OIDC token, representing a Buildkite Agent interaction (containing the relevant pipeline job metadata), can be used by these third-party services and Buildkite Packages, to allow the service to authenticate this interaction. If the interaction does not match or comply with the service's policy, the OIDC token and hence, subsequent interactions are rejected.
+A Buildkite OIDC token, representing a Buildkite Agent interaction (containing the relevant pipeline job metadata), can be used by these third-party services and Buildkite Packages, to allow the service to authenticate this interaction. If the interaction does not match or comply with the service's OIDC policy, the OIDC token and hence, subsequent interactions are rejected.
 
-The [Buildkite Agent's `oidc` command](/docs/agent/v3/cli-oidc) allows you to request an OIDC token from Buildkite for the pipeline's current job. These tokens are then exchanged on federated systems like AWS for authenticated role-based access with specific permissions to interact with your cloud environments.
+The [Buildkite Agent's `oidc` command](/docs/agent/v3/cli-oidc) allows you to request an OIDC token from Buildkite for the pipeline's current job. These tokens are then consumed by federated systems like AWS, and exchanged for authenticated role-based access with specific permissions to interact with your cloud environments.
 
 This section of the Buildkite Docs covers Buildkite's OIDC implementation with other federated systems, such as [AWS](/docs/pipelines/security/oidc/aws).

--- a/pages/pipelines/security/oidc.md
+++ b/pages/pipelines/security/oidc.md
@@ -8,7 +8,7 @@ keywords: oidc, authentication, IAM, roles
 
 Third-party products and services, such as [AWS](https://aws.amazon.com/), [GCP](https://cloud.google.com/), [Azure](https://azure.microsoft.com/) and many others, as well as Buildkite products, such as [Packages](/docs/packages/security/oidc), can be configured with OIDC-compatible policies that only permit Buildkite Agent interactions from specific Buildkite organizations, pipelines, jobs, and agents, associated with a pipeline's job.
 
-A Buildkite OIDC token, representing a Buildkite Agent interaction (containing such relevant pipeline job metadata), can be used by these third-party services and Buildkite Packages, to allow the service to authenticate this interaction. If the interaction does not match or comply with the service's policy, the OIDC token and hence, subsequent interactions are rejected.
+A Buildkite OIDC token, representing a Buildkite Agent interaction (containing the relevant pipeline job metadata), can be used by these third-party services and Buildkite Packages, to allow the service to authenticate this interaction. If the interaction does not match or comply with the service's policy, the OIDC token and hence, subsequent interactions are rejected.
 
 The [Buildkite Agent's `oidc` command](/docs/agent/v3/cli-oidc) allows you to request an OIDC token from Buildkite for the pipeline's current job. These tokens are then exchanged on federated systems like AWS for authenticated role-based access with specific permissions to interact with your cloud environments.
 

--- a/pages/pipelines/security/oidc.md
+++ b/pages/pipelines/security/oidc.md
@@ -6,9 +6,9 @@ keywords: oidc, authentication, IAM, roles
 
 <%= render_markdown partial: 'platform/buildkite_agent_oidc_token_overview' %>
 
-Third-party products and services, such as [AWS](https://aws.amazon.com/), [GCP](https://cloud.google.com/), [Azure](https://azure.microsoft.com/) and many others, as well as Buildkite products, such as [Packages](/docs/packages/security/oidc), can be configured with OIDC-compatible policies that only permit agent interactions from specific Buildkite organizations, pipelines, jobs, and agents, associated with a pipeline's job.
+Third-party products and services, such as [AWS](https://aws.amazon.com/), [GCP](https://cloud.google.com/), [Azure](https://azure.microsoft.com/) and many others, as well as Buildkite products, such as [Packages](/docs/packages/security/oidc), can be configured with OIDC-compatible policies that only permit Buildkite Agent interactions from specific Buildkite organizations, pipelines, jobs, and agents, associated with a pipeline's job.
 
-A Buildkite OIDC token, representing such an agent interaction containing this metadata, can be used by these third-party services and Buildkite Packages, to allow the service to authenticate the Buildkite interaction. If one of these interactions does not match or comply with the service's policy, the OIDC token and hence, subsequent interactions are rejected.
+A Buildkite OIDC token, representing a Buildkite Agent interaction (containing such relevant pipeline job metadata), can be used by these third-party services and Buildkite Packages, to allow the service to authenticate this interaction. If the interaction does not match or comply with the service's policy, the OIDC token and hence, subsequent interactions are rejected.
 
 The [Buildkite Agent's `oidc` command](/docs/agent/v3/cli-oidc) allows you to request an OIDC token from Buildkite for the pipeline's current job. These tokens are then exchanged on federated systems like AWS for authenticated role-based access with specific permissions to interact with your cloud environments.
 

--- a/pages/pipelines/security/oidc/aws.md
+++ b/pages/pipelines/security/oidc/aws.md
@@ -4,7 +4,7 @@ keywords: oidc, authentication, IAM, roles, AWS
 
 # OIDC with AWS
 
-The [Buildkite Agent's oidc command](/docs/agent/v3/cli-oidc) allows you to request an OpenID Connect (OIDC) token representing the current job. These tokens can be exchanged in AWS for an Identity and Access Management (IAM) role with AWS-scoped permissions.
+The [Buildkite Agent's `oidc` command](/docs/agent/v3/cli-oidc) allows you to request an [Open ID Connect (OIDC)](https://openid.net/developers/how-connect-works/) token representing the current pipeline and its job. These tokens can be consumed by AWS and exchanged for an Identity and Access Management (IAM) role with AWS-scoped permissions.
 
 This process uses the following Buildkite plugins to implement OIDC with AWS and your Buildkite pipelines:
 


### PR DESCRIPTION
Clarify the [OIDC intro for Buildkite Packages](https://buildkite.com/docs/packages/security/oidc) (preview [here](https://2874--bk-docs-preview.netlify.app/docs/packages/security/oidc)), to also make it clearer that 3rd-party systems mentioned on this page are designed to generate OIDC tokens for consumption by Buildkite Packages, and not the other way around (i.e. Buildkite Agents generating tokens).

Also, further down the page, clarifies/defines each 'entry' in a Buildkite Packages' registry's OIDC policy as a _rule_.

As part of implementing these changes, the [equivalent (overview) page for Buildkite Packages](https://buildkite.com/docs/pipelines/security/oidc) (preview [here](https://2874--bk-docs-preview.netlify.app/docs/pipelines/security/oidc)) was amended accordingly too.