### PR TITLE
Add gcloud CLI to hosted agents

### DIFF
--- a/pages/pipelines/hosted_agents/mac.md
+++ b/pages/pipelines/hosted_agents/mac.md
@@ -125,6 +125,7 @@ Updated Xcode versions will be available one week after Apple offers them for do
 
 - AWS CLI
 - Azure CLI
+- gcloud CLI
 - CodeQL
 - Bicep CLI
 - fastlane


### PR DESCRIPTION
Add "gcloud CLI" to hosted agents to "Assorted tools" in Mac docs, now gcli is available.