### PR TITLE
Improve/Standardize `alias`

### DIFF
--- a/pages/pipelines/block_step.md
+++ b/pages/pipelines/block_step.md
@@ -102,7 +102,7 @@ Optional attributes:
   <tr>
     <td><code>key</code></td>
     <td>
-      <p>A unique string to identify the block step.</p>
+      <p>A unique string to identify the block step.<br>Keys can not have the same pattern as a UUID (<code>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</code>).</p>
       <p><em>Example:</em> <code>"test-suite"</code></p>
       <p><em>Alias:</em> <code>identifier</code></p>
     </td>

--- a/pages/pipelines/block_step.md
+++ b/pages/pipelines/block_step.md
@@ -102,8 +102,9 @@ Optional attributes:
   <tr>
     <td><code>key</code></td>
     <td>
-	    <p>A unique string to identify the block step.</p>
+      <p>A unique string to identify the block step.</p>
       <p><em>Example:</em> <code>"test-suite"</code></p>
+      <p><em>Alias:</em> <code>identifier</code></p>
     </td>
    </tr>
    <tr>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -22,9 +22,10 @@ Required attributes:
   <tr>
     <td><code>command</code></td>
     <td>
-      The shell command/s to run during this step. This can be a single line of commands, or a list of commands that must all pass. Also available as the alias <code>commands</code>.<br>
+      The shell command/s to run during this step. This can be a single line of commands, or a list of commands that must all pass.<br>
       <em>Example:</em> <code>"build.sh"</code><br>
-      <em>Example:</em><br><code>- "npm install"</code><br><code>- "tests.sh"</code>
+      <em>Example:</em><br><code>- "npm install"</code><br><code>- "tests.sh"</code><br>
+      <em>Alias:</em>em> <code>commands</code>
     </td>
   </tr>
 </table>
@@ -120,7 +121,7 @@ Optional attributes:
     <td>
       A unique string to identify the step. The value is available in the <code>BUILDKITE_STEP_KEY</code> <a href="/docs/pipelines/environment-variables">environment variable</a>.<br>
       Keys can not have the same pattern as a UUID (<code>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</code>).<br>
-      <em>Example:</em> <code>"linter"</code>
+      <em>Example:</em> <code>"linter"</code><br>
       <em>Alias:</em> <code>identifier</code>
     </td>
   </tr>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -119,7 +119,7 @@ Optional attributes:
   <tr>
     <td><code>key</code></td>
     <td>
-      A unique string to identify the step. The value is available in the <code>BUILDKITE_STEP_KEY</code> <a href="/docs/pipelines/environment-variables">environment variable</a>.<br>
+      A unique string to identify the command step. The value is available in the <code>BUILDKITE_STEP_KEY</code> <a href="/docs/pipelines/environment-variables">environment variable</a>.<br>
       Keys can not have the same pattern as a UUID (<code>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</code>).<br>
       <em>Example:</em> <code>"linter"</code><br>
       <em>Alias:</em> <code>identifier</code>

--- a/pages/pipelines/command_step.md
+++ b/pages/pipelines/command_step.md
@@ -25,7 +25,7 @@ Required attributes:
       The shell command/s to run during this step. This can be a single line of commands, or a list of commands that must all pass.<br>
       <em>Example:</em> <code>"build.sh"</code><br>
       <em>Example:</em><br><code>- "npm install"</code><br><code>- "tests.sh"</code><br>
-      <em>Alias:</em>em> <code>commands</code>
+      <em>Alias:</em> <code>commands</code>
     </td>
   </tr>
 </table>

--- a/pages/pipelines/group_step.md
+++ b/pages/pipelines/group_step.md
@@ -81,7 +81,7 @@ Optional attributes:
   <tr>
     <td><code>key</code></td>
     <td>
-      A unique string to identify the step, block, or group.<br>
+      A unique string to identify the step, block, or group.<br>Keys can not have the same pattern as a UUID (<code>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</code>).<br>
       <em>Example:</em> <code>"test-suite"</code><br>
       <em>Alias:</em> <code>identifier</code>
     </td>

--- a/pages/pipelines/group_step.md
+++ b/pages/pipelines/group_step.md
@@ -81,8 +81,9 @@ Optional attributes:
   <tr>
     <td><code>key</code></td>
     <td>
