### PR TITLE
fix: specify that the average build stat uses default branch

### DIFF
--- a/pages/pipelines/dashboard_walkthrough.md
+++ b/pages/pipelines/dashboard_walkthrough.md
@@ -30,7 +30,7 @@ The reliability of your pipeline is a calculation based on passing vs failing bu
 
 ## Builds per week
 
-The builds per week measurement is calculated based on the average number of builds created over the past 4 weeks. This metric helps you to understand how frequently a pipeline is run.
+The builds per week measurement is calculated based on the average number of builds created over the past 4 weeks on the pipeline's default branch. This metric helps you to understand how frequently a pipeline is run.
 
 <%= image "frequency.png", width: 2028/2, height: 880/2, alt: "Screenshot of the builds per week metric" %>
 


### PR DESCRIPTION
This PR adds a small clarification about the "Builds per week" measurement.

This is something that one of our engineers ran across when doing some investigations and was unsure about until we inspected the number of builds actually run ourselves. 

Feel free to reject this PR if this is documented elsewhere. I haven't found it though!