### PR TITLE
Add a note to explicitly state that signed pipeline are not supported …

### DIFF
--- a/pages/agent/buildkite_hosted.md
+++ b/pages/agent/buildkite_hosted.md
@@ -58,6 +58,9 @@ The ephemeral nature of Buildkite hosted agents' virtualized environments also o
 
 - Short-lived hosted agents mitigate the window of opportunity for attackers to compromise the build environment, and any data generated or used during job execution, such as secrets or credentials, are destroyed after job completion or failure.
 
+> 📘 Signed pipelines
+> [Signed pipeline validation](/docs/agent/self-hosted/security/signed-pipelines) is not supported for Buildkite hosted agents.
+
 ## Getting started with Buildkite hosted agents
 
 Buildkite offers both [Linux](/docs/agent/buildkite-hosted/linux) and [macOS](/docs/agent/buildkite-hosted/macos) hosted agents, whose respective pages explain how to start setting them up.

--- a/pages/agent/self_hosted/security/signed_pipelines.md
+++ b/pages/agent/self_hosted/security/signed_pipelines.md
@@ -2,7 +2,7 @@
 
 Signed pipelines are a security feature where pipelines are cryptographically signed when uploaded to Buildkite. Agents then verify the signature before running the job. If an agent detects a signature mismatch, it'll refuse to run the job.
 
-Maintaining a strong security boundary is important to Buildkite and informs how we design features. It's also a key reason people choose Buildkite over other CI/CD tools. Signing pipelines improves your security posture by ensuring agents don't run jobs where a malicious actor has modified the instructions. This moves you towards zero-trust CI/CD by further isolating you from Buildkite itself being compromised.
+Maintaining a strong security boundary is important to Buildkite and informs how we design features. It's also a key reason people choose Buildkite over other CI/CD tools. Signing pipelines improves your security posture by ensuring agents don't run jobs where a malicious actor has modified the instructions. This moves you towards zero-trust CI/CD by further isolating you from Buildkite itself being compromised. Signed pipelines are a feature that can be enabled on self-hosted agents, and is not available on Buildkite hosted agents.
 
 The signature guarantees the origin of jobs by asserting:
 


### PR DESCRIPTION
…in HA

ref: https://linear.app/buildkite/issue/A-1677/docs-dont-state-that-signed-pipelines-are-unsupported-on-hosted-agents