### PR TITLE
Update branch config docs to wrap patterns in quotes

### DIFF
--- a/pages/pipelines/configure/workflows/branch_configuration.md
+++ b/pages/pipelines/configure/workflows/branch_configuration.md
@@ -58,7 +58,7 @@ When combining positive and negative patterns, any positive pattern must match, 
 
 The following are examples of patterns, and the branches that they will match:
 
-* `'main'` will match `main` only
+* `main` will match `main` only
 * `'!production'` will match any branch that's not `production`
 * `'main features/*'` will match `main` and any branch that starts with `features/`
 * `'*-test'` will match any branch ending with `-test`, such as `rails-update-test`
@@ -66,7 +66,7 @@ The following are examples of patterns, and the branches that they will match:
 * `'v*.0'` will match any branch that begins with a `v` and ends with a `.0`, such as `v1.0`
 * `'v* !v1.*'` will match any branch that begins with a `v` unless it also begins with `v1.`, such as `v2.3`, but not `v1.1`
 
-It's recommended to wrap your branch patterns inside quotes to prevent characters such as exclamation marks from causing issues as they are part of the YAML spec.  For more advanced step filtering, see the [Using conditionals](/docs/pipelines/configure/conditionals) guide.
+If your branch pattern contains any special characters like exclamation marks or asterisks then you should wrap the pattern in quotes to prevent issues.  For more advanced step filtering, see the [Using conditionals](/docs/pipelines/configure/conditionals) guide.
 
 ## Alternative methods
 


### PR DESCRIPTION
Based on a conversation with Karen on the Support team, suggesting this modification to the branch pattern docs to highlight the need to quote expression containing special characters