### PR TITLE
Define Step Uploads action before talking about it

### DIFF
--- a/pages/pipelines/configure/defining_steps.md
+++ b/pages/pipelines/configure/defining_steps.md
@@ -124,6 +124,9 @@ For more example steps and detailed configuration options, see the example `pipe
 
 If your pipeline has more than one step and you have multiple agents available to run them, they will automatically run at the same time. If your steps rely on running in sequence, you can separate them with [wait steps](/docs/pipelines/configure/step-types/wait-step). This will ensure that any steps before the 'wait' are completed before steps after the 'wait' are run.
 
+> 📘
+> It is also possible to upload additional steps while a build is in progress. This isn't a step type, instead it is an action performed by an agent within the context of a job. See [Dynamic pipelines](/docs/pipelines/configure/dynamic_pipelines) for more information.
+
 >🚧 Explicit dependencies in uploaded steps
 > If a step <a href="/docs/pipelines/configure/depends-on">depends</a> on an upload step, then all steps uploaded by that step become dependencies of the original step. For example, if step B depends on step A, and step A uploads step C, then step B will also depend on step C.
 


### PR DESCRIPTION
As a newbie to the Buildkite platform I got tripped up by the sudden appearance of the Step Upload concept with no context.  Further up the page there is some discussion of uploads though it isn't clear how the two are related.  It was doubly confusing as immediately prior to its usage in the warning was an exhaustive enumeration of Step Types that did not mention Uploads.  

Adding a quick unobtrusive note to link the concepts of step uploads and dynamic pipelines would have helped me bridge the understanding gap and resolve my issue so adding one in to help future explorers.  