### PR TITLE
chore: update Elastic CI Stack to v6.36.0

### DIFF
--- a/data/content/aws-stack.yml
+++ b/data/content/aws-stack.yml
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "Buildkite stack v6.34.0"
+Description: "Buildkite stack v6.36.0"
 
 # The Buildkite Elastic CI Stack for AWS gives you a private,
 # autoscaling Buildkite Agent cluster. Use it to parallelize
@@ -586,7 +586,7 @@ Parameters:
 
   PipelineSigningKMSKeyId:
     Type: String
-    Description: Optional - Identifier of the KMS key used to sign and verify pipelines (Created if left blank and PipelineSigningKMSKeySpec is selected)
+    Description: Optional - Identifier or ARN of the KMS key used to sign and verify pipelines (created if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN are left blank and PipelineSigningKMSKeySpec is selected)
     Default: ""
 
   PipelineSigningKMSKeySpec:
@@ -637,7 +637,7 @@ Rules:
             - !Equals
               - !Ref PipelineSigningKMSKeySpec
               - "none"
-        AssertDescription: "You must provide either provide a PipelineSigningKMSKeyId or select a PipelineSigningKMSKeySpec but not both"
+        AssertDescription: "You must provide either a PipelineSigningKMSKeyId, or select a PipelineSigningKMSKeySpec, but not both"
 
 Outputs:
   VpcId:
@@ -780,6 +780,9 @@ Conditions:
     HasSigningKMSAccessSignAndVerify:
       !Equals [ !Ref PipelineSigningKMSAccess, "sign-and-verify" ]
 
+    PipelineSigningKMSKeyIsARN:
+      !Equals [!Select [0, !Split [":", !Ref PipelineSigningKMSKeyId]], "arn"]
+
     HasKeyName:
       !Not [ !Equals [ !Ref KeyName, "" ] ]
 
@@ -857,26 +860,26 @@ Mappings:
 
   # Generated from Makefile via build/mappings.yml
   AWSRegion2AMI:
