### PR TITLE
Follow naming convention for docs page feedback event

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -70,7 +70,7 @@
         var email = document.getElementById('page-rating-email').value.trim();
 
         if (typeof posthog !== 'undefined') {
-          posthog.capture('✍️ Docs page feedback', {
+          posthog.capture('docs:page_feedback', {
             rating: selectedRating,
             page_url: window.location.href,
             page_path: window.location.pathname,


### PR DESCRIPTION
We have a [naming convention](https://www.notion.so/buildkite/New-analytics-event-naming-convention-for-PostHog-304b8dbc2c898040963ff19f230079c4?source=copy_link) for some of our PostHog events, and it'd be great if we could standardise on it. I wasn't sure if this event is going to be used for a funnel, so I left out the "funnel" part of the naming convention. Happy to change it to whatever suits, just creating a PR to start the conversation if required.