### PR TITLE
Use correct URL for annotation link

### DIFF
--- a/.buildkite/update_graphql_docs
+++ b/.buildkite/update_graphql_docs
@@ -42,4 +42,4 @@ git push -u origin $BRANCH
 
 echo "+++ Create pull request"
 create_pull_request "Update GraphQL docs" "This is an automated PR based on the current GraphQL schema" \
-  | jq ".url" | buildkite-agent annotate --style "success"
+  | jq ".html_url" | buildkite-agent annotate --style "success"


### PR DESCRIPTION
I noticed https://buildkite.com/buildkite/docs-graphql/builds/605 was using the wrong link. This change should fix it. 