### PR TITLE
Document last_resolved_at flaky-tests api field

### DIFF
--- a/pages/apis/rest_api/analytics/flaky_tests.md
+++ b/pages/apis/rest_api/analytics/flaky_tests.md
@@ -22,7 +22,8 @@ curl -H "Authorization: Bearer $TOKEN" \
     "file_name": "./spec/models/user_spec.rb",
     "instances": 1,
     "latest_occurrence_at": "2024-07-15T00:07:02.547Z",
-    "most_recent_instance_at": "2024-07-15T00:07:02.547Z"
+    "most_recent_instance_at": "2024-07-15T00:07:02.547Z",
+    "last_resolved_at": null
   }
 ]
 ```


### PR DESCRIPTION
Now that the Test Analytics v2 ingestion is GA we can add the last_resolved_at field to the flaky-tests api docs
