### PR TITLE
Clarify Docker support on macOS hosted agents

### DIFF
--- a/data/llm_descriptions.yml
+++ b/data/llm_descriptions.yml
@@ -247,7 +247,7 @@
   agent/buildkite-hosted/linux: "Linux hosted agent instance sizes, architectures (AMD64/ARM64), agent images, concurrency, and security details."
   agent/buildkite-hosted/linux/custom-agent-images: "Creating custom Docker-based agent images for Linux hosted agents: image requirements, building from the Buildkite hosted agent base image, creating images via the Buildkite interface, agent hooks, or the internal container registry, using and deleting images, and troubleshooting job startup issues."
   agent/buildkite-hosted/linux/remote-docker-builders: "How remote Docker builders offload docker build commands to dedicated machines with layer caching (Enterprise)."
-  agent/buildkite-hosted/macos: "macOS hosted agent sizes, Apple silicon support, pre-installed software (Xcode, Homebrew), and configuration."
+  agent/buildkite-hosted/macos: "macOS hosted agent sizes, Apple silicon support, pre-installed software (Xcode, Homebrew), Docker daemon limitations, and configuration."
   agent/buildkite-hosted/macos/getting-started-with-ios: "Tutorial for building iOS apps using Buildkite macOS hosted agents with the FlappyKite sample project."
   agent/buildkite-hosted/macos/troubleshooting-fastlane: "Troubleshooting fastlane issues on Buildkite hosted macOS agents: code signing, provisioning profiles, and keychains."
   agent/buildkite-hosted/code-access: "Configuring hosted agents to access private GitHub repositories and other providers using SSH or HTTPS."

--- a/pages/agent/buildkite_hosted/macos.md
+++ b/pages/agent/buildkite_hosted/macos.md
@@ -55,6 +55,12 @@ Updated Xcode versions will be available one week after Apple offers them for do
 
 Older Xcode versions are removed from base images over time. If your queue has an Xcode version pinned that is no longer available, a warning is displayed on the queue list and queue settings pages: "Xcode {version} is no longer available for this macOS version. Your agents may fail to start until you update the base image of your queue." To resolve the warning, navigate to the queue's **Base image** settings and select an available Xcode version.
 
+### Docker support
+
+macOS hosted agents do not include a running Docker daemon. Pipeline jobs that require Docker daemon access, such as `docker build` or `docker run`, will fail unless they connect to a Docker daemon that you provide.
+
+For Docker image builds, use [Linux hosted agents](/docs/agent/buildkite-hosted/linux) with [remote Docker builders](/docs/agent/buildkite-hosted/linux/remote-docker-builders), or run the job on [self-hosted agents](/docs/agent/self-hosted) where you control the Docker installation.
+
 > 📘
 > Three macOS Tahoe versions are available, each with a unique set of Xcode versions. [Tahoe (26.3.1)](/docs/agent/buildkite-hosted/macos#macos-tahoe) includes older Xcode versions, because certain older Xcode versions are incompatible with newer Tahoe base images. [Tahoe (26.5)](/docs/agent/buildkite-hosted/macos#macos-tahoe-26-dot-5) and [Tahoe (26.6)](#macos-tahoe-26-dot-6) include newer Xcode 26.x versions.
 


### PR DESCRIPTION
## Summary
- document that macOS hosted agents do not include a running Docker daemon
- point Docker image build users toward Linux hosted agents with remote Docker builders or self-hosted agents
- update the LLM page description so the limitation is discoverable in generated docs summaries

Closes #3053.

## Testing
- npx markdownlint-cli2@0.3 pages/agent/buildkite_hosted/macos.md
- npx alex@10 -q pages/agent/buildkite_hosted/macos.md
- git diff --check