### PR TITLE
remove fragment from when we didn't offer custom images

### DIFF
--- a/pages/pipelines/hosted_agents/linux.md
+++ b/pages/pipelines/hosted_agents/linux.md
@@ -22,10 +22,6 @@ Buildkite offers a selection of instance sizes, allowing you to tailor your host
     </tbody>
 </table>
 
-## Image configuration
-
-To configure your Linux instance you can use the [Docker Compose](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin) plugin.
-
 ## Cache volumes
 
 _Cache volumes_ are external volumes attached to hosted agent instances. These volumes are attached on a best-effort basis depending on their locality, expiration and current usage, and therefore, should not be relied upon as durable data storage.


### PR DESCRIPTION
maybe this was just a leftover from a prior cleanup? it doesn't seem to fit in the doc anymore