### PR TITLE
Remove beta callout for GitHub merge queues

### DIFF
--- a/pages/tutorials/github_merge_queue.md
+++ b/pages/tutorials/github_merge_queue.md
@@ -4,9 +4,6 @@ keywords: docs, pipelines, tutorials, github merge queues
 
 # Using GitHub merge queues
 
-> 🚧 GitHub beta feature
-> The merge queue feature for pull requests is in public beta and subject to change.
-
 Merge queues are a feature of GitHub to improve development velocity on busy branches. They can increase the rate at which pull requests are merged into a branch while ensuring all the required branch protection checks pass. Merge queues preserve the order of pull requests to merge, remove redundant builds, and reduce flaky merges.
 
 ## Before you start
@@ -24,10 +21,10 @@ To enable a merge queue for a pipeline:
 1. In the **GitHub Settings** section, select the **Skip builds with existing commits** checkbox.
 1. If you are already using branch filters in the **Branch Limiting** section, add another filter for the following pattern:
 
-   ```text
-   gh-readonly-queue/{base_branch}/*
-   ```
+    ```text
+    gh-readonly-queue/{base_branch}/*
+    ```
 
-   Otherwise, leave the branch filter text box blank, and builds will be triggered for GitHub merge queue branches automatically.
+    Otherwise, leave the branch filter text box blank, and builds will be triggered for GitHub merge queue branches automatically.
 
 That's it! Your pipeline supports merge queues in GitHub. 🎉


### PR DESCRIPTION
Merge queues are not in beta any longer with GitHub ([docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)).

I've also fixed up the spacing for the indentation in the steps.