### PR TITLE
adding exception for Hosted Agents

### DIFF
--- a/pages/pipelines/configure/workflows/managing_priorities.md
+++ b/pages/pipelines/configure/workflows/managing_priorities.md
@@ -2,7 +2,7 @@
 
 By default, jobs are dispatched (taken from the queue and assigned to an agent) on a first-in-first-out basis. However, job priority and pipeline upload time can affect that order.
 
-This is not the case for Hosted Agents. Jobs are assigned and run based on the time they are triggered.
+This is not the case for [Buildkite hosted agents](/docs/pipelines/hosted-agents), where jobs are assigned and dispatched at the time they are executed.
 
 ## Prioritizing specific jobs
 


### PR DESCRIPTION
We found out that hosted agents doesn't respect the priority list.

We should get updated in the docs so customers know for the future.

I've poorly written a line about this but wanted to get it directly into the docs.

This is the linear with more information
https://linear.app/buildkite/issue/MDC-776/hosted-agents-not-respecting-job-priority-in-buildkite


