### PR TITLE
fix for language around no hooks or plugins description

### DIFF
--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -226,13 +226,13 @@ attributes:
   default_value: "false"
   required: false
   desc: |
-      Do not execute any local hooks, or plugins from any source.
+      Don't allow any local hooks, or plugins from any source.
 - name: no-plugins
   env_var: BUILDKITE_NO_PLUGINS
   default_value: "false"
   required: false
   desc: |
-      Do not load any plugins.
+      Don't allow loading of plugins.
 - name: no-plugin-validation
   env_var: BUILDKITE_NO_PLUGIN_VALIDATION
   default_value: "true"


### PR DESCRIPTION
The descriptions in the agent is slightly different to the docs, this causes confusion around the behaviour. 

<img width="843" alt="Screenshot 2024-08-16 at 8 28 56 AM" src="https://github.com/user-attachments/assets/87635fb8-7f5d-4aae-8258-5a590018fecf">
