### PR TITLE
feat: add docs for GitHub secret scanning program

### DIFF
--- a/pages/apis.md
+++ b/pages/apis.md
@@ -14,7 +14,7 @@ All webhooks contain an [`X-Buildkite-Token` header](/docs/apis/webhooks#http-he
 
 ## API security
 
-Buildkite is a member of the [GitHub Secret Scanning Program](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program).
+Buildkite is a member of the [GitHub secret scanning program](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program).
 This service [alerts](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program#the-secret-scanning-process) us when a Buildkite API key has been leaked on GitHub in a public repository.
 
 Once Buildkite receives a notification of a publicly leaked token from GitHub, Buildkite will:

--- a/pages/apis.md
+++ b/pages/apis.md
@@ -22,9 +22,11 @@ Once Buildkite receives a notification of a publicly leaked token from GitHub, B
 - Email the user who generated the token to let them know it has been revoked.
 - Email the organizations associated with the token to let them know it has been revoked.
 
-This can also be enabled for [private repositories](https://docs.github.com/en/code-security/secret-scanning/enabling-secret-scanning-features/enabling-secret-scanning-for-your-repository).
+You can also:
 
-You can generate a new access token [here](https://buildkite.com/user/api-access-tokens).
+- Enable GitHub secret scanning for [private repositories](https://docs.github.com/en/code-security/secret-scanning/enabling-secret-scanning-features/enabling-secret-scanning-for-your-repository).
+
+- Generate a new [access token for your Buildkite user account](https://buildkite.com/user/api-access-tokens).
 
 ## REST API
 

--- a/pages/apis.md
+++ b/pages/apis.md
@@ -14,7 +14,7 @@ All webhooks contain an [`X-Buildkite-Token` header](/docs/apis/webhooks#http-he
 
 ## API security
 
-We are a member of the [GitHub Secret Scanning Program](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program).
+Buildkite is a member of the [GitHub Secret Scanning Program](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program).
 This service [alerts](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program#the-secret-scanning-process) us when a Buildkite API key has been leaked on GitHub in a public repository.
 
 Once we receive a notification of a publicly leaked token from GitHub, we will:

--- a/pages/apis.md
+++ b/pages/apis.md
@@ -17,7 +17,7 @@ All webhooks contain an [`X-Buildkite-Token` header](/docs/apis/webhooks#http-he
 Buildkite is a member of the [GitHub Secret Scanning Program](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program).
 This service [alerts](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program#the-secret-scanning-process) us when a Buildkite API key has been leaked on GitHub in a public repository.
 
-Once we receive a notification of a publicly leaked token from GitHub, we will:
+Once Buildkite receives a notification of a publicly leaked token from GitHub, Buildkite will:
 - Revoke the token immediately.
 - Email the user who generated the token to let them know it has been revoked.
 - Email the organizations associated with the token to let them know it has been revoked.

--- a/pages/apis.md
+++ b/pages/apis.md
@@ -18,6 +18,7 @@ Buildkite is a member of the [GitHub secret scanning program](https://docs.githu
 This service [alerts](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program#the-secret-scanning-process) us when a Buildkite API key has been leaked on GitHub in a public repository.
 
 Once Buildkite receives a notification of a publicly leaked token from GitHub, Buildkite will:
+
 - Revoke the token immediately.
 - Email the user who generated the token to let them know it has been revoked.
 - Email the organizations associated with the token to let them know it has been revoked.

--- a/pages/apis.md
+++ b/pages/apis.md
@@ -18,7 +18,7 @@ We are a member of the [GitHub Secret Scanning Program](https://docs.github.com/
 This service [alerts](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program#the-secret-scanning-process) us when a Buildkite API key has been leaked on GitHub in a public repository.
 
 Once we receive a notification of a publicly leaked token from GitHub, we will:
-- Revoke the token immediately
+- Revoke the token immediately.
 - Email the user who generated the token to let them know it has been revoked.
 - Email the organizations associated with the token to let them know it has been revoked.
 

--- a/pages/apis.md
+++ b/pages/apis.md
@@ -12,6 +12,20 @@ Generate an [access token](https://buildkite.com/user/api-access-tokens).
 
 All webhooks contain an [`X-Buildkite-Token` header](/docs/apis/webhooks#http-headers) which allows you to verify the authenticity of the request.
 
+## API security
+
+We are a member of the [GitHub Secret Scanning Program](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program).
+This service [alerts](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program#the-secret-scanning-process) us when a Buildkite API key has been leaked on GitHub in a public repository.
+
+Once we receive a notification of a publicly leaked token from GitHub, we will:
+- Revoke the token immediately
+- Email the user who generated the token to let them know it has been revoked.
+- Email the organizations associated with the token to let them know it has been revoked.
+
+This can also be enabled for [private repositories](https://docs.github.com/en/code-security/secret-scanning/enabling-secret-scanning-features/enabling-secret-scanning-for-your-repository).
+
+You can generate a new access token [here](https://buildkite.com/user/api-access-tokens).
+
 ## REST API
 
 The Buildkite REST API aims to give you complete programmatic access and control of Buildkite to extend, integrate and automate anything to suit your particular needs.


### PR DESCRIPTION
We've just received word from GitHub that they're ready to go live with our membership to the GitHub Secret Scanning Program:
https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partnership-program/secret-scanning-partner-program#the-secret-scanning-process

But it seems they need this documentation to be up before they can hit the 'go' button:
![Screenshot 2025-04-02 at 9 42 16 am](https://github.com/user-attachments/assets/b963f425-c159-494d-9516-b43b2f225e1b)
![Screenshot 2025-04-02 at 9 42 26 am](https://github.com/user-attachments/assets/a27d8efd-1165-4182-b5ad-e4997ad7c080)

The 'API' section seemed like the most logical place for this information, but I don't mind too much - just need somewhere to point to.

![Screenshot 2025-04-02 at 10 10 42 am](https://github.com/user-attachments/assets/389727f3-78e2-46b0-9e5d-03623e60b48b)

Once this is up, I can reply to GitHub and hopefully they can press the big red button!