### PR TITLE
[PKG-6378] Documentation for Packages 'Files' (generic)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,40 +1,4 @@
 steps:
-  - label: ":rspec: RSpec"
-    depends_on: linting
-    command: bundle exec rspec
-    artifact_paths: "log/rspec-*.xml"
-    key: "rspec"
-    env:
-      RAILS_ENV: test
-    agents:
-      queue: hosted
-    plugins:
-      - docker-compose#v3.9.0:
-          run: app
-          dependencies: false
-          env:
-            - BUILDKITE_ANALYTICS_TOKEN
-            - BUILDKITE_BRANCH
-            - BUILDKITE_BUILD_ID
-            - BUILDKITE_BUILD_NUMBER
-            - BUILDKITE_BUILD_URL
-            - BUILDKITE_COMMIT
-            - BUILDKITE_JOB_ID
-            - BUILDKITE_MESSAGE
-            - CI
-            - RAILS_ENV
-
-  - label: ":docker: Build image"
-    depends_on: "linting"
-    key: "assets"
-    env:
-      RAILS_ENV: production
-    agents:
-      queue: hosted
-    plugins:
-      - docker-compose#v3.9.0:
-          build: app
-
   - label: ":spider: muffet"
     # We need to wait until rails has started before running muffet as otherwise it will error out
     # and the test will appear to have failed without having run. The time to wait is hard to
@@ -64,21 +28,6 @@ steps:
           upload-container-logs: always
           env:
             - RAILS_ENV
-
-  - label: ":junit: Test Summary"
-    depends_on: "rspec"
-    allow_dependency_failure: true
-    agents:
-      queue: hosted
-    plugins:
-      - bugcrowd/test-summary#v1.11.0:
-          inputs:
-            - label: ":rspec: RSpec"
-              artifact_path: "log/rspec*"
-              type: junit
-          formatter:
-            type: details
-          context: test-summary
 
   - label: ":graphql: Check generated code is up to date"
     command: bundle exec rake graphql:generate
@@ -175,3 +124,54 @@ steps:
               account-ids: public.ecr.aws
           - docker#v3.7.0:
               image: "public.ecr.aws/docker/library/node:lts-alpine3.14"
+
+  - label: ":rspec: RSpec"
+    depends_on: linting
+    command: bundle exec rspec
+    artifact_paths: "log/rspec-*.xml"
+    key: "rspec"
+    env:
+      RAILS_ENV: test
+    agents:
+      queue: hosted
+    plugins:
+      - docker-compose#v3.9.0:
+          run: app
+          dependencies: false
+          env:
+            - BUILDKITE_ANALYTICS_TOKEN
+            - BUILDKITE_BRANCH
+            - BUILDKITE_BUILD_ID
+            - BUILDKITE_BUILD_NUMBER
+            - BUILDKITE_BUILD_URL
+            - BUILDKITE_COMMIT
+            - BUILDKITE_JOB_ID
+            - BUILDKITE_MESSAGE
+            - CI
+            - RAILS_ENV
+
+  - label: ":docker: Build image"
+    depends_on: "linting"
+    key: "assets"
+    env:
+      RAILS_ENV: production
+    agents:
+      queue: hosted
+    plugins:
+      - docker-compose#v3.9.0:
+          build: app
+
+  - label: ":junit: Test Summary"
+    depends_on: "rspec"
+    allow_dependency_failure: true
+    agents:
+      queue: hosted
+    plugins:
+      - bugcrowd/test-summary#v1.11.0:
+          inputs:
+            - label: ":rspec: RSpec"
+              artifact_path: "log/rspec*"
+              type: junit
+          formatter:
+            type: details
+          context: test-summary

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -485,6 +485,8 @@
           path: "packages/container"
         - name: "Debian"
           path: "packages/debian"
+        - name: "Files"
+          path: "packages/files"
         - name: "Java"
           start_expanded: true
           children:

--- a/pages/packages.md
+++ b/pages/packages.md
@@ -34,6 +34,7 @@ If you're familiar with the basics, explore how to use registries for each of Bu
   <%= button ":redhat: Red Hat (RPM)", "/docs/packages/red-hat" %>
   <%= button ":ruby: Ruby (RubyGems)", "/docs/packages/ruby" %>
   <%= button ":terraform: Terraform (modules)", "/docs/packages/terraform" %>
+  <%= button ":package: Files (generic)", "/docs/packages/files" %>
 </div>
 
 <!-- vale on -->

--- a/pages/packages/_file_details_page_sections.md
+++ b/pages/packages/_file_details_page_sections.md
@@ -1,6 +1,6 @@
 The file details page provides the following information in the following sections:
 
