### PR TITLE
A few tweaks to our report-only CSP header

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -19,7 +19,7 @@
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
   policy.font_src    :self, "https://www2.buildkiteassets.com/"
-  policy.object_src  :none, "https://beacon-v2.helpscout.net"
+  policy.object_src  "https://beacon-v2.helpscout.net"
   policy.style_src   :self, :unsafe_inline, "https://beacon-v2.helpscout.net"
 
   policy.img_src(
@@ -44,6 +44,8 @@ Rails.application.config.content_security_policy do |policy|
   policy.script_src *policy.script_src, :unsafe_eval, "http://#{ ViteRuby.config.host_with_port }" if Rails.env.development?
 
   policy.connect_src(
+    "https://www.google-analytics.com",
+
     # allow AJAX queries against our search vendor
     "https://#{ENV['ALGOLIA_APP_ID']}-dsn.algolia.net",
     "https://#{ENV['ALGOLIA_APP_ID']}-1.algolianet.com",
@@ -52,14 +54,22 @@ Rails.application.config.content_security_policy do |policy|
 
     "https://cdn.segment.com/",
     "https://api.segment.io/",
+
+    # We have Datadog Real User Monitoring enabled
+    "https://rum.browser-intake-datadoghq.com",
+
+    # For collecting feedback from customers
     "https://emojicom.io/",
+
+    # helpscout beacon sends data to two places
     "https://beacon-v2.helpscout.net",
-    "https://rum.browser-intake-datadoghq.com"
+    "https://d3hb14vkzrxvla.cloudfront.net",
   )
 
   # Allow @vite/client to hot reload changes in development
   policy.connect_src *policy.connect_src, "ws://#{ ViteRuby.config.host_with_port }" if Rails.env.development?
 
+  # For collecting feedback from customers
   policy.frame_src(
     "https://cdn.emojicom.io/"
   )


### PR DESCRIPTION
Our CSP is in report-only mode, but we'd like to get it closer to being enforcable. As a step in that direction I've opened a few pages in production, audited the most common CSP warnings in the browser console, and this should resolve them. These are all expected tools, our policy has just bitrotted, or the vendor has changed their resources.

1. object_src: we can't include `none` alongside an actual value
2. connect_src: we load GA v4 from www.googletagmanager.com, but it wants to submit data to https://www.google-analytics.com
3. connect_src: helpscout beacon wants tosend data to a cloudfront distribution

CSP docs for Helpscout beacon (mentions the cloudfront domain): https://docs.helpscout.com/article/815-csp-settings-for-beacon

CSP docs for datadog real user monitoring:
https://docs.datadoghq.com/integrations/content_security_policy_logs/

I also added some comments as context for future travelers.