### PR TITLE
Link to bktec README for supported test frameworks (TE-6299)

### DIFF
--- a/pages/pipelines/configure/tests/bktec/installing_and_using_the_client.md
+++ b/pages/pipelines/configure/tests/bktec/installing_and_using_the_client.md
@@ -94,7 +94,7 @@ Skipping automatic installation is useful when bktec is pre-installed in your bu
 
 ## Using bktec
 
-Buildkite maintains its open source Test Engine Client ([bktec](https://github.com/buildkite/test-engine-client)) tool. Currently, the bktec tool supports [RSpec](/docs/pipelines/configure/tests/test-collection/ruby-collectors#rspec-collector), [Jest](/docs/pipelines/configure/tests/test-collection/javascript-collectors#configure-the-test-framework-jest), [Cypress](/docs/pipelines/configure/tests/test-collection/javascript-collectors#configure-the-test-framework-cypress), [PlayWright](/docs/pipelines/configure/tests/test-collection/javascript-collectors#configure-the-test-framework-playwright), and [Pytest](/docs/pipelines/configure/tests/test-collection/python-collectors#pytest-collector), pytest-pants, [Go](/docs/pipelines/configure/tests/test-collection/golang-collectors), and cucumber testing frameworks.
+Buildkite maintains its open source Test Engine Client ([bktec](https://github.com/buildkite/test-engine-client)) tool. For the current list of test frameworks bktec supports, see the [supported runners and features](https://github.com/buildkite/test-engine-client#supported-runners-and-features) table in the bktec README.
 
 If your testing framework is not supported, get in touch through support@buildkite.com or submit a pull request.
 

--- a/pages/pipelines/configure/tests/test_suites/test_state_and_quarantine.md
+++ b/pages/pipelines/configure/tests/test_suites/test_state_and_quarantine.md
@@ -45,10 +45,7 @@ Manually quarantining a test either mutes or skips that test when the pipeline i
 
 The easiest way to respect test states in your builds is to run the [Buildkite Test Engine Client (bktec)](https://github.com/buildkite/test-engine-client) command in your pipelines. The `bktec` command automatically excludes quarantined tests from your test runs, preventing [flaky tests](/docs/pipelines/reduce-flaky-tests) from causing build failures, leading to faster, more reliable builds, and less need for retries.
 
-Currently, bktec supports the following test frameworks for:
-
-- muting tests—RSpec, Jest, and Playwright
-- skipping tests—RSpec only
+For the current list of test frameworks bktec supports for muting and skipping tests, see the [supported runners and features](https://github.com/buildkite/test-engine-client#supported-runners-and-features) table in the bktec README.
 
 When using a supported test framework, bktec automatically handles quarantined tests, along with providing the benefits of efficient [test splitting](/docs/pipelines/speed-up-builds-with-bktec) and retry support.
 
@@ -57,7 +54,7 @@ When using a supported test framework, bktec automatically handles quarantined t
   command: bktec
   parallelism: 10
   env:
-    BUILDKITE_TEST_ENGINE_TEST_RUNNER: rspec|jest|playwright
+    BUILDKITE_TEST_ENGINE_TEST_RUNNER: rspec # see supported runners in the bktec README
 ```
 
 ### REST API


### PR DESCRIPTION
## Summary
- The test state and quarantine page hardcoded bktec's mute/skip framework support, which had gone stale (missing Vitest, pytest, gotest, Cucumber for mute, and Cucumber for skip)
- The bktec installation page had a similar hardcoded, stale general framework list
- Both now link to the [supported runners and features](https://github.com/buildkite/test-engine-client#supported-runners-and-features) table in the bktec README, which stays current automatically

Fixes [TE-6299](https://linear.app/buildkite/issue/TE-6299/docs-on-bktec-support-for-test-state-are-out-of-date)

## Test plan
- [x] Confirm both links resolve to the bktec README's supported runners and features section
- [x] Proofread updated copy on `test_state_and_quarantine.md` and `installing_and_using_the_client.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)