### PR TITLE
Review of new Files and Helm registry pages.

### DIFF
--- a/pages/packages/files.md
+++ b/pages/packages/files.md
@@ -3,7 +3,7 @@
 
 Buildkite Packages provides registry support for generic files to cover some cases where native package management isn't required.
 
-Once your Files registry has been [created](/docs/packages/manage-registries#create-a-registry), you can publish/upload files (of any type and extension) to this registry via the relevant `curl` command presented on your registry details page.
+Once your files registry has been [created](/docs/packages/manage-registries#create-a-registry), you can publish/upload files (of any type and extension) to this registry via the relevant `curl` command presented on your registry details page.
 
 To view and copy this `curl` command:
 


### PR DESCRIPTION
This PR provides a PR review for the newish Files and Helm registry pages.



This PR also adds newer features, which includes:

- The 'single command' (with short-lived token) publish option for each registry type.