### PR TITLE
Document `text` field in InputStep:TextInput

### DIFF
--- a/pages/pipelines/input_step.md
+++ b/pages/pipelines/input_step.md
@@ -141,6 +141,13 @@ Optional attributes:
 
 <table>
   <tr>
+    <td><code>text</code></td>
+    <td>
+      The text input name.<br>
+      <em>Example:</em> <code>"Release Name"</code>
+    </td>
+  </tr>
+  <tr>
     <td><code>hint</code></td>
     <td>
       The explanatory text that is shown after the label.<br>


### PR DESCRIPTION
The examples show the field, but it is undocumented.

Description/Example ripped from https://github.com/buildkite/pipeline-schema