### PR TITLE
SUP-2860/update-job-queue-api

### DIFF
--- a/pages/apis/graphql/cookbooks/jobs.md
+++ b/pages/apis/graphql/cookbooks/jobs.md
@@ -6,7 +6,7 @@ You can test out the Buildkite GraphQL API using the [Buildkite explorer](https:
 
 ## Get all jobs in a given queue for a given timeframe
 
-Get all jobs in a named queue, created on or after a given date. Note that if you want all jobs in the default queue, you do not need to set a queue name, so you can omit the `agentQueryRules` option.
+Get all jobs in a named queue, created on or after a given date. Note that if you want all jobs across the organization, you do not need to set a queue name, so you can omit the `agentQueryRules` option.
 
 ```graphql
 query PipelineRecentBuildLastJobQueue {


### PR DESCRIPTION
Based on the finding from the customer raising this change.

When no "agentQueryRules" is specified in the query https://buildkite.com/docs/apis/graphql/cookbooks/jobs#get-all-jobs-in-a-given-queue-for-a-given-timeframe, it pulls all the jobs across the cluster.
 
