### PR TITLE
fix(tablet): set rows grid to 0 if it's empty (e.g. no toc section)

### DIFF
--- a/app/frontend/css/components/_page.scss
+++ b/app/frontend/css/components/_page.scss
@@ -10,7 +10,7 @@ $lg-screen-margin-top: map-get($header-height, "one-row");
 
 .Page {
   display: grid;
-  grid-template-rows: auto;
+  grid-template-rows: minmax(0, auto);
   grid-template-columns: 1fr;
   grid-template-areas:
     "sidebar"


### PR DESCRIPTION
- on tablet, the screen is split into 4 grid areas: if there's no automatic TOC generated, which takes up the top right corner, and the content doesn't fill up the screen, the content ends up in the bottom left corner. If we add a `minmax` to the grid rows, with a min of 0 and a max of auto, it should sort itself out better.

**After:**
<img width="1026" alt="Screenshot 2024-10-28 at 1 53 18 PM" src="https://github.com/user-attachments/assets/93c6979d-b6f6-4bc7-98c1-f7f4954c7701">


**Before** Reported by @zhming0:
![Screenshot 2024-10-28 at 1 23 23 PM](https://github.com/user-attachments/assets/431e3f22-e785-481d-b900-8dfa1da43320)

