### PR TITLE
Move Content Security Policy reports to report-uri.com [PLT-2978]

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -69,7 +69,7 @@ Rails.application.config.content_security_policy do |policy|
   )
 
   # Specify URI for violation reports
-  policy.report_uri "/_csp-violation-reports"
+  policy.report_uri "https://buildkite.report-uri.com/r/d/csp/reportOnly"
 end
 
 # We use nonce for inline scripts


### PR DESCRIPTION
We've been sending CSP reports to a route on our own site for years, but never looking at them or taking action.

We're trialing report-uri.com as a cheap hosted option for collecting these reports and (hopefully) discovering actionable improvements we can make to our Javascript security.

The docs CSP headers are in report only mode and this doesn't change that. We should get data, but I expect no customer visible behaviour change.