### PR TITLE
Updating PATCH /pipelines REST API Documentation to Include Optional `slug` Parameter 

### DIFF
--- a/pages/apis/rest_api/pipelines.md
+++ b/pages/apis/rest_api/pipelines.md
@@ -876,7 +876,10 @@ Optional [request body properties](/docs/api#request-body-properties):
   </tr>
   <tr>
     <th><code>name</code></th>
-    <td>The name of the pipeline. If you provide a new name without a <code>slug</code> parameter, the slug will be automatically updated to match the new name.<p class="Docs__api-param-eg"><em>Example:</em> <code>"New Pipeline"</code></p></td>
+    <td>
+      <p>The name of the pipeline. If you provide a new name without a <code>slug</code> parameter, the slug will be automatically updated to match the new name.</p>
+      <p class="Docs__api-param-eg"><em>Example:</em> <code>"New Pipeline"</code></p>
+    </td>
   </tr>
   <tr>
     <th><code>pipeline_template_uuid</code></th>
@@ -900,7 +903,9 @@ Optional [request body properties](/docs/api#request-body-properties):
   </tr>
   <tr>
     <th><code>slug</code></th>
-    <td>A custom identifier for the pipeline. This slug will be used as the pipeline's URL path. If not provided when the pipeline name is updated, the slug will be automatically generated from the new pipeline name. If the pipeline name is not updated, the existing slug will remain unchanged.
+    <td>
+      <p>A custom identifier for the pipeline. This slug will be used as the pipeline's URL path. If not provided when the pipeline name is updated, the slug will be automatically generated from the new pipeline name. If the pipeline name is not updated, the existing slug will remain unchanged.<br>
+      The slug may only contain alphanumeric characters or dashes, and cannot begin with a dash.</p>
       <p><em>Example:</em> <code>"my-custom-pipeline-slug"</code></p>
     </td>
   </tr>

--- a/pages/apis/rest_api/pipelines.md
+++ b/pages/apis/rest_api/pipelines.md
@@ -904,8 +904,8 @@ Optional [request body properties](/docs/api#request-body-properties):
   <tr>
     <th><code>slug</code></th>
     <td>
-      <p>A custom identifier for the pipeline. This slug will be used as the pipeline's URL path. If not provided when the pipeline name is updated, the slug will be automatically generated from the new pipeline name. If the pipeline name is not updated, the existing slug will remain unchanged.<br>
-      The slug may only contain alphanumeric characters or dashes, and cannot begin with a dash.</p>
+      <p>A custom identifier for the pipeline. This slug will be used as the pipeline's URL path. It can only contain alphanumeric characters or dashes and cannot begin with a dash.<br>
+      The slug updates whenever the pipeline name changes. If you don't provide a slug when you update the pipeline name, the slug will be automatically generated from the new pipeline name.</p>
       <p><em>Example:</em> <code>"my-custom-pipeline-slug"</code></p>
     </td>
   </tr>

--- a/pages/apis/rest_api/pipelines.md
+++ b/pages/apis/rest_api/pipelines.md
@@ -876,7 +876,7 @@ Optional [request body properties](/docs/api#request-body-properties):
   </tr>
   <tr>
     <th><code>name</code></th>
-    <td>The name of the pipeline.<p class="Docs__api-param-eg"><em>Example:</em> <code>"New Pipeline"</code></p></td>
+    <td>The name of the pipeline. If you provide a new name without a <code>slug</code> parameter, the slug will be automatically updated to match the new name.<p class="Docs__api-param-eg"><em>Example:</em> <code>"New Pipeline"</code></p></td>
   </tr>
   <tr>
     <th><code>pipeline_template_uuid</code></th>
@@ -897,6 +897,12 @@ Optional [request body properties](/docs/api#request-body-properties):
   <tr>
     <th><code>skip_queued_branch_builds_filter</code></th>
     <td>A <a href="/docs/pipelines/branch-configuration#branch-pattern-examples">branch filter pattern</a> to limit which branches intermediate build skipping applies to. <p class="Docs__api-param-eg"><em>Example:</em> <code>"!main"</code><br><em>Default:</em> <code>null</code></p></td>
+  </tr>
+  <tr>
+    <th><code>slug</code></th>
+    <td>A custom identifier for the pipeline. This slug will be used as the pipeline's URL path. If not provided when the pipeline name is updated, the slug will be automatically generated from the new pipeline name. If the pipeline name is not updated, the existing slug will remain unchanged.
+      <p><em>Example:</em> <code>"slug": "my-custom-pipeline-slug"</code></p>
+    </td>
   </tr>
   <tr>
     <th><code>tags</code></th>

--- a/pages/apis/rest_api/pipelines.md
+++ b/pages/apis/rest_api/pipelines.md
@@ -382,7 +382,7 @@ Optional [request body properties](/docs/api#request-body-properties):
     <th><code>slug</code></th>
     <td>
       <p>A custom identifier for the pipeline. If provided, this slug will be used as the pipeline's URL path instead of automatically converting the pipeline name. If the value is <code>null</code>, the pipeline name will be used to generate the slug.</p>
-      <p><em>Example:</em> <code>"slug": "my-custom-pipeline-slug"</code></p>
+      <p><em>Example:</em> <code>"my-custom-pipeline-slug"</code></p>
     </td>
   </tr>
   <tr>
@@ -901,7 +901,7 @@ Optional [request body properties](/docs/api#request-body-properties):
   <tr>
     <th><code>slug</code></th>
     <td>A custom identifier for the pipeline. This slug will be used as the pipeline's URL path. If not provided when the pipeline name is updated, the slug will be automatically generated from the new pipeline name. If the pipeline name is not updated, the existing slug will remain unchanged.
-      <p><em>Example:</em> <code>"slug": "my-custom-pipeline-slug"</code></p>
+      <p><em>Example:</em> <code>"my-custom-pipeline-slug"</code></p>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
### Description
Implementation to expose an optional slug parameter to `PATCH /pipelines`

This PR is to update the REST API documentation to include the optional `slug` paramenter for `docs/apis/rest-api/pipelines` for updating properties of an existing pipeline. 

A user can now update the pipeline `slug` name using `PATCH /pipelines` when they provide a `slug` parameter. 

It is important to note that if a user updates the `name` of a pipeline _without_ providing a `slug` parameter, a new `slug` will be generated for that pipeline that is derived from the updated name. If a user updates the `name` and forgot to add the `slug` parameter (because they wanted to preserve their pipeline `slug`) they can update the `slug` name in isolation.


Under "Update a pipeline" in the "Optional request body properties" table
![image](https://github.com/user-attachments/assets/f20c7f7e-9a26-4827-a00a-bf8448731b97)

![image](https://github.com/user-attachments/assets/eff18a51-8f0c-4279-8c0d-372a89f3d8f9)





