### PR TITLE
docs: note that MCP has its own rate limit on the overview page

### DIFF
--- a/pages/apis/mcp_server.md
+++ b/pages/apis/mcp_server.md
@@ -12,6 +12,8 @@ To start using Buildkite's MCP server, first determine which [type of Buildkite 
 
 Once you have established which Buildkite MCP server to use (remote or local) and if local, have [installed the MCP server](/docs/apis/mcp-server/local/installing#install-and-run-the-server-locally) and [configured its API access token](/docs/apis/mcp-server/local/installing#configure-an-api-access-token), you can then proceed to configure your AI tools to work with the [remote](/docs/apis/mcp-server/remote/configuring-ai-tools) (recommended) or [local](/docs/apis/mcp-server/local/configuring-ai-tools) MCP server.
 
+Note: MCP requests count against a separate rate limit from your org's REST API budget. See [[platform limits](https://buildkite.com/docs/platform/limits)](https://buildkite.com/docs/platform/limits) for the specific numbers.
+
 ## Types of MCP servers
 
 Buildkite provides both a [remote](#types-of-mcp-servers-remote-mcp-server) and [local](#types-of-mcp-servers-local-mcp-server) MCP server, both of which provide access to its [MCP server tools](/docs/apis/mcp-server/tools#available-mcp-tools). The remote MCP server supports OAuth authentication for interactive AI tools and [API token pass-through](#api-token-pass-through-remote-mcp-server) for headless agents.


### PR DESCRIPTION
Customer feedback surfaced that the MCP-specific rate limit is easy to miss. It is already documented at /docs/platform/limits but is not surfaced on the MCP server overview page. This adds one line pointing at the limits page so it is easier to find.