### PR TITLE
Move Job API docs to promoted experiments section

### DIFF
--- a/pages/agent/v3.md
+++ b/pages/agent/v3.md
@@ -101,25 +101,6 @@ After repository checkout, resolve `BUILDKITE_COMMIT` to a commit hash. This mak
 > 🛠 Experimental feature
 > To use it, set <code>experiment="resolve-commit-after-checkout"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.
 
-### Job API
-
-Exposes a local API to introspect and mutate the state of a running job through environment variables. This lets you write scripts, hooks, and plugins in languages other than Bash, using them to interact with the agent.
-
-The API uses a Unix Domain Socket, whose path is exposed to running jobs with the `BUILDKITE_AGENT_JOB_API_SOCKET` environment variable. Calls are authenticated using the Bearer HTTP Authorization scheme made available through a token in the `BUILDKITE_AGENT_JOB_API_TOKEN` environment variable.
-
-The API provides the following endpoints:
-
-- `GET /api/current-job/v0/env` - Returns a JSON object of all environment variables for the current job.
-- `PATCH /api/current-job/v0/env` - Accepts a JSON object of environment variables to set for the current job.
-- `DELETE /api/current-job/v0/env` - Accepts a JSON array of environment variable names to unset for the current job.
-
-See [the agent repo](https://github.com/buildkite/agent/blob/main/jobapi/payloads.go) for the full API request and response definitions.
-
-The job API is unavailable on agents running versions of Windows before build 17063, as this was when Windows added Unix Domain Socket support. If you enable this experiment on an unsupported Windows agent, the agent outputs a warning and the API is unavailable.
-
-> 🛠 Experimental feature
-> To use the job API, set <code>experiment="job-api"</code> in your <a href="/docs/agent/v3/configuration#experiment"> agent configuration</a>.
-
 ### Agent API
 
 Like the Job API experiment, this exposes a (separate) local API for interacting with the agent process.
@@ -170,6 +151,24 @@ The Buildkite agent can redact strings that match the value of environment varia
 Promoted in [v3.31.0](https://github.com/buildkite/agent/releases/tag/v3.31.0).
 
 See [redacted-vars](/docs/pipelines/managing-log-output#redacted-environment-variables) for more information.
+
+### Job API
+
+Exposes a local API to introspect and mutate the state of a running job through environment variables. This lets you write scripts, hooks, and plugins in languages other than Bash, using them to interact with the agent.
+
+Promoted in [v3.64.0](https://github.com/buildkite/agent/releases/tag/v3.64.0).
+
+The API uses a Unix Domain Socket, whose path is exposed to running jobs with the `BUILDKITE_AGENT_JOB_API_SOCKET` environment variable. Calls are authenticated using the Bearer HTTP Authorization scheme made available through a token in the `BUILDKITE_AGENT_JOB_API_TOKEN` environment variable.
+
+The API provides the following endpoints:
+
+- `GET /api/current-job/v0/env` - Returns a JSON object of all environment variables for the current job.
+- `PATCH /api/current-job/v0/env` - Accepts a JSON object of environment variables to set for the current job.
+- `DELETE /api/current-job/v0/env` - Accepts a JSON array of environment variable names to unset for the current job.
+
+See [the agent repo](https://github.com/buildkite/agent/blob/main/jobapi/payloads.go) for the full API request and response definitions.
+
+The job API is unavailable on agents running versions of Windows before build 17063, as this was when Windows added Unix Domain Socket support. If you enable this experiment on an unsupported Windows agent, the agent outputs a warning and the API is unavailable.
 
 ## Customizing with hooks
 

--- a/pages/agent/v3/hooks.md
+++ b/pages/agent/v3/hooks.md
@@ -102,7 +102,7 @@ Polyglot hook usage comes with the following caveats:
 * Interpreted hooks are not supported on Windows.
 * Hooks must not have a file extension–except on Windows, where binary hooks must have the `.exe` extension.
 * For interpreted hooks, the specified interpreter must already be installed on the agent machine. The agent won't install the interpreter or any package dependencies for you.
-* Unlike shell hooks, environment variable changes are not automatically captured from polyglot hooks. If you want to modify the job's environment, you'll have to use the [Job API](/docs/agent/v3#experimental-features-job-api).
+* Unlike shell hooks, environment variable changes are not automatically captured from polyglot hooks. If you want to modify the job's environment, you'll have to use the [Job API](/docs/agent/v3#promoted-experiments-job-api).
 
 ## Agent lifecycle hooks
 


### PR DESCRIPTION
This was promoted a while ago but not updated here. This moves the section to the promoted section in the docs