-- **Installation** (tab): the [installation instructions](#access-a-files-details-installing-a-file).
+- **Installation** (tab): the [installation instructions](#access-a-files-details-downloading-a-file).
 - **Details** (tab): a list of checksum values for this file—MD5, SHA1, SHA256, and SHA512.
 - **About this version**: a brief (metadata) description about the file.
 - **Details**: details about:

--- a/pages/packages/_file_details_page_sections.md
+++ b/pages/packages/_file_details_page_sections.md
@@ -1,0 +1,12 @@
+The file details page provides the following information in the following sections:
+
+- **Installation** (tab): the [installation instructions](#access-a-packages-details-installing-a-package).
+- **Details** (tab): a list of checksum values for this file—MD5, SHA1, SHA256, and SHA512.
+- **About this version**: a brief (metadata) description about the file.
+- **Details**: details about:
+    * the name of the file 
+    * the registry the file is located in.
+    * the file's visibility (based on its registry's visibility)—whether the file is **Private** and requires authentication to access, or is publicly accessible.
+- **Pushed**: the date when the last file was uploaded to the registry.
+- **File size**: the storage size (in bytes) of this package.
+- **Downloads**: the number of times this package has been downloaded.

--- a/pages/packages/_file_details_page_sections.md
+++ b/pages/packages/_file_details_page_sections.md
@@ -1,10 +1,10 @@
 The file details page provides the following information in the following sections:
 
-- **Installation** (tab): the [installation instructions](#access-a-packages-details-installing-a-package).
+- **Installation** (tab): the [installation instructions](#access-a-files-details-installing-a-file).
 - **Details** (tab): a list of checksum values for this file—MD5, SHA1, SHA256, and SHA512.
 - **About this version**: a brief (metadata) description about the file.
 - **Details**: details about:
-    * the name of the file 
+    * the name of the file
     * the registry the file is located in.
     * the file's visibility (based on its registry's visibility)—whether the file is **Private** and requires authentication to access, or is publicly accessible.
 - **Pushed**: the date when the last file was uploaded to the registry.

--- a/pages/packages/_registry_slug.md
+++ b/pages/packages/_registry_slug.md
@@ -1,0 +1,1 @@
+- `{registry.slug}` is the slug of your registry, which is the [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case) version of your registry name, and can be obtained after accessing **Packages** in the global navigation > your registry from the **Registries** page.

--- a/pages/packages/alpine.md
+++ b/pages/packages/alpine.md
@@ -68,7 +68,7 @@ An Alpine (apk) package can be downloaded from the package's details page. To do
 An Alpine package can be installed using code snippet details provided on the package's details page. To do this:
 
 1. [Access the package's details](#access-a-packages-details).
-1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. Ensure the **Installation** > **Instructions** section is displayed.
 1. For each required command in the relevant code snippets, copy the relevant code snippet, paste it into your terminal, and run it.
 
 The following set of code snippets are descriptions of what each code snippet does and where applicable, its format:
@@ -97,7 +97,7 @@ wget -O /etc/apk/keys/{org.uuid}_{registry.uuid}.rsa.pub "https://buildkite:{reg
 
 where:
 
-- `{org.uuid}` is the UUID of your Buildkite organization. This value can be obtained from this Alpine package **Installation instructions** page section. Alternatively, you can also obtain this value:
+- `{org.uuid}` is the UUID of your Buildkite organization. This value can be obtained from this Alpine package **Instructions** page section. Alternatively, you can also obtain this value:
     * From your organization's **Pipeline Settings** page. To do this:
         1. Select **Settings** in the global navigation to access the [**Organization Settings**](https://buildkite.com/organizations/~/settings) page.
         1. Select **Pipelines** > **Settings** to access the [**Pipeline Settings**](https://buildkite.com/organizations/~/pipeline-settings) page.
@@ -121,7 +121,7 @@ where:
         }
         ```
 
-- `{registry.uuid}` is the UUID of your Alpine registry. Again, this value can be obtained from this Alpine package **Installation instructions** page section. Alternatively, you can also obtain this value:
+- `{registry.uuid}` is the UUID of your Alpine registry. Again, this value can be obtained from this Alpine package **Instructions** page section. Alternatively, you can also obtain this value:
     * From your registry's **Settings** page. To do this:
         1. Select **Packages** in the global navigation to access the [**Registries**](https://buildkite.com/organizations/~/packages) page.
         1. Select your Alpine registry on this page.

--- a/pages/packages/container.md
+++ b/pages/packages/container.md
@@ -93,7 +93,7 @@ A container image can be downloaded from the image's details page. To do this:
 A container image can be obtained using code snippet details provided on the image's details page. To do this:
 
 1. [Access the image's details](#access-an-images-details).
-1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. Ensure the **Installation** > **Instructions** section is displayed.
 1. For each required command in the relevant code snippets, copy the relevant code snippet, paste it into your terminal, and run it.
 
 The following set of code snippets are descriptions of what each code snippet does and where applicable, its format:

--- a/pages/packages/debian.md
+++ b/pages/packages/debian.md
@@ -68,7 +68,7 @@ A Debian (deb) package can be downloaded from the package's details page. To do 
 A Debian package can be installed using code snippet details provided on the package's details page. To do this:
 
 1. [Access the package's details](#access-a-packages-details).
-1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. Ensure the **Installation** > **Instructions** section is displayed.
 1. For each required command set in the relevant code snippets, copy the relevant code snippet, paste it into your terminal, and run it.
 
 The following set of code snippets are descriptions of what each code snippet does and where applicable, its format:

--- a/pages/packages/files.md
+++ b/pages/packages/files.md
@@ -1,0 +1,71 @@
+
+# Files
+
+Buildkite Packages provides registry support for generic files to cover some cases where native package management isn't required.
+
+Once your Files registry has been [created](/docs/packages/manage-registries#create-a-registry), you can publish/upload files (of any type and extension) to this registry via the relevant `curl` command presented on your registry details page.
+
+To view and copy this `curl` command:
+
+1. Select **Packages** in the global navigation to access the **Registries** page.
+1. Select your registry on this page.
+1. Select **Publish a File** and in the resulting dialog, use the copy icon at the top-right of the code box to copy this `curl` command and run it to publish a file to your registry.
+
+This command provides:
+
+- The specific URL to publish a file to your specific registry in Buildkite.
+- The API access token required to publish files to your registry.
+- The file to be published.
+
+## Publish a file
+
+The following `curl` command (which you'll need to modify as required before submitting) describes the process above to publish a file to your registry:
+
+```bash
+curl -X POST https://api.buildkite.com/v2/packages/organizations/{org.slug}/registries/{registry.slug}/packages \
+  -H "Authorization: Bearer $REGISTRY_WRITE_TOKEN" \
+  -F "file=@<path_to_file>"
+```
+
+where:
+
+<%= render_markdown partial: 'packages/org_slug' %>
+
+<%= render_markdown partial: 'packages/registry_slug' %>
+
+- `$REGISTRY_WRITE_TOKEN` is your [API access token](https://buildkite.com/user/api-access-tokens) used to publish/upload files to your registry. Ensure this access token has the **Write Packages** REST API scope, which allows this token to publish files to any registry your user account has access to within your Buildkite organization.
+
+<%= render_markdown partial: 'packages/path_to_file' %>
+
+For example, to upload the file `my-custom-app.ipa` from the current directory to the **My files** registry in the **My organization** Buildkite organization, run the `curl` command:
+
+```bash
+curl -X POST https://api.buildkite.com/v2/packages/organizations/my-organization/registries/my-files/packages \
+  -H "Authorization: Bearer $REPLACE_WITH_YOUR_REGISTRY_WRITE_TOKEN" \
+  -F "file=@my-custom-app.ipa"
+```
+
+## Access a file's details
+
+The file details can be accessed from this registry using the **Packages** section of your registry page.
+
+To access your file details page:
+
+1. Select **Packages** in the global navigation to access the **Registries** page.
+1. Select your registry on this page.
+1. On your registry page, select the file to display its details page.
+
+<%= render_markdown partial: 'packages/file_details_page_sections' %>
+
+### Downloading a file
+
+The file can be downloaded from the file details page. To do this:
+
+1. [Access the file's details](#access-a-files-details).
+1. Select **Download**.
+
+Or; a file can be installed via the command line using code snippet details provided on the file details page. To do this:
+
+1. [Access the file's details](#access-a-files-details).
+1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. For each required command in the relevant code snippets, copy the relevant code snippet, paste it into your terminal, and run it.

--- a/pages/packages/files.md
+++ b/pages/packages/files.md
@@ -67,5 +67,5 @@ The file can be downloaded from the file details page. To do this:
 Or; a file can be installed via the command line using code snippet details provided on the file details page. To do this:
 
 1. [Access the file's details](#access-a-files-details).
-1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. Ensure the **Installation** > **Instructions** section is displayed.
 1. For each required command in the relevant code snippets, copy the relevant code snippet, paste it into your terminal, and run it.

--- a/pages/packages/getting_started.md
+++ b/pages/packages/getting_started.md
@@ -107,7 +107,7 @@ To confirm that your Node.js package was successfully published to your Buildkit
     The package name (for example, **nodejs.example-package-1.0.1.tgz**) should appear under **Packages**.
 
 1. Click the package name to access its details, and note the following:
-    * **Installation instructions**: this section of the **Installation** tab provides command line instructions for installing the package you just published.
+    * **Instructions**: this section of the **Installation** tab provides command line instructions for installing the package you just published.
     * **Details** tab: provides various checksum values for this published package.
     * **About this version**: obtained from the `description` field value of the `package.json` file.
     * **Details**, which lists the following (where any field values are also obtained from the `package.json` file):

--- a/pages/packages/gradle.md
+++ b/pages/packages/gradle.md
@@ -99,7 +99,7 @@ A Java package can be downloaded from the package's details page. To do this:
 A Java package can be installed using code snippet details provided on the package's details page. To do this:
 
 1. [Access the package's details](#access-a-packages-details).
-1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. Ensure the **Installation** > **Instructions** section is displayed.
 1. Copy the code snippet, paste this into the `build.gradle` Gradle file, and run `gradle install` on this modified script file to install this package.
 
 This code snippet is based on this format:

--- a/pages/packages/javascript.md
+++ b/pages/packages/javascript.md
@@ -76,7 +76,7 @@ A JavaScript package can be downloaded from the package's details page. To do th
 A JavaScript package can be installed using code snippet details provided on the package's details page. To do this:
 
 1. [Access the package's details](#access-a-packages-details).
-1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. Ensure the **Installation** > **Instructions** section is displayed.
 1. If your registry is _private_ and you haven't already performed this `.npmrc` configuration step, copy the `npm set` command from the [**Registry Configuration**](#registry-configuration) section, paste it into your terminal, and modify as required before running to update your `~/.npmrc` file.
 1. Copy the `npm install` command from the [**Package Installation**](#package-installation) section, paste it into your terminal, and modify as required before running it.
 

--- a/pages/packages/javascript.md
+++ b/pages/packages/javascript.md
@@ -8,7 +8,7 @@ To view and copy the required command/code snippet for your `~/.npmrc` and `pack
 
 1. Select **Packages** in the global navigation to access the **Registries** page.
 1. Select your JavaScript registry on this page.
-1. Select **Publish a Nodejs Package** and in the resulting dialog, use the copy icon at the top-right of the relevant code box to copy its snippet and paste it into your command line tool or the appropriate file.
+1. Select **Publish a JavaScript Package** and in the resulting dialog, use the copy icon at the top-right of the relevant code box to copy its snippet and paste it into your command line tool or the appropriate file.
 
 These file configurations contain the following:
 

--- a/pages/packages/manage_registries.md
+++ b/pages/packages/manage_registries.md
@@ -28,6 +28,7 @@ Once a [registry is created](#create-a-registry), packages can then be uploaded 
 - [Alpine (apk)](/docs/packages/alpine)
 - [Container (Docker)](/docs/packages/container) images
 - [Debian/Ubuntu (deb)](/docs/packages/debian)
+- [Files (generic)](/docs/packages/files)
 - Java ([Maven](/docs/packages/maven) or [Gradle leveraging the Maven Publish Plugin](/docs/packages/gradle))
 - [JavaScript (npm)](/docs/packages/javascript)
 - [Python (PyPI)](/docs/packages/python)

--- a/pages/packages/maven.md
+++ b/pages/packages/maven.md
@@ -95,7 +95,7 @@ A Java package can be downloaded from the package's details page. To do this:
 A Java package can be installed using code snippet details provided on the package's details page. To do this:
 
 1. [Access the package's details](#access-a-packages-details).
-1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. Ensure the **Installation** > **Instructions** section is displayed.
 1. Copy each code snippet, and paste them into their respective `~/.m2/settings.xml` and `pom.xml` files (under the `project` XML tag), and run `mvn install` on this modified `pom.xml` to install this package.
 
     **Note:** The `~/.m2/settings.xml` configuration:

--- a/pages/packages/permissions.md
+++ b/pages/packages/permissions.md
@@ -36,7 +36,7 @@ To do this:
 
 1. In the **Packages** section, select **Enable** to open the **Enable Packages** page.
 
-1. Select the **Enable Buildkite Packages (Beta)** button, then **Enable Buildkite Packages** in the **Ready to enable Buildkite Packages** confirmation dialog.
+1. Select the **Enable Buildkite Packages** button, then **Enable Buildkite Packages** in the **Ready to enable Buildkite Packages** confirmation dialog.
 
 > 📘
 > Once Buildkite Packages is enabled, the **Enable** link on the **Organization Settings** page changes to **Enabled** and Buildkite Packages can only be disabled by contacting [support](https://buildkite.com/support).

--- a/pages/packages/python.md
+++ b/pages/packages/python.md
@@ -68,7 +68,7 @@ A Python package can be downloaded from the package's details page. To do this:
 A Python package can be installed using code snippet details provided on the package's details page. To do this:
 
 1. [Access the package's details](#access-a-packages-details).
-1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. Ensure the **Installation** > **Instructions** section is displayed.
 1. Copy the relevant code snippet from the [**Registry Configuration**](#registry-configuration) section and paste it into either the package installer for Python (pip) configuration (`pip.conf`) file or end of the virtualenv `requirements.txt` file.
 1. Run the installation command from the [**Package Installation**](#package-installation) section.
 

--- a/pages/packages/red_hat.md
+++ b/pages/packages/red_hat.md
@@ -8,7 +8,7 @@ To view and copy this `curl` command:
 
 1. Select **Packages** in the global navigation to access the **Registries** page.
 1. Select your Red Hat registry on this page.
-1. Select **Publish a RPM Package** and in the resulting dialog, use the copy icon at the top-right of the code box to copy this `curl` command and run it to publish a package to your Red Hat registry.
+1. Select **Publish an RPM Package** and in the resulting dialog, use the copy icon at the top-right of the code box to copy this `curl` command and run it to publish a package to your Red Hat registry.
 
 This command provides:
 

--- a/pages/packages/red_hat.md
+++ b/pages/packages/red_hat.md
@@ -68,7 +68,7 @@ A Red Hat (RPM) package can be downloaded from the package's details page. To do
 A Red Hat package can be installed using code snippet details provided on the package's details page. To do this:
 
 1. [Access the package's details](#access-a-packages-details).
-1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. Ensure the **Installation** > **Instructions** section is displayed.
 1. For each required command in the relevant code snippets, copy the relevant code snippet, paste it into your terminal, and run it.
 
 The following set of code snippets are descriptions of what each code snippet does and where applicable, its format:

--- a/pages/packages/ruby.md
+++ b/pages/packages/ruby.md
@@ -111,7 +111,7 @@ A Ruby package can be installed using code snippet details provided on the packa
 To install a package:
 
 1. [Access the package's details](#access-a-packages-details).
-1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. Ensure the **Installation** > **Instructions** section is displayed.
 1. Copy the command in the code snippet, paste it into your terminal, and run it.
 
 This code snippet is based on this format:

--- a/pages/packages/terraform.md
+++ b/pages/packages/terraform.md
@@ -91,7 +91,7 @@ A Terraform module can be installed using code snippet details provided on the m
 To install a module:
 
 1. [Access the module's details](#access-a-modules-details).
-1. Ensure the **Installation** > **Installation instructions** section is displayed.
+1. Ensure the **Installation** > **Instructions** section is displayed.
 1. If your Terraform registry is private, copy the top section of the code snippet, and paste it into your `~/.terraformrc` configuration file. This code snippet is based on the format:
 
     ```config


### PR DESCRIPTION

https://linear.app/buildkite/issue/PKG-6378/documentation-anyfile

First cut of docs for the new 'files' package type. 

![CleanShot 2024-08-02 at 12 11 56@2x](https://github.com/user-attachments/assets/103bc60d-2633-404d-aa64-530f61c67bd9)


This is a bit awkward as a file isn't really a package type, nor part of an ecosystem. I've rejigged everything I thought appropriate, but perhaps the nav should change and be outside the package ecosystem parent heading, let me know what you think.

I've also fixed in same PR (see individual commits): 
  * Publish button and title labelling for Javascript + Red Hat
  * Beta removed from enable packages flow
  * Installation instructions section title is now simply 'Instructions'
  * The ordering of the pipeline - my OCD needs to see the steps being built first on the left 🙃 

## Changes

![CleanShot 2024-08-02 at 12 12 46@2x](https://github.com/user-attachments/assets/a80235ba-29b8-4b9f-a99c-7cda12af6d24)

![CleanShot 2024-08-02 at 12 12 30@2x](https://github.com/user-attachments/assets/2f8ef676-f53d-4980-ae65-d063147bcdea)

![CleanShot 2024-08-02 at 12 11 11@2x](https://github.com/user-attachments/assets/23b1c17c-5bc1-4585-825e-3084ca0b02ac)
