### PR TITLE
Add Kubernetes version requirement to agent-stack-k8s prerequisites

### DIFF
--- a/pages/agent/v3/self_hosted/agent_stack_k8s.md
+++ b/pages/agent/v3/self_hosted/agent_stack_k8s.md
@@ -20,7 +20,7 @@ When a matching job is returned from the Agent REST API, the controller creates 
 
 ## Before you start
 
-- A Kubernetes cluster.
+- A Kubernetes cluster running version 1.29.0 or later (required for agent-stack-k8s v0.35.0 and later, which uses native sidecar containers). For older Kubernetes clusters, use agent-stack-k8s version 0.34.0 or earlier.
 - A [Buildkite cluster](/docs/pipelines/security/clusters/manage) and an [agent token](/docs/agent/v3/self-hosted/tokens#create-a-token) for this cluster.
 
 <!-- vale off -->


### PR DESCRIPTION
Version 0.35.0 and later of agent-stack-k8s requires Kubernetes 1.29.0+ due to native sidecar container support. Added guidance for users with older clusters to use version 0.34.0 or earlier.