### PR TITLE
Open external links in a new tab

### DIFF
--- a/app/models/page/renderers/external_link.rb
+++ b/app/models/page/renderers/external_link.rb
@@ -43,6 +43,7 @@ class Page::Renderers::ExternalLink
   def decorate_external_link_node
     unless node['class']
       node.set_attribute('class', 'external-link')
+      node.set_attribute('target', '_blank')
     end
   end
 

--- a/spec/models/page/renderer_spec.rb
+++ b/spec/models/page/renderer_spec.rb
@@ -84,13 +84,13 @@ RSpec.describe Page::Renderer do
   end
 
   describe "#decorate_external_links" do
-    it "adds `.external-link` class to external links" do
+    it "adds `.external-link` class and `_blank` target to external links" do
       md = <<~MD
         [Google](https://www.google.com)
       MD
 
       html = <<~HTML
-        <p><a href="https://www.google.com" class="external-link">Google</a></p>
+        <p><a href="https://www.google.com" class="external-link" target="_blank">Google</a></p>
       HTML
 
       expect(Page::Renderer.render(md).strip).to eql(html.strip)


### PR DESCRIPTION
We currently style external links with an arrow by adding the the class `external-link`. This change extends that behavior to also add the target `_blank` so that external links open in a new tab.

Opening external links in a new tab helps users avoid losing the context they were in with Buildkite.

## Example

See the link on to Jenkins in the first sentence:

Before: [Current page](https://buildkite.com/docs/pipelines/migrate-from-jenkins)
After: [Preview page](https://2880--bk-docs-preview.netlify.app/docs/pipelines/migrate-from-jenkins)