-    us-east-1 : { linuxamd64: ami-05183d4b158c34dce, linuxarm64: ami-0c8c1c769a58bb6d4, windows: ami-075ef5cab71200ff1 }
-    us-east-2 : { linuxamd64: ami-0165d9c8b1afa4cda, linuxarm64: ami-0428df4752e1633b8, windows: ami-0e7ede18c0d5cc983 }
-    us-west-1 : { linuxamd64: ami-00f02b357a5a6e36c, linuxarm64: ami-043325378fdfa1088, windows: ami-0c21245e0017b2656 }
-    us-west-2 : { linuxamd64: ami-027125f97c2a1d307, linuxarm64: ami-0993c143f98f0697b, windows: ami-08c141f30ab14f4b4 }
-    af-south-1 : { linuxamd64: ami-04fd9fcad835431d9, linuxarm64: ami-048579b6f4d681497, windows: ami-06430463c32711a27 }
-    ap-east-1 : { linuxamd64: ami-05cb938d385d5bda6, linuxarm64: ami-0f4c5ea02e451f144, windows: ami-0a41fd2fa313a8a6f }
-    ap-south-1 : { linuxamd64: ami-0d3cceb699934e3ef, linuxarm64: ami-048997b3a4cfa4479, windows: ami-01685077b14216221 }
-    ap-northeast-2 : { linuxamd64: ami-0e354070f8d059f9a, linuxarm64: ami-09624533736914f79, windows: ami-026ea3763c15ad793 }
-    ap-northeast-1 : { linuxamd64: ami-02baa58971f180429, linuxarm64: ami-00b97c38da4bc220f, windows: ami-068833cdbf5a76f84 }
-    ap-southeast-2 : { linuxamd64: ami-045786294af83ab0e, linuxarm64: ami-0d3cd19e4787f89d9, windows: ami-0b903d7c331dc746f }
-    ap-southeast-1 : { linuxamd64: ami-0452c4fcc5f3b7b57, linuxarm64: ami-04828d6b9aadf6bbe, windows: ami-002d7950c23f61d4f }
-    ca-central-1 : { linuxamd64: ami-00a8216f7e07f4cb7, linuxarm64: ami-01565cb007e52fa3e, windows: ami-0a8c3daca452f215e }
-    eu-central-1 : { linuxamd64: ami-0f43a64b62ae85457, linuxarm64: ami-0c068bca75ed3749d, windows: ami-030d84ebc1b3d4e8f }
-    eu-west-1 : { linuxamd64: ami-02fe7c0046141a0e2, linuxarm64: ami-012ed6a0c3cfdc8ea, windows: ami-09fb570628375f9fb }
-    eu-west-2 : { linuxamd64: ami-022a807fd47ddcd8c, linuxarm64: ami-0ff03613e8f79a68f, windows: ami-0657768007d61b4dc }
-    eu-south-1 : { linuxamd64: ami-0514405efa2c639d5, linuxarm64: ami-0f8f83e00f5cc2317, windows: ami-075c25b77e2257555 }
-    eu-west-3 : { linuxamd64: ami-0425d3ad3279c246b, linuxarm64: ami-06962d143f62d4d02, windows: ami-0b312514e6938314c }
-    eu-north-1 : { linuxamd64: ami-0171a289892a3e298, linuxarm64: ami-094a22f540c438ba7, windows: ami-0a4e09e04ca967b64 }
-    me-south-1 : { linuxamd64: ami-0d46210c0a8fe4e42, linuxarm64: ami-0a8c759b58fb2d886, windows: ami-062100aad8abded9c }
-    sa-east-1 : { linuxamd64: ami-0f7408d187088d556, linuxarm64: ami-049c4100cfe82e7fa, windows: ami-0f5087c54805d0c65 }
+    us-east-1 : { linuxamd64: ami-0f8127a8a4c84919f, linuxarm64: ami-0b68803b716854ed4, windows: ami-0f0620582505b05ad }
+    us-east-2 : { linuxamd64: ami-028b9abe30f0429b7, linuxarm64: ami-06273b924054a85a6, windows: ami-069abfbf50e7f5ebd }
+    us-west-1 : { linuxamd64: ami-0281ff5d72a000005, linuxarm64: ami-0640204111ae90c6a, windows: ami-0e5ba962268dbe462 }
+    us-west-2 : { linuxamd64: ami-015cbfbcf30b2a72f, linuxarm64: ami-065f49b459c1104da, windows: ami-0ff462012324e158d }
+    af-south-1 : { linuxamd64: ami-006ede0b69eee6f4d, linuxarm64: ami-04a919d2a3b96f7fa, windows: ami-0e6e15368438bdc0b }
+    ap-east-1 : { linuxamd64: ami-0d322389e64fccdf1, linuxarm64: ami-06ae98d21a36d3a81, windows: ami-02075c89ae0180cfc }
+    ap-south-1 : { linuxamd64: ami-0642c96cc2c332aa8, linuxarm64: ami-079a6c4193439a64d, windows: ami-0230f64c950e5135f }
+    ap-northeast-2 : { linuxamd64: ami-005730fb8e1d28fc9, linuxarm64: ami-0f91c7857033c2222, windows: ami-0d70203846cf9b8e3 }
+    ap-northeast-1 : { linuxamd64: ami-0e5f281b5dde0c6a8, linuxarm64: ami-0c73873b45fc52887, windows: ami-0d67a00e19ab30fb9 }
+    ap-southeast-2 : { linuxamd64: ami-0df7740808cb1dd29, linuxarm64: ami-0613f4bff52e1d552, windows: ami-08904cd89668a5a60 }
+    ap-southeast-1 : { linuxamd64: ami-0b0a78360eef6765a, linuxarm64: ami-0698a1bc6debe5d1d, windows: ami-09a4de4dd4196f89a }
+    ca-central-1 : { linuxamd64: ami-0abc56d4e8a980b10, linuxarm64: ami-09af13d5d74edae48, windows: ami-0ccedc4aaae3605cd }
+    eu-central-1 : { linuxamd64: ami-093ef0a37780d4cb0, linuxarm64: ami-0a9bec2001fe6f110, windows: ami-021dfa396889621e7 }
+    eu-west-1 : { linuxamd64: ami-0fc51a11ba6910353, linuxarm64: ami-07f600280643f4e8c, windows: ami-0c489832a2c4a7c5c }
+    eu-west-2 : { linuxamd64: ami-0e89f681a97ae1713, linuxarm64: ami-08451d15eef2ad517, windows: ami-0a5862ed16e7dcf51 }
+    eu-south-1 : { linuxamd64: ami-0e56e7cb15fe6da5c, linuxarm64: ami-0a191054bc5e764b6, windows: ami-0147793d6ddeef423 }
+    eu-west-3 : { linuxamd64: ami-07eec27ba36f5dda9, linuxarm64: ami-0191414d25346c4c2, windows: ami-0582cc5f729a6191a }
+    eu-north-1 : { linuxamd64: ami-0affcff963ba3a1e6, linuxarm64: ami-0cb4ece075f5d93d8, windows: ami-0ba2100e6c8bd94b4 }
+    me-south-1 : { linuxamd64: ami-0cc90d98447df3dc3, linuxarm64: ami-07e8269f2d8b6b1b2, windows: ami-014c3e620810d4c6b }
+    sa-east-1 : { linuxamd64: ami-05e387fb923acc08d, linuxarm64: ami-04a5fadc76f784993, windows: ami-00796fe7e08c91d4f }
 
 Resources:
   Vpc:
@@ -1047,10 +1050,14 @@ Resources:
                         - kms:GetPublicKey
                       - - kms:Verify
                         - kms:GetPublicKey
-                  Resource: !If
-                              - CreatePipelineSigningKMSKey
-                              - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                              - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
+                  Resource:
+                    !If
+                      - CreatePipelineSigningKMSKey
+                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                      - !If
+                        - PipelineSigningKMSKeyIsARN
+                        - !Ref PipelineSigningKMSKeyId
+                        - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
           - !Ref 'AWS::NoValue'
         - !If
           - UseCustomerManagedKeyForParameterStore
