### PR TITLE
Add `priority` to POST to annotations

### DIFF
--- a/pages/apis/rest_api/annotations.md
+++ b/pages/apis/rest_api/annotations.md
@@ -67,6 +67,7 @@ curl -H "Authorization: Bearer $TOKEN" \
   -d '{
     "body": "Hello world!",
     "style": "info",
+    "priority": 5,
     "context": "greeting"
   }'
 ```
@@ -76,6 +77,7 @@ curl -H "Authorization: Bearer $TOKEN" \
   "id": "018b8d10-6b5b-4df2-b0ff-dfa2af566050",
   "context": "greeting",
   "style": "info",
+  "priority": 5,
   "body_html": "<p>Hello world!</p>\n",
   "created_at": "2023-11-01T22:45:45.435Z",
   "updated_at": "2023-11-01T22:45:45.435Z"
@@ -105,6 +107,13 @@ Optional [request body properties](/docs/api#request-body-properties):
     <td>
       The style of the annotation. Can be <code>success</code>, <code>info</code>, <code>warning</code> or <code>error</code>.
       <p class="Docs__api-param-eg"><em>Example:</em> <code>"info"</code></p>
+    </td>
+  </tr>
+  <tr>
+    <th><code>priority</code></th>
+    <td>
+      Priority of the annotation (1 to 10). By default annotations have a priority of 3. Annotations with a priority of 10 will be shown first, and annotations with a priority of 1 will be shown last.
+      <p class="Docs__api-param-eg"><em>Example:</em> <code>5</code></p>
     </td>
   </tr>
   <tr>

--- a/pages/apis/rest_api/annotations.md
+++ b/pages/apis/rest_api/annotations.md
@@ -112,7 +112,7 @@ Optional [request body properties](/docs/api#request-body-properties):
   <tr>
     <th><code>priority</code></th>
     <td>
-      Priority of the annotation (1 to 10). By default annotations have a priority of 3. Annotations with a priority of 10 will be shown first, and annotations with a priority of 1 will be shown last.
+      The priority of the annotation (`1` to `10`). Annotations with a priority of `10` are shown first, while annotations with a priority of `1` are shown last. When this option is not specified, annotations have a default priority of `3`.
       <p class="Docs__api-param-eg"><em>Example:</em> <code>5</code></p>
     </td>
   </tr>


### PR DESCRIPTION
This is already supported in the CLI (where I ripped the description): https://buildkite.com/docs/agent/v3/cli-annotate#creating-an-annotation-options

And you can see the implementation as well: https://github.com/buildkite/agent/blob/5d69f8b625a97ec7b7db1cfc7031c31cf89a10ae/api/annotations.go#L14C25-L14C33

I also tested this locally:
```
% curl -H "Authorization: Bearer $TOKEN" \
  -X POST "https://api.buildkite.com/v2/organizations/.../pipelines/.../builds/254731/annotations" \
  -H "Content-Type: application/json" \
  -d '{
    "body": "Hello world!",
    "style": "info",
    "context": "greeting",
    "priority": 10
  }'
{"id":"...","context":"greeting","style":"info","priority":10,"created_at":"2024-08-16T14:37:09.882Z","updated_at":"2024-08-16T14:37:09.882Z","body_html":"<p>Hello world!</p>\n"}
```