### PR TITLE
coda-instance-type update docs to reflect recent changes

### DIFF
--- a/data/content/aws-stack.yml
+++ b/data/content/aws-stack.yml
@@ -303,12 +303,12 @@ Parameters:
     Default: ""
 
   InstanceTypes:
-    Description: Comma-separated list with 1-4 instance types. The order is a prioritized preference for launching OnDemand instances, and a non-prioritized list of types to consider for Spot Instances (where used).
+    Description: Comma-separated list with 1-10 instance types. The order is a prioritized preference for launching OnDemand instances, and a non-prioritized list of types to consider for Spot Instances (where used).
     Type: String
     Default: t3.large
     MinLength: 1
-    AllowedPattern: "^[\\w-\\.]+(,[\\w-\\.]*){0,3}$"
-    ConstraintDescription: "must contain 1-4 instance types separated by commas. No space before/after the comma."
+    AllowedPattern: "^[\\w-\\.]+(,[\\w-\\.]*){0,9}$"
+    ConstraintDescription: "must contain 1-10 instance types separated by commas. No space before/after the comma."
 
   MaxSize:
     Description: Maximum number of instances


### PR DESCRIPTION
Recently we made a change to the elastic ci stack for AWS whereby we increase the pool of instance types from 4 to 10 due to issues around spot interruptions in our BK ASG

PR https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1396
Coda: https://coda.io/d/_dHnUHNps1YO#Escalations-Pipelines_tuQbCBf6/r812&view=center

This PR is to keep our public facing docs current. 