### PR TITLE
Update BK OIDC CLI page about auto redaction

### DIFF
--- a/pages/agent/v3/cli_oidc.md
+++ b/pages/agent/v3/cli_oidc.md
@@ -9,6 +9,9 @@ Refer to the following documentation for more information:
 
 Learn more about how to restrict your Buildkite Agents' access to deployment environments like AWS, from the OIDC in [Buildkite Pipelines](/docs/pipelines/security/oidc) and with [AWS](/docs/pipelines/security/oidc/aws) documentation pages, as well as the [Buildkite Package Registries](/docs/package-registries/security/oidc) documentation page.
 
+>📘
+> Note that as of Agent v3.104.0, OIDC tokens are now automatically redacted from build logs by default, with an optional `skip-redaction` flag to disable this behavior when needed. This behaviour is similar to the [buildkite-agent secret get](/docs/agent/v3/cli-secret) for redacting the token.
+
 ## Request OIDC token
 
 <%= render "agent/v3/help/oidc_request_token" %>


### PR DESCRIPTION
As of [Buildkite Agent v3.104.0](https://github.com/buildkite/agent/releases/tag/v3.104.0), the Agent now automatically redacts the OIDC token for security reasons. Here is the related [PR](https://github.com/buildkite/agent/pull/3450) deployed that added this feature.

This PR is to update our Agent CLI OIDC Token doc so the new behaviour is reflected accordingly.