### PR TITLE
Adding build event response disclaimer

### DIFF
--- a/pages/apis/webhooks/pipelines/build_events.md
+++ b/pages/apis/webhooks/pipelines/build_events.md
@@ -58,7 +58,7 @@ Example request body:
 ```
 
 > 📘 Job data not included
-> When using webhooks, the build object does not contain job data as specified in the <a href="/docs/api/builds">Build API</a> documentation. See <a href="/docs/webhooks/pipelines/job_events">job events</a> if this is required.
+> When using webhooks, the build object does not contain job data as specified in the <a href="/docs/api/builds">Build API</a> docs. See <a href="/docs/webhooks/pipelines/job_events">job events</a> if this is required.
 
 
 ## Finding out if a build is blocked

--- a/pages/apis/webhooks/pipelines/build_events.md
+++ b/pages/apis/webhooks/pipelines/build_events.md
@@ -56,9 +56,14 @@ Example request body:
   }
 }
 ```
+
+> 📘 Job data not included
+> When using webhooks, the build object does not contain job data as specified in the <a href="/docs/api/builds">Build API</a> documentation. See <a href="/docs/webhooks/pipelines/job_events">job events</a> if this is required.
+
+
 ## Finding out if a build is blocked
 
-To if a build is blocked, look for `blocked: true` in the `build.finished` event
+If a build is blocked, look for `blocked: true` in the `build.finished` event
 
 Example request body for blocked build:
 


### PR DESCRIPTION
- Adding clarification of build webhooks not lining up 1:1 with REST API response body.

- Fixing typo for "Finding out if a build is blocked"
