### PR TITLE
`cluster_id` is the UUID ID, not the b64 encoded one

### DIFF
--- a/pages/apis/rest_api/pipelines.md
+++ b/pages/apis/rest_api/pipelines.md
@@ -295,7 +295,7 @@ Required [request body properties](/docs/api#request-body-properties):
   </tr>
   <tr>
     <th><code>cluster_id</code></th>
-    <td>The ID value of the cluster the pipeline will be associated with.<p class="Docs__api-param-eg"><em>Example:</em> <code>"Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv10Wx11Yz12Ab1Cd2Ef3Gh4Ij5Kl6Mn=="</code></p></td>
+    <td>The ID value of the cluster the pipeline will be associated with.<p class="Docs__api-param-eg"><em>Example:</em> <code>"018e5a22-d14c-7085-bb28-db0f83f43a1c"</code></p></td>
   </tr>
   <tr>
     <th><code>repository</code></th>


### PR DESCRIPTION
(title)