### PR TITLE
Document organization usage REST endpoint

### DIFF
--- a/data/llm_descriptions.yml
+++ b/data/llm_descriptions.yml
@@ -432,6 +432,7 @@
   apis/rest-api/organizations/invitations: "REST endpoints to list, retrieve, create, and revoke invitations for a Buildkite organization, including role, SSO, and team assignment options."
   apis/rest-api/organizations/members: "REST endpoints to list, retrieve, update, and remove members of a Buildkite organization."
   apis/rest-api/organizations/rate-limits: "REST endpoint to query an organization's current REST and GraphQL API rate limit status."
+  apis/rest-api/organizations/usage: "REST endpoint to query an organization's billable active-user count for the current Usage summary period."
   apis/rest-api/organizations/notification-services: "REST endpoints to list, retrieve, create, update, delete, enable, and disable notification services for a Buildkite organization."
   apis/rest-api/organizations/pipeline-settings: "REST endpoints to read and update organization-level pipeline settings, including default branch, timeouts, hosted agents SSH access, public pipeline creation, advanced queue metrics, and build exports (admin only)."
   apis/rest-api/organizations/repository-connections: "REST endpoints to list and retrieve an organization's connected source control integrations, including GitHub, GitHub Enterprise Server, Bitbucket Server, GitLab Self-Managed, and Origin connections."

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -1064,6 +1064,8 @@
               path: "apis/rest-api/organizations/members"
             - name: "Rate limits"
               path: "apis/rest-api/organizations/rate-limits"
+            - name: "Usage"
+              path: "apis/rest-api/organizations/usage"
             - name: "Notification services"
               path: "apis/rest-api/organizations/notification-services"
             - name: "Pipeline settings"

--- a/pages/apis/rest_api.md
+++ b/pages/apis/rest_api.md
@@ -35,6 +35,7 @@ Method | Endpoint | Description
 GET | `/v2/organizations` | [List organizations](/docs/apis/rest-api/organizations#list-organizations)
 GET | `/v2/organizations/{org.slug}` | [Get an organization](/docs/apis/rest-api/organizations#get-an-organization)
 GET | `/v2/organizations/{org.slug}/rate_limit` | [Get organization rate limits](/docs/apis/rest-api/organizations/rate-limits#get-rate-limits)
+GET | `/v2/organizations/{org.slug}/usage` | [Get organization usage](/docs/apis/rest-api/organizations/usage#get-organization-usage)
 {: class="responsive-table"}
 
 ### Audit events

--- a/pages/apis/rest_api/organizations/usage.md
+++ b/pages/apis/rest_api/organizations/usage.md
@@ -1,0 +1,52 @@
+# Organization usage API
+
+The organization usage API returns the billable active-user count shown on the organization's **Usage > Platform** page.
+
+Any organization member can use this endpoint. The API access token must include the `read_organizations` scope and grant access to the requested organization.
+
+## Get organization usage
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.buildkite.com/v2/organizations/{org.slug}/usage"
+```
+
+```json
+{
+  "active_users_count": 1842
+}
+```
+
+Required scope: `read_organizations`
+
+Success response: `200 OK`
+
+The `active_users_count` value is the number of distinct billable users active during the current Usage summary period. This is the same period displayed on the Usage page. For organizations with annual subscriptions, the summary period includes the current calendar month and the previous six calendar months, rather than the full annual billing period.
+
+For a billing parent organization, the count includes activity from its linked billing child organizations. A user active in more than one linked organization is counted once.
+
+## Response fields
+
+Field | Type | Description
+----- | ---- | -----------
+`active_users_count` | integer | Number of distinct billable users active during the current Usage summary period.
+{: class="table table--no-wrap"}
+
+## Error responses
+
+<table class="responsive-table">
+<tbody>
+  <tr>
+    <th><code>403 Forbidden</code></th>
+    <td>The token does not have the <code>read_organizations</code> scope.</td>
+  </tr>
+  <tr>
+    <th><code>404 Not Found</code></th>
+    <td>The organization does not exist, or the authenticated user or token cannot access it.</td>
+  </tr>
+  <tr>
+    <th><code>503 Service Unavailable</code></th>
+    <td>Usage data is temporarily unavailable. Retry the request.</td>
+  </tr>
+</tbody>
+</table>


### PR DESCRIPTION
## Summary

Documents the new organization usage REST endpoint that exposes the billable active-user count shown on the Usage page.

- adds the endpoint reference and navigation entries
- documents authorization and tenant visibility
- documents exact Usage-page period parity: for annual subscriptions, the current calendar month plus the previous six calendar months rather than the annual billing period
- documents billing-child aggregation, deduplication, and error responses

## Context

- https://linear.app/buildkite/issue/PB-3211
- REST implementation: https://github.com/buildkite/buildkite/pull/33817

## Validation

- `bundle exec rspec` (244 examples, 0 failures, 7 expected pending)
- `npm run mdlint`
- `npm run lint`
- `npx markdownlint-cli2@0.3 pages/apis/rest_api/organizations/usage.md`
- `npx alex@10 -q pages/apis/rest_api/organizations/usage.md`
- `bin/ls-lint`
- YAML parse check
- rendered and visually inspected the new page at 1440px

## Deployment

Merge with or before the corresponding REST API implementation is publicly released.