@@ -1370,7 +1377,7 @@ Resources:
                   powershell -file C:\buildkite-agent\bin\bk-configure-docker.ps1 >> C:\buildkite-agent\elastic-stack.log
 
                   $Env:BUILDKITE_STACK_NAME="${AWS::StackName}"
-                  $Env:BUILDKITE_STACK_VERSION="v6.34.0"
+                  $Env:BUILDKITE_STACK_VERSION="v6.36.0"
                   $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
                   $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
                   $Env:BUILDKITE_SECRETS_BUCKET_REGION="${LocalSecretsBucketRegion}"
@@ -1400,12 +1407,22 @@ Resources:
                   $Env:AWS_REGION="${AWS::Region}"
                   powershell -file C:\buildkite-agent\bin\bk-install-elastic-stack.ps1 >> C:\buildkite-agent\elastic-stack.log
                   </powershell>
-                - {
-                    LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
-                    LocalSecretsBucketRegion: !If [ CreateSecretsBucket, !Ref "AWS::Region", !Ref SecretsBucketRegion ],
-                    AgentTokenPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ],
-                    PipelineSigningKMSKey: !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, !Ref PipelineSigningKMSKeyId ],
-                  }
+                - LocalSecretsBucket: !If
+                    - CreateSecretsBucket
+                    - !Ref ManagedSecretsBucket
+                    - !Ref SecretsBucket
+                  LocalSecretsBucketRegion: !If
+                    - CreateSecretsBucket
+                    - !Ref "AWS::Region"
+                    - !Ref SecretsBucketRegion
+                  AgentTokenPath: !If
+                    - UseCustomerManagedParameterPath
+                    - !Ref BuildkiteAgentTokenParameterStorePath
+                    - !Ref BuildkiteAgentTokenParameter
+                  PipelineSigningKMSKey: !If
+                    - CreatePipelineSigningKMSKey
+                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                    - !Ref PipelineSigningKMSKeyId
               - !Sub
                 - |
                   Content-Type: multipart/mixed; boundary="==BOUNDARY=="
@@ -1433,7 +1450,7 @@ Resources:
                   Content-Type: text/x-shellscript; charset="us-ascii"
                   #!/bin/bash -v
                   BUILDKITE_STACK_NAME="${AWS::StackName}" \
-                  BUILDKITE_STACK_VERSION="v6.34.0" \
+                  BUILDKITE_STACK_VERSION="v6.36.0" \
                   BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}" \
                   BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
                   BUILDKITE_SECRETS_BUCKET_REGION="${LocalSecretsBucketRegion}" \
@@ -1466,12 +1483,22 @@ Resources:
                   AWS_REGION="${AWS::Region}" \
                     /usr/local/bin/bk-install-elastic-stack.sh
                   --==BOUNDARY==--
-                - {
-                    LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
-                    LocalSecretsBucketRegion: !If [ CreateSecretsBucket, !Ref "AWS::Region", !Ref SecretsBucketRegion ],
-                    AgentTokenPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ],
-                    PipelineSigningKMSKey: !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, !Ref PipelineSigningKMSKeyId ],
-                  }
+                - LocalSecretsBucket: !If
+                    - CreateSecretsBucket
+                    - !Ref ManagedSecretsBucket
+                    - !Ref SecretsBucket
+                  LocalSecretsBucketRegion: !If
+                    - CreateSecretsBucket
+                    - !Ref "AWS::Region"
+                    - !Ref SecretsBucketRegion
+                  AgentTokenPath: !If
+                    - UseCustomerManagedParameterPath
+                    - !Ref BuildkiteAgentTokenParameterStorePath
+                    - !Ref BuildkiteAgentTokenParameter
+                  PipelineSigningKMSKey: !If
+                    - CreatePipelineSigningKMSKey
+                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                    - !Ref PipelineSigningKMSKeyId
 
   AgentAutoScaleGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/pages/agent/v3/elastic_ci_aws.md
+++ b/pages/agent/v3/elastic_ci_aws.md
@@ -71,7 +71,7 @@ Buildkite services are billed according to your [plan](https://buildkite.com/pri
 <!-- vale off -->
 
 - [Amazon Linux 2023](https://aws.amazon.com/amazon-linux-2/)
-- [Buildkite Agent v3.91.0](/docs/agent)
+- [Buildkite Agent v3.93.1](/docs/agent)
 - [Git](https://git-scm.com/) and [Git LFS](https://git-lfs.com/)
 - [Docker](https://www.docker.com)
 - [Docker Compose](https://docs.docker.com/compose/)


### PR DESCRIPTION
Update link to the newest Elastic CI Stack v6.36.0 including buildkite-agent v3.93.1.

https://github.com/buildkite/elastic-ci-stack-for-aws/releases/tag/v6.36.0