### PR TITLE
Update docs to reflect new naming for Rules params, and creation via pipeline slugs 

### DIFF
--- a/pages/apis/graphql/cookbooks/rules.md
+++ b/pages/apis/graphql/cookbooks/rules.md
@@ -50,7 +50,7 @@ mutation {
   ruleCreate(input: {
     organizationId: "organization-id",
     type: "pipeline.trigger_build.pipeline",
-    value: "{\"source_pipeline_uuid\":\"{uuid-of-source-pipeline}\",\"target_pipeline_uuid\":\"{uuid-of-target-pipeline}\"}"
+    value: "{\"source_pipeline\":\"{uuid-of-source-pipeline}\",\"target_pipeline\":\"{uuid-of-target-pipeline}\"}"
   }) {
      rule {
       id

--- a/pages/apis/rest_api/rules.md
+++ b/pages/apis/rest_api/rules.md
@@ -93,8 +93,8 @@ curl -H "Authorization: Bearer $TOKEN" \
   -d '{
     "type": "pipeline.trigger_build.pipeline",
     "value": {
-      "source_pipeline_uuid": "16f3b56f-4934-4546-923c-287859851332",
-      "target_pipeline_uuid": "d07d5d84-d1bd-479c-902c-ce8a01ce5aac"
+      "source_pipeline": "16f3b56f-4934-4546-923c-287859851332",
+      "target_pipeline": "d07d5d84-d1bd-479c-902c-ce8a01ce5aac"
     }
   }'
 ```
@@ -139,8 +139,8 @@ Required [request body properties](/docs/api#request-body-properties):
   </tr>
   <tr>
     <th><code>value</code></th>
-    <td>A JSON object containing the value fields for the rule.<br>
-    <em>Example:</em> <code>{"source_pipeline_uuid": "16f3b56f-4934-4546-923c-287859851332", "target_pipeline_uuid": "d07d5d84-d1bd-479c-902c-ce8a01ce5aac"}</code></td>
+    <td>A JSON object containing the value fields for the rule. <code>source_pipeline</code> and <code>target_pipeline</code> fields accept either a pipeline UUID or a pipeline slug.<br>
+    <em>Example:</em> <code>{"source_pipeline": "16f3b56f-4934-4546-923c-287859851332", "target_pipeline": "d07d5d84-d1bd-479c-902c-ce8a01ce5aac"}</code></td>
   </tr>
 </tbody>
 </table>

--- a/pages/pipelines/rules.md
+++ b/pages/pipelines/rules.md
@@ -29,16 +29,16 @@ This rule type allows one pipeline to trigger another, where:
 {
   "rule": "pipeline.trigger_build.pipeline",
   "value": {
-    "source_pipeline_uuid": "pipeline-uuid",
-    "target_pipeline_uuid": "pipeline-uuid"
+    "source_pipeline": "pipeline-uuid-or-slug",
+    "target_pipeline": "pipeline-uuid-or-slug"
   }
 }
 ```
 
 where:
 
-- `source_pipeline_uuid` is the UUID of the pipeline that's allowed to trigger another pipeline.
-- `target_pipeline_uuid` is the UUID of the pipeline that can be triggered by the `source_pipeline_uuid` pipeline.
+- `source_pipeline` is the UUID or slug of the pipeline that's allowed to trigger another pipeline.
+- `target_pipeline` is the UUID or slug of the pipeline that can be triggered by the `source_pipeline` pipeline.
 
 Learn more about creating rules in [Manage rules](/docs/pipelines/rules/manage).
 
@@ -61,16 +61,16 @@ This rule type allows one pipeline to access (that is, with read-only permission
 {
   "rule": "pipeline.artifacts_read.pipeline",
   "value": {
-    "source_pipeline_uuid": "pipeline-uuid",
-    "target_pipeline_uuid": "pipeline-uuid"
+    "source_pipeline": "pipeline-uuid-or-slug",
+    "target_pipeline": "pipeline-uuid-or-slug"
   }
 }
 ```
 
 where:
 
-- `source_pipeline_uuid` is the UUID of the pipeline that's allowed to access the artifacts from another pipeline.
-- `target_pipeline_uuid` is the UUID of the pipeline whose artifacts can be accessed by jobs in the `source_pipeline_uuid` pipeline.
+- `source_pipeline` is the UUID or slug of the pipeline that's allowed to access the artifacts from another pipeline.
+- `target_pipeline` is the UUID or slug of the pipeline whose artifacts can be accessed by jobs in the `source_pipeline` pipeline.
 
 Learn more about creating rules in [Manage rules](/docs/pipelines/rules/manage).
 

--- a/pages/pipelines/rules/manage.md
+++ b/pages/pipelines/rules/manage.md
@@ -16,7 +16,7 @@ To create a new rule using the Buildkite interface:
 
 1. Under **Rule Type**, select the [type of rule](/docs/pipelines/rules#rule-types) to be created, that is, either **pipeline.trigger_build.pipeline** or **pipeline.artifacts_read.pipeline**.
 
-1. Under **Rule Document**, specify the relevant `pipeline-uuid` (UUID) values for both the `source_pipeline_uuid` and `target_pipeline_uuid` pipelines, of your [**pipeline.trigger_build.pipeline**](/docs/pipelines/rules#rule-types-pipeline-dot-trigger-build-dot-pipeline) or [**pipeline.artifacts_read.pipeline**](/docs/pipelines/rules#rule-types-pipeline-dot-artifacts-read-dot-pipeline) rule. You can find the UUID values for these pipelines on the pipelines' respective **Settings** page under the **GraphQL API integration** section.
+1. Under **Rule Document**, specify the relevant values (either a pipeline UUID or a pipeline slug) for both the `source_pipeline` and `target_pipeline` pipelines, of your [**pipeline.trigger_build.pipeline**](/docs/pipelines/rules#rule-types-pipeline-dot-trigger-build-dot-pipeline) or [**pipeline.artifacts_read.pipeline**](/docs/pipelines/rules#rule-types-pipeline-dot-artifacts-read-dot-pipeline) rule. You can find the UUID values for these pipelines on the pipelines' respective **Settings** page under the **GraphQL API integration** section.
 
 1. Select **Submit**.
 
@@ -33,8 +33,8 @@ curl -H "Authorization: Bearer $TOKEN" \
   -d '{
     "rule": "pipeline.trigger_build.pipeline",
     "value": {
-      "source_pipeline_uuid": "{pipeline.uuid}",
-      "target_pipeline_uuid": "{pipeline.uuid}"
+      "source_pipeline": "{pipeline-uuid-or-slug}",
+      "target_pipeline": "{pipeline-uuid-or-slug}"
     }
   }'
 ```
@@ -47,11 +47,13 @@ where:
 
 - `rule` is the [type of rule](/docs/pipelines/rules#rule-types) to be created, that is, either `pipeline.trigger_build.pipeline` or `pipeline.artifacts_read.pipeline`.
 
-- `{pipeline.uuid}` value for `source_pipeline_uuid` and `target_pipeline_uuid` can be obtained:
+- `source_pipeline` and `target_pipeline` accept either a pipeline slug or UUID.
+
+- Pipeline UUID values for `source_pipeline` and `target_pipeline` can be obtained:
 
     * From the **Pipeline Settings** page of the appropriate pipeline. To do this:
         1. Select **Pipelines** (in the global navigation) > the specific pipeline > **Settings**.
-        1. Once on the **Pipeline Settings** page, copy the `UUID` value from the **GraphQL API Integration** section, which is the `{pipeline.uuid}` value.
+        1. Once on the **Pipeline Settings** page, copy the `UUID` value from the **GraphQL API Integration** section
 
     * By running the [List pipelines](/docs/apis/rest-api/pipelines#list-pipelines) REST API query to obtain this value from `id` in the response from the specific pipeline. For example:
 
@@ -69,7 +71,7 @@ mutation {
   ruleCreate(input: {
     organizationId: "organization-id",
     type: "pipeline.trigger_build.pipeline",
-    value: "{\"source_pipeline_uuid\":\"pipeline-uuid\",\"target_pipeline_uuid\":\"pipeline-uuid\"}"
+    value: "{\"source_pipeline\":\"pipeline-uuid-or-slug\",\"target_pipeline\":\"pipeline-uuid-or-slug\"}"
   }) {
      rule {
       id
@@ -103,11 +105,13 @@ where:
 
 - `type` is the [type of rule](/docs/pipelines/rules#rule-types) to be created, that is, either `pipeline.trigger_build.pipeline` or `pipeline.artifacts_read.pipeline`.
 
-- `pipeline-uuid` value for `source_pipeline_uuid` and `target_pipeline_uuid` can be obtained:
+- `source_pipeline` and `target_pipeline` accept either a pipeline slug or UUID.
+
+- Pipeline UUID values for `source_pipeline` and `target_pipeline` can be obtained:
 
     * From the **Pipeline Settings** page of the appropriate pipeline. To do this:
         1. Select **Pipelines** (in the global navigation) > the specific pipeline > **Settings**.
-        1. Once on the **Pipeline Settings** page, copy the `UUID` value from the **GraphQL API Integration** section, which is the `pipeline-uuid` value.
+        1. Once on the **Pipeline Settings** page, copy the `UUID` value from the **GraphQL API Integration** section
 
     * By running the `getCurrentUsersOrgs` GraphQL API query to obtain the organization slugs for the current user's accessible organizations, then [getOrgPipelines](/docs/apis/graphql/schemas/query/organization) query to obtain the pipeline's `uuid` in the response. For example:
 
@@ -140,7 +144,7 @@ where:
                   uuid
                   name
                 }
-              } 
+              }
             }
           }
         }


### PR DESCRIPTION
In https://github.com/buildkite/buildkite/pull/18890 we are updating the rules parameter names to `source_pipeline` and `target_pipeline` rather than `source_pipeline_uuid` and `target_pipeline_uuid`. This is because these fields will now accept either a UUID or a pipeline slug. 

This PR updates the docs to indicate the above. 