### PR TITLE
Add caveat for --priority flag

### DIFF
--- a/pages/agent/v3/prioritization.md
+++ b/pages/agent/v3/prioritization.md
@@ -26,7 +26,7 @@ env BUILDKITE_AGENT_PRIORITY=9 buildkite-agent start
 ```
 
 > 📘
-> Using the `--priority` flag requires agent 3.65.0 or higher.
+> Using the `--priority` flag requires agent v3.65.0 or later.
 
 ## Load balancing
 

--- a/pages/agent/v3/prioritization.md
+++ b/pages/agent/v3/prioritization.md
@@ -25,6 +25,9 @@ or with the `BUILDKITE_AGENT_PRIORITY` an environment variable:
 env BUILDKITE_AGENT_PRIORITY=9 buildkite-agent start
 ```
 
+> 📘
+> Using the `--priority` flag requires agent 3.65.0 or higher.
+
 ## Load balancing
 
 You can use the Agent priority value to load balance jobs across machines running multiple Agents.


### PR DESCRIPTION
In order to use the `--priority` flag on `annotate` in the CLI, an agent version >= 3.65.0 is needed
