### PR TITLE
This small change ensures all dependencies used are installed

### DIFF
--- a/pages/agent/v2/debian.md
+++ b/pages/agent/v2/debian.md
@@ -19,7 +19,7 @@ sudo apt-get update
 Next, ensure you have the `apt-transport-https` package installed for the HTTPS package repository, and the `dirmngr` package installed for adding the signing key:
 
 ```shell
-sudo apt-get install -y apt-transport-https dirmngr curl gpg
+sudo apt-get install -y apt-transport-https dirmngr
 ```
 
 Download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):

--- a/pages/agent/v2/debian.md
+++ b/pages/agent/v2/debian.md
@@ -19,7 +19,7 @@ sudo apt-get update
 Next, ensure you have the `apt-transport-https` package installed for the HTTPS package repository, and the `dirmngr` package installed for adding the signing key:
 
 ```shell
-sudo apt-get install -y apt-transport-https dirmngr
+sudo apt-get install -y apt-transport-https dirmngr curl gpg
 ```
 
 Download the Buildkite PGP key to a directory that is only writable by `root` (create the directory before running the following command if it doesn't already exist):

--- a/pages/agent/v3/debian.md
+++ b/pages/agent/v3/debian.md
@@ -17,7 +17,7 @@ sudo apt-get update
 Next, ensure you have the `apt-transport-https` package installed for the HTTPS package repository, and the `dirmngr` package installed for adding the signing key:
 
 ```shell
-sudo apt-get install -y apt-transport-https dirmngr
+sudo apt-get install -y apt-transport-https dirmngr curl gpg
 ```
 
 Now you can add our signed apt repository. The default version of the agent is `stable`, but you can get the beta version by using `unstable` instead of `stable` in the following command, or the agent built from the `main` branch of the repository by using `experimental` instead of `stable`.


### PR DESCRIPTION
For context if you pull down the docker image for debian curl and gpg are not installed by default as it is a "slim" image, so subsequent commands fail.

Just a small tweak to help customers.