### PR TITLE
Ignore CVE-2024-37371 and CVE-2024-37370 in docker image

### DIFF
--- a/.buildkite/ecr-scan-results-ignore.yml
+++ b/.buildkite/ecr-scan-results-ignore.yml
@@ -19,3 +19,5 @@ ignores:
   - id: CVE-2023-50387 # systemd 252.17-1~deb12u1
   - id: CVE-2024-0553 # gnutls28 3.7.9-2
   - id: CVE-2024-0567 # gnutls28 3.7.9-2+deb12u1
+  - id: CVE-2024-37371 # krb5 1.20.1-2+deb12u1
+  - id: CVE-2024-37370 # krb5 1.20.1-2+deb12u1


### PR DESCRIPTION
These CVEs are in krb5, a library that handles kerbeos authentication. We don't any kerbeos in production, but also the issues are  fixed in 1.20.1-2+deb12u2 which is available in the debian repos and the docker build logs show is being installed. This seems to be a false positive by ECR