### PR TITLE
Job expiry process delays

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,5 @@
   "dependencies": {
     "@docsearch/js": "3",
     "@hotwired/turbo-rails": "^7.3.0"
-  },
-  "version": "0.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
   "dependencies": {
     "@docsearch/js": "3",
     "@hotwired/turbo-rails": "^7.3.0"
-  }
+  },
+  "version": "0.0.0"
 }

--- a/pages/pipelines/build_timeouts.md
+++ b/pages/pipelines/build_timeouts.md
@@ -40,4 +40,4 @@ You can override the default by setting a shorter value in your organization's [
 Scheduled job limits should not be confused with [scheduled builds](/docs/pipelines/scheduled-builds). A scheduled build's jobs will still go through the [build states](/docs/pipelines/defining-steps#build-states), and the timeout will apply once its individual jobs are in the scheduled state waiting for agents.
 
 > 📘 Delays in expiring a job
-> A job's expiry process is run hourly at 5 minutes past. When the expiry process runs and the job's scheduled expiry was not over at that hour, it will only be expired until the next hour when the process is executed again. 
+> A job's expiry process is run hourly at 5 minutes past. When the expiry process runs and the job's scheduled expiry was not over at that hour, it will only be expired until the next hour when the process is executed again.

--- a/pages/pipelines/build_timeouts.md
+++ b/pages/pipelines/build_timeouts.md
@@ -39,5 +39,5 @@ You can override the default by setting a shorter value in your organization's [
 
 Scheduled job limits should not be confused with [scheduled builds](/docs/pipelines/scheduled-builds). A scheduled build's jobs will still go through the [build states](/docs/pipelines/defining-steps#build-states), and the timeout will apply once its individual jobs are in the scheduled state waiting for agents.
 
-> 📘 Delays in expiring a job
-> A job's expiry process is run hourly at 5 minutes past. When the expiry process runs and the job's scheduled expiry was not over at that hour, it will only be expired until the next hour when the process is executed again.
+> 📘 Delays in job expiration
+> A job's expiration process is run hourly at 5 minutes past. When the expiration process runs and the job's scheduled expiration was not over at that hour, it will only be expired until the next hour when the process is executed again.

--- a/pages/pipelines/build_timeouts.md
+++ b/pages/pipelines/build_timeouts.md
@@ -38,3 +38,6 @@ By default, jobs are canceled when not picked up for 30 days. This will cause th
 You can override the default by setting a shorter value in your organization's [**Pipeline Settings**](https://buildkite.com/organizations/~/pipeline-settings) page.
 
 Scheduled job limits should not be confused with [scheduled builds](/docs/pipelines/scheduled-builds). A scheduled build's jobs will still go through the [build states](/docs/pipelines/defining-steps#build-states), and the timeout will apply once its individual jobs are in the scheduled state waiting for agents.
+
+> 📘 Delays in expiring a job
+> A job's expiry process is run hourly at 5 minutes past. When the expiry process runs and the job's scheduled expiry was not over at that hour, it will only be expired until the next hour when the process is executed again. 


### PR DESCRIPTION
A customer has asked why there was delays in expiring jobs in their org. After clarification from the pipelines team, it would be good to have this information available for the customers to know. 