### PR TITLE
fix buildkite-test-collector npm install command

### DIFF
--- a/pages/test_analytics/javascript_collectors.md
+++ b/pages/test_analytics/javascript_collectors.md
@@ -31,7 +31,7 @@ To add the test collector package:
     For npm, run:
 
     ```shell
-    npm install --dev buildkite-test-collector
+    npm install --save-dev buildkite-test-collector
     ```
 
     For yarn, run:


### PR DESCRIPTION
Installing `buildkite-test-collector` with the `--dev` command produces a warning.

This command likely is intended to be `--save-dev` (or maybe truly `--include=dev`) instead.

<img width="536" alt="image" src="https://github.com/user-attachments/assets/ad625aa9-0e96-43fb-9130-05c999624924">
