### PR TITLE
Updating `POST /pipelines` REST API Documentation to Include Optional `slug` Parameter

### DIFF
--- a/pages/apis/rest_api/pipelines.md
+++ b/pages/apis/rest_api/pipelines.md
@@ -379,6 +379,13 @@ Optional [request body properties](/docs/api#request-body-properties):
     </td>
   </tr>
   <tr>
+    <th><code>slug</code></th>
+    <td>
+      <p>A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If the value is `nil`, the pipeline name will be used to generate the slug.</p>
+      <p><em>Example:</em> <code>"slug": "my-custom-pipeline-slug"</code></p>
+    </td>
+  </tr>
+  <tr>
     <th><code>tags</code></th>
     <td>
       <p>An array of strings representing <a href="/docs/pipelines/tags">tags</a> to add to this pipeline. Emojis, using the <code>:emoji:</code> string syntax, are also supported.</p>
@@ -695,6 +702,13 @@ Optional [request body properties](/docs/api#request-body-properties):
     <td>
       <p>A <a href="/docs/pipelines/branch-configuration#branch-pattern-examples">branch filter pattern</a> to limit which branches intermediate build skipping applies to.</p>
       <p><em>Example:</em> <code>"!main"</code><br><em>Default:</em> <code>null</code></p>
+    </td>
+  </tr>
+  <tr>
+    <th><code>slug</code></th>
+    <td>
+      <p>A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If the value is `nil`, the pipeline name will be used to generate the slug.</p>
+      <p><em>Example:</em> <code>"slug": "my-custom-pipeline-slug"</code></p>
     </td>
   </tr>
   <tr>

--- a/pages/apis/rest_api/pipelines.md
+++ b/pages/apis/rest_api/pipelines.md
@@ -381,7 +381,7 @@ Optional [request body properties](/docs/api#request-body-properties):
   <tr>
     <th><code>slug</code></th>
     <td>
-      <p>A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If the value is <code>nil</code>, the pipeline name will be used to generate the slug.</p>
+      <p>A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If the value is <code>null</code>, the pipeline name will be used to generate the slug.</p>
       <p><em>Example:</em> <code>"slug": "my-custom-pipeline-slug"</code></p>
     </td>
   </tr>
@@ -707,8 +707,8 @@ Optional [request body properties](/docs/api#request-body-properties):
   <tr>
     <th><code>slug</code></th>
     <td>
-      <p>A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If the value is <code>nil</code>, the pipeline name will be used to generate the slug.</p>
-      <p><em>Example:</em> <code>"slug": "my-custom-pipeline-slug"</code></p>
+      <p>A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If the value is <code>null</code>, the pipeline name will be used to generate the slug.</p>
+      <p><em>Example:</em> <code>"my-custom-pipeline-slug"</code></p>
     </td>
   </tr>
   <tr>

--- a/pages/apis/rest_api/pipelines.md
+++ b/pages/apis/rest_api/pipelines.md
@@ -381,7 +381,7 @@ Optional [request body properties](/docs/api#request-body-properties):
   <tr>
     <th><code>slug</code></th>
     <td>
-      <p>A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If the value is `nil`, the pipeline name will be used to generate the slug.</p>
+      <p>A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If the value is <code>nil</code>, the pipeline name will be used to generate the slug.</p>
       <p><em>Example:</em> <code>"slug": "my-custom-pipeline-slug"</code></p>
     </td>
   </tr>
@@ -707,7 +707,7 @@ Optional [request body properties](/docs/api#request-body-properties):
   <tr>
     <th><code>slug</code></th>
     <td>
-      <p>A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If the value is `nil`, the pipeline name will be used to generate the slug.</p>
+      <p>A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If the value is <code>nil</code>, the pipeline name will be used to generate the slug.</p>
       <p><em>Example:</em> <code>"slug": "my-custom-pipeline-slug"</code></p>
     </td>
   </tr>

--- a/pages/platform/_deriving_a_pipeline_slug_from_the_pipelines_name.md
+++ b/pages/platform/_deriving_a_pipeline_slug_from_the_pipelines_name.md
@@ -1,4 +1,4 @@
-Pipeline slugs are derived from the pipeline name you provide when the pipeline is created.
+Pipeline slugs are derived from the pipeline name you provide when the pipeline is created (unless you use the optional `slug` parameter to specify a custom slug).
 
 This derivation process involves converting all space characters (including consecutive ones) in the pipeline's name to single hyphen `-` characters, and all uppercase characters to their lowercase counterparts. Therefore, pipeline names of either `Hello there friend` or `Hello    There Friend` are converted to the slug `hello-there-friend`.
 


### PR DESCRIPTION
### Description
Implementation to expose an optional slug parameter to `POST /pipelines`

This PR is to update the REST API documentation to include the optional `slug` paramenter for `docs/apis/rest-api/pipelines` for creating a YAML pipeline, and creating a visual step pipeline.

<img width="715" alt="image" src="https://github.com/user-attachments/assets/fbdfa57e-2065-4894-822c-44098664bf88">

<img width="699" alt="image" src="https://github.com/user-attachments/assets/ca46d1dc-1ae3-4a0a-a328-dfd3de82fa5d">




