### PR TITLE
Add information on using priority as a global value

### DIFF
--- a/pages/pipelines/managing_priorities.md
+++ b/pages/pipelines/managing_priorities.md
@@ -19,9 +19,7 @@ Job priority is considered before jobs are dispatched to [agent queues](/docs/ag
 
 ## Prioritizing whole builds
 
-`priority` can be set as a top-level value, applying it to all steps in the pipeline which do not have their own `priority` set. This is useful when you may need an entire pipeline to be considered a higher priority than others:
-
-This may be
+The `priority` key can be set as a top-level value, which applies it to all steps in the pipeline that do not have their own `priority` key set. This is useful when an entire pipeline requires a higher priority than others. For example:
 
 ```yml
 priority: 100

--- a/pages/pipelines/managing_priorities.md
+++ b/pages/pipelines/managing_priorities.md
@@ -17,6 +17,28 @@ steps:
 
 Job priority is considered before jobs are dispatched to [agent queues](/docs/agent/v3/queues), so jobs with higher priority are assigned before jobs with lower priority, regardless of which has been longest in the queue. Priority only applies to command jobs, including plugin commands.
 
+## Prioritizing whole builds
+
+`priority` can be set as a top-level value, applying it to all steps in the pipeline which do not have their own `priority` set. This is useful when you may need an entire pipeline to be considered a higher priority than others:
+
+This may be
+
+```yml
+priority: 100
+steps:
+  - label: "emergency fix"
+    command: "run_this_now.sh"
+  - wait: ~
+  - label: "this can wait"
+    command: "tests.sh"
+    priority: 1
+```
+{: codeblock-file="pipeline.yml"}
+
+Our `emergency fix` step will run before *any* step in *any* of our pipelines, unless a step in another build has a priority greater than 100.
+
+This may come in handy where you scale down instances but want to ensure any builds created on a pipeline aren't left waiting for agents; these jobs will run before jobs across the organisation that haven't already started.
+
 ## Job dispatch precedence
 
 Jobs are dispatched in the following order:

--- a/pages/pipelines/managing_priorities.md
+++ b/pages/pipelines/managing_priorities.md
@@ -33,9 +33,9 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-The `emergency fix` step will run before _any_ step in _any_ existing running pipelines throughout the organization, unless a step in another build has a priority greater than 100.
+The `emergency fix` step runs before _any step of any other running pipeline_ within your organization, unless one of these other pipeline steps has a priority greater than 100. If all available agents are running jobs, an appropriate agent will run the `emergency fix` step _only_ after its current job completes running.
 
-This may come in handy when you need to reduce the number of agents (for example, to reduce costs over a weekend with fewer employees in the office) but want to ensure any builds created on a critical pipeline are not left waiting for agents to run their jobs.
+Prioritizing whole builds comes in handy when you need to reduce the number of agents (for example, to reduce costs over a weekend due to fewer available team members) but want to ensure any builds created on a critical pipeline are not left waiting for agents to run their jobs.
 
 ## Job dispatch precedence
 

--- a/pages/pipelines/managing_priorities.md
+++ b/pages/pipelines/managing_priorities.md
@@ -33,9 +33,9 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-The `emergency fix` step will run before _any_ step in _any_ of our pipelines, unless a step in another build has a priority greater than 100.
+The `emergency fix` step will run before _any_ step in _any_ existing running pipelines throughout the organization, unless a step in another build has a priority greater than 100.
 
-This may come in handy where you scale down instances but want to ensure any builds created on a pipeline aren't left waiting for agents; these jobs will run before jobs across the organisation that haven't already started.
+This may come in handy when you need to reduce the number of agents (for example, to reduce costs over a weekend with fewer employees in the office) but want to ensure any builds created on a critical pipeline are not left waiting for agents to run their jobs.
 
 ## Job dispatch precedence
 

--- a/pages/pipelines/managing_priorities.md
+++ b/pages/pipelines/managing_priorities.md
@@ -33,7 +33,7 @@ steps:
 ```
 {: codeblock-file="pipeline.yml"}
 
-Our `emergency fix` step will run before *any* step in *any* of our pipelines, unless a step in another build has a priority greater than 100.
+The `emergency fix` step will run before _any_ step in _any_ of our pipelines, unless a step in another build has a priority greater than 100.
 
 This may come in handy where you scale down instances but want to ensure any builds created on a pipeline aren't left waiting for agents; these jobs will run before jobs across the organisation that haven't already started.
 


### PR DESCRIPTION
## Changes

`priority` can be used as a top level value, applying to all steps in a build that don't have their own `priority` value set. This may come in handy to know where folks wish for a **build** to run quickly.
