### PR TITLE
Fix incorrect test runner env var name

### DIFF
--- a/data/content/test_splitting_env.yaml
+++ b/data/content/test_splitting_env.yaml
@@ -31,7 +31,7 @@ mandatory:
       - Please refer to the `BUILDKITE_TEST_ENGINE_TEST_CMD` environment variable for more details.
     note:
       - The Test Engine Client will not delete the file after running the test, however it will be deleted by Buildkite Agent as part of the build lifecycle.
-  - name: BUILDKITE_TEST_ENGINE_RUNNER
+  - name: BUILDKITE_TEST_ENGINE_TEST_RUNNER
     desc:
       - The test runner to use for running tests. Currently `rspec` and `jest` are supported.
   - name: BUILDKITE_TEST_ENGINE_SUITE_SLUG 

--- a/pages/test_engine/test_splitting/configuring.md
+++ b/pages/test_engine/test_splitting/configuring.md
@@ -163,7 +163,7 @@ steps:
       BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: your-secret-token
       BUILDKITE_TEST_ENGINE_RESULT_PATH: tmp/rspec-result.json
       BUILDKITE_TEST_ENGINE_SUITE_SLUG: my-suite
-      BUILDKITE_TEST_ENGINE_RUNNER: rspec
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: rspec
 ```
 {: codeblock-file="pipeline.yml"}
 


### PR DESCRIPTION
Currently documented ENV var name [is incorrect](https://github.com/buildkite/test-engine-client/blob/3f045ed4a69a569913b007ca3aecc96a0c541e00/internal/config/env.go#L52).