### PR TITLE
document and remove BUILDKITE_GIT_FETCH_FLAGS from experimental

### DIFF
--- a/data/content/agent_attributes.yaml
+++ b/data/content/agent_attributes.yaml
@@ -103,7 +103,7 @@ attributes:
   env_var: BUILDKITE_GIT_FETCH_FLAGS
   default_value: "-v --prune"
   required: false
-  experimental: true
+  experimental: false
   desc: |
       Flags to pass to the `git fetch` command. Before [running builds on git tags](https://buildkite.com/docs/integrations/github#running-builds-on-git-tags), make sure your agent is fetching git tags.
 - name: git-mirrors-lock-timeout

--- a/data/content/environment_variables.yaml
+++ b/data/content/environment_variables.yaml
@@ -215,6 +215,11 @@ variables:
       The value of the `git-clone-flags` [agent configuration option](/docs/agent/v3/configuration). The value can be modified by exporting the environment variable in the `environment` or `pre-checkout` hooks.
     modifiable: true
     example: "-v"
+  - name: BUILDKITE_GIT_FETCH_FLAGS
+    desc: |
+      The value of the `git-fetch-flags` [agent configuration option](/docs/agent/v3/configuration). The value can be modified by exporting the environment variable in the `environment` or `pre-checkout` hooks.
+    modifiable: true
+    example: "-v --prune"
   - name: BUILDKITE_GIT_SUBMODULES
     desc: |
       The opposite of the value of the `no-git-submodules` [agent configuration option](/docs/agent/v3/configuration).


### PR DESCRIPTION
This feature was added [6 years ago](https://github.com/buildkite/agent/commit/93daef3e00f7481f8000e07975bd98275c3f0c84) and I think it's confusing referring to it as experimental given it's unrelated to `BUILDKITE_AGENT_EXPERIMENT`.

I don't feel strongly about experimental or not, I would just like `data/content/environment_variables.yaml` updated.

Closes https://github.com/buildkite/docs/issues/1819