### PR TITLE
Document GitHub issue activity builds

### DIFF
--- a/pages/pipelines/source_control/github.md
+++ b/pages/pipelines/source_control/github.md
@@ -208,6 +208,21 @@ Beyond pushes, pull requests, and tags, Buildkite Pipelines can trigger builds f
 - **Pull request review comments**: trigger builds from inline diff comments on pull requests. Like issue comments, requires a command word match and a trusted author. A commenter is trusted if GitHub reports their association as owner, member, or collaborator. They are also trusted if their GitHub account is linked to a Buildkite user who has build permission on the pipeline. Supports `exact` and `contains` match modes (useful for AI assistant triggers like `@claude`).
 - **Deployment statuses**: trigger builds when a deployment status changes. Requires the **Deployment** trigger mode.
 - **Branch and tag creation**: trigger builds when a new branch or tag is created.
+- **Issue activity**: trigger builds for the GitHub `issues` event. This option is off by default and appears only for pipelines in organizations where the rollout is enabled.
+
+### Issue activity events
+
+To enable issue activity builds for an eligible organization, select **Pipelines** > your pipeline > **Settings** > **GitHub**. In **Additional Webhooks**, select **Issue activity**.
+
+Buildkite Pipelines accepts every [GitHub-documented `issues` activity type](https://docs.github.com/en/webhooks/webhook-events-and-payloads#issues). Deliveries with an unknown or empty activity type do not create builds. Branch, tag, path, and workflow filters are not supported for this event.
+
+When processing the delivery, Buildkite Pipelines resolves the repository default branch to an exact, immutable commit. The build loads its code and pipeline configuration from that commit. Rebuilds and builds created from trigger steps preserve the original event and commit provenance instead of resolving the default branch again.
+
+Issue authors do not need access to the Buildkite organization to trigger these builds, so activity from public GitHub users can create builds. Buildkite platform quota controls still apply. Configure steps that process issue content as untrusted input.
+
+GitHub suppresses recursive webhook events created with the Buildkite-minted `GITHUB_TOKEN`. Third-party automation can create more issue activity and cause a loop, so configure that automation to ignore Buildkite Pipelines activity or otherwise bound its updates.
+
+Issue activity builds are separate from issue comment commands. The **Issue comments** option requires a trusted author and a matching command word. **Issue activity** responds to changes to the issue itself and does not use comment commands.
 
 > 🚧 Configure the GitHub webhook for issue comments
 > To trigger builds from pull request comments, configure the repository webhook in GitHub to send both **Issue comments** and **Pull requests** events. Buildkite Pipelines uses the `pull_request` event to identify the pull request branch and commit when processing a later `issue_comment` event.

--- a/pages/pipelines/source_control/github.md
+++ b/pages/pipelines/source_control/github.md
@@ -208,19 +208,19 @@ Beyond pushes, pull requests, and tags, Buildkite Pipelines can trigger builds f
 - **Pull request review comments**: trigger builds from inline diff comments on pull requests. Like issue comments, requires a command word match and a trusted author. A commenter is trusted if GitHub reports their association as owner, member, or collaborator. They are also trusted if their GitHub account is linked to a Buildkite user who has build permission on the pipeline. Supports `exact` and `contains` match modes (useful for AI assistant triggers like `@claude`).
 - **Deployment statuses**: trigger builds when a deployment status changes. Requires the **Deployment** trigger mode.
 - **Branch and tag creation**: trigger builds when a new branch or tag is created.
-- **Issue activity**: trigger builds for the GitHub `issues` event. This option is off by default and appears only for pipelines in organizations where the rollout is enabled.
+- **Issue activity**: trigger builds for the GitHub `issues` event. This option is off by default. It appears only for GitHub.com pipelines that use the full-access **GitHub** App in organizations where the rollout is enabled.
 
 ### Issue activity events
 
-To enable issue activity builds for an eligible organization, select **Pipelines** > your pipeline > **Settings** > **GitHub**. In **Additional Webhooks**, select **Issue activity**.
+To enable issue activity builds for an eligible organization, select **Pipelines** > your pipeline > **Settings** > **GitHub**. In **Additional Webhooks**, expand **Issue activity**, then select **Build on GitHub issue activity**.
 
 Buildkite Pipelines accepts every [GitHub-documented `issues` activity type](https://docs.github.com/en/webhooks/webhook-events-and-payloads#issues). Deliveries with an unknown or empty activity type do not create builds. Branch, tag, path, and workflow filters are not supported for this event.
 
 When processing the delivery, Buildkite Pipelines resolves the repository default branch to an exact, immutable commit. The build loads its code and pipeline configuration from that commit. Rebuilds and builds created from trigger steps preserve the original event and commit provenance instead of resolving the default branch again.
 
-Issue authors do not need access to the Buildkite organization to trigger these builds, so activity from public GitHub users can create builds. Buildkite platform quota controls still apply. Configure steps that process issue content as untrusted input.
+Issue authors do not need access to the Buildkite organization to trigger these builds, so activity from public GitHub users can create builds. Buildkite platform quota controls still apply. Configure steps that process issue content as untrusted input. Issue builds can request the same explicit workflow access token permissions as trusted branch builds, including write permissions, because the workflow code comes from the trusted default branch. A public issue author does not make the token read-only.
 
-GitHub suppresses recursive webhook events created with the Buildkite-minted `GITHUB_TOKEN`. Third-party automation can create more issue activity and cause a loop, so configure that automation to ignore Buildkite Pipelines activity or otherwise bound its updates.
+GitHub still delivers issue events created with a Buildkite-minted `GITHUB_TOKEN`. Buildkite Pipelines recognizes its Code Access App bot and skips the corresponding builds to prevent recursion. Third-party automation can create more issue activity and cause a loop, so configure that automation to ignore Buildkite Pipelines activity or otherwise bound its updates.
 
 Issue activity builds are separate from issue comment commands. The **Issue comments** option requires a trusted author and a matching command word. **Issue activity** responds to changes to the issue itself and does not use comment commands.
 
@@ -241,6 +241,7 @@ GitHub webhook-triggered builds expose environment variables that you can use at
 - `BUILDKITE_GITHUB_REVIEW_ID`: the review that triggered the build (pull request reviews)
 - `BUILDKITE_GITHUB_EVENT`: the GitHub webhook event name (for example, `pull_request`, `check_run`, `release`)
 - `BUILDKITE_GITHUB_ACTION`: the GitHub webhook action (for example, `opened`, `completed`, `published`)
+- `BUILDKITE_GITHUB_ISSUE_NUMBER`: the issue number that triggered the build (issue activity events)
 - `BUILDKITE_GITHUB_DEPLOYMENT_ID`: the deployment ID (deployment status events)
 
 **Available in conditionals and pipeline interpolation only:**


### PR DESCRIPTION
## Why

Native GitHub issue builds differ from issue-comment commands and have security and execution semantics that pipeline authors need before opting in. In particular, public authors can trigger builds, workflow code comes from an immutable default-branch commit, and third-party automation can create loops.

Related server support: https://github.com/buildkite/buildkite/pull/32958

## What

Document the gated, default-off pipeline setting, supported activity types and unsupported filters, immutable default-branch resolution, rebuild and trigger provenance, public-author trust boundary, quota controls, token recursion behavior, and the distinction from issue-comment commands.