-    A unique string to identify the step, block, or group. Alias: `identifier` or `id`.<br>
-      <em>Example:</em> <code>"test-suite"</code>
+      A unique string to identify the step, block, or group.<br>
+      <em>Example:</em> <code>"test-suite"</code><br>
+      <em>Alias:</em> <code>identifier</code>
     </td>
   </tr>
   <tr>

--- a/pages/pipelines/input_step.md
+++ b/pages/pipelines/input_step.md
@@ -91,8 +91,9 @@ Optional attributes:
    <tr>
     <td><code>key</code></td>
     <td>
-	    <p>A unique string to identify the input step.</p>
-      <p><em>Example:</em> <code>"test-suite"</code></p>
+      A unique string to identify the input step.<br>
+      <em>Example:</em> <code>"test-suite"</code><br>
+      <em>Alias:</em> <code>identifier</code>
     </td>
    </tr>
    <tr>

--- a/pages/pipelines/input_step.md
+++ b/pages/pipelines/input_step.md
@@ -91,7 +91,7 @@ Optional attributes:
    <tr>
     <td><code>key</code></td>
     <td>
-      A unique string to identify the input step.<br>
+      A unique string to identify the input step.<br>Keys can not have the same pattern as a UUID (<code>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</code>).<br>
       <em>Example:</em> <code>"test-suite"</code><br>
       <em>Alias:</em> <code>identifier</code>
     </td>

--- a/pages/pipelines/trigger_step.md
+++ b/pages/pipelines/trigger_step.md
@@ -92,6 +92,14 @@ Optional attributes:
     </td>
    </tr>
    <tr>
+    <td><code>key</code></td>
+    <td>
+      A unique string to identify the trigger step.<br>
+      <em>Example:</em> <code>"trigger-deploy"</code><br>
+      <em>Alias:</em> <code>identifier</code>
+    </td>
+   </tr>
+   <tr>
     <td><code>allow_dependency_failure</code></td>
     <td>
       Whether to continue to run this step if any of the steps named in the <code>depends_on</code> attribute fail.<br>

--- a/pages/pipelines/trigger_step.md
+++ b/pages/pipelines/trigger_step.md
@@ -94,7 +94,7 @@ Optional attributes:
    <tr>
     <td><code>key</code></td>
     <td>
-      A unique string to identify the trigger step.<br>
+      A unique string to identify the trigger step.<br>Keys can not have the same pattern as a UUID (<code>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</code>).<br>
       <em>Example:</em> <code>"trigger-deploy"</code><br>
       <em>Alias:</em> <code>identifier</code>
     </td>

--- a/pages/pipelines/wait_step.md
+++ b/pages/pipelines/wait_step.md
@@ -38,7 +38,7 @@ Optional attributes:
    <tr>
     <td><code>key</code></td>
     <td>
-      A unique string to identify the wait step.<br>
+      A unique string to identify the wait step.<br>Keys can not have the same pattern as a UUID (<code>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</code>).<br>
       <em>Example:</em> <code>"confirmation"</code><br>
       <em>Alias:</em> <code>identifier</code>
     </td>

--- a/pages/pipelines/wait_step.md
+++ b/pages/pipelines/wait_step.md
@@ -36,6 +36,14 @@ Optional attributes:
     </td>
    </tr>
    <tr>
+    <td><code>key</code></td>
+    <td>
+      A unique string to identify the wait step.<br>
+      <em>Example:</em> <code>"confirmation"</code><br>
+      <em>Alias:</em> <code>identifier</code>
+    </td>
+   </tr>
+   <tr>
     <td><code>allow_dependency_failure</code></td>
     <td>
       Whether to continue to proceed past this step if any of the steps named in the <code>depends_on</code> attribute fail.<br>


### PR DESCRIPTION
- `key` has aliases `identifier` and `id` (however I suspect y'all don't want to advertise the latter due to confusion with `BUILDKITE_STEP_ID` (not being the `id`)) so make sure `identifier` is listed as an alias
- Document the "not-UUID-like" restriction on all `key`s
- Add missing `key` field to Trigger and Wait